### PR TITLE
Remove transport from discovery on transport deregister

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 )
 
 // Uncomment for tests with alternate branches of 'dmsg'
-// replace github.com/SkycoinProject/dmsg => ../dmsg
+replace github.com/SkycoinProject/dmsg => ../dmsg

--- a/pkg/transport-discovery/client/client.go
+++ b/pkg/transport-discovery/client/client.go
@@ -160,7 +160,7 @@ func (c *apiClient) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) (
 	return entries, nil
 }
 
-// DeleteTransport deletes given transpot by it's ID. A visor can only delete transports if he is one of it's edges.
+// DeleteTransport deletes given transport by it's ID. A visor can only delete transports if he is one of it's edges.
 func (c *apiClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
 	resp, err := c.Delete(ctx, fmt.Sprintf("/transports/id:%s", id.String()))
 	if resp != nil {

--- a/pkg/transport/discovery.go
+++ b/pkg/transport/discovery.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -90,7 +91,7 @@ func (td *mockDiscoveryClient) DeleteTransport(ctx context.Context, id uuid.UUID
 
 	_, ok := td.entries[id]
 	if !ok {
-		return errors.New("transport not found")
+		return fmt.Errorf("transport with id: %s not found in transport discovery", id)
 	}
 
 	delete(td.entries, id)

--- a/pkg/transport/discovery.go
+++ b/pkg/transport/discovery.go
@@ -83,7 +83,7 @@ func (td *mockDiscoveryClient) GetTransportsByEdge(ctx context.Context, pk ciphe
 	return res, nil
 }
 
-// NOTE that mock implementation doesn't checks wheter the transport to be deleted is valid or not, this is, that
+// NOTE that mock implementation doesn't checks whether the transport to be deleted is valid or not, this is, that
 // it can be deleted by the visor who called DeleteTransport
 func (td *mockDiscoveryClient) DeleteTransport(ctx context.Context, id uuid.UUID) error {
 	td.Lock()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/SkycoinProject/skywire-mainnet/pkg/routing"
 	"github.com/SkycoinProject/skywire-mainnet/pkg/snet"
@@ -222,7 +223,15 @@ func (tm *Manager) DeleteTransport(id uuid.UUID) {
 	if tp, ok := tm.tps[id]; ok {
 		tp.Close()
 		delete(tm.tps, id)
-		tm.Logger.Infof("Unregistered transport %s", id)
+		tm.Logger.Infof("Unregistered transport %s from manager", id)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		err := tm.conf.DiscoveryClient.DeleteTransport(ctx, id)
+		if err != nil {
+			tm.Logger.Errorf("Unregister transport %s from discovery failed with error: %s", id, err)
+		}
+		tm.Logger.Infof("Unregistered transport %s from discovery", id)
 	}
 }
 

--- a/pkg/transport/manager_test.go
+++ b/pkg/transport/manager_test.go
@@ -141,7 +141,7 @@ func TestNewManager(t *testing.T) {
 		assert.True(t, entry.IsUp)
 
 		m2.DeleteTransport(tp2.Entry.ID)
-		entry, err = tpDisc.GetTransportByID(context.TODO(), tpID)
+		_, err = tpDisc.GetTransportByID(context.TODO(), tpID)
 		require.Contains(t, err.Error(), "not found")
 	})
 }

--- a/pkg/transport/manager_test.go
+++ b/pkg/transport/manager_test.go
@@ -142,8 +142,7 @@ func TestNewManager(t *testing.T) {
 
 		m2.DeleteTransport(tp2.Entry.ID)
 		entry, err = tpDisc.GetTransportByID(context.TODO(), tpID)
-		require.NoError(t, err)
-		assert.False(t, entry.IsUp)
+		require.Contains(t, err.Error(), "not found")
 	})
 }
 


### PR DESCRIPTION
Fixes #10 10

 Changes:	
- Added `DeleteTransport` to client as well as to the mock	

How to test this PR:
Either `make test` or integration test on `skywire-services` using the branch of the same name.