### PR TITLE
Stop hypervisor StartApp from hanging.

### DIFF
--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -190,11 +190,7 @@ func (r *RPC) StartApp(name *string, _ *struct{}) error {
 
 // StopApp stops App with provided name.
 func (r *RPC) StopApp(name *string, _ *struct{}) error {
-	err := r.node.StopApp(*name)
-	if err == ErrUnknownApp {
-		err = errors.New("app is either non-existent, or is already stopped")
-	}
-	return err
+	return r.node.StopApp(*name)
 }
 
 // SetAutoStartIn is input for SetAutoStart.

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -190,7 +190,11 @@ func (r *RPC) StartApp(name *string, _ *struct{}) error {
 
 // StopApp stops App with provided name.
 func (r *RPC) StopApp(name *string, _ *struct{}) error {
-	return r.node.StopApp(*name)
+	err := r.node.StopApp(*name)
+	if err == ErrUnknownApp {
+		err = errors.New("app is either non-existent, or is already stopped")
+	}
+	return err
 }
 
 // SetAutoStartIn is input for SetAutoStart.

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -1,6 +1,7 @@
 package visor
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -124,7 +125,7 @@ func TestStartStopApp(t *testing.T) {
 
 	err = rpc.StopApp(&unknownApp, nil)
 	require.Error(t, err)
-	assert.Equal(t, ErrUnknownApp, err)
+	assert.Equal(t, errors.New("app is either non-existent, or is already stopped"), err)
 
 	require.NoError(t, rpc.StopApp(&app, nil))
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -1,7 +1,6 @@
 package visor
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -125,7 +124,7 @@ func TestStartStopApp(t *testing.T) {
 
 	err = rpc.StopApp(&unknownApp, nil)
 	require.Error(t, err)
-	assert.Equal(t, errors.New("app is either non-existent, or is already stopped"), err)
+	assert.Equal(t, ErrAppNotRunning, err)
 
 	require.NoError(t, rpc.StopApp(&app, nil))
 	time.Sleep(100 * time.Millisecond)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -50,6 +50,9 @@ const (
 // ErrUnknownApp represents lookup error for App related calls.
 var ErrUnknownApp = errors.New("unknown app")
 
+// ErrAppNotRunning occurs when an app is attempted to be stopped when it was not running.
+var ErrAppNotRunning = errors.New("app is not running")
+
 // Version is the node version.
 const Version = "0.0.1"
 
@@ -532,7 +535,7 @@ func (node *Node) StopApp(appName string) error {
 	node.startedMu.Unlock()
 
 	if bind == nil {
-		return ErrUnknownApp
+		return ErrAppNotRunning
 	}
 
 	return node.stopApp(appName, bind)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -402,16 +402,25 @@ func (node *Node) Apps() []*AppState {
 func (node *Node) StartApp(appName string) error {
 	for _, app := range node.appsConf {
 		if app.App == appName {
-			return node.SpawnApp(&app, nil)
+			startCh := make(chan struct{})
+			go func(app AppConfig) {
+				if err := node.SpawnApp(&app, startCh); err != nil {
+					node.logger.Warnf("Failed to start app %s: %s", appName, err)
+				}
+			}(app)
+
+			<-startCh
+			return nil
 		}
 	}
+
 	return ErrUnknownApp
 }
 
 // SpawnApp configures and starts new App.
 func (node *Node) SpawnApp(config *AppConfig, startCh chan<- struct{}) (err error) {
 	node.logger.Infof("Starting %s.v%s", config.App, config.Version)
-
+	node.logger.Warnf("here: config.Args: %+v, with len %d", config.Args, len(config.Args))
 	conn, cmd, err := app.Command(
 		&app.Config{ProtocolVersion: supportedProtocolVersion, AppName: config.App, AppVersion: config.Version},
 		node.appsPath,
@@ -431,6 +440,7 @@ func (node *Node) SpawnApp(config *AppConfig, startCh chan<- struct{}) (err erro
 		node.startedMu.Unlock()
 		return fmt.Errorf("app %s is already started", config.App)
 	}
+
 	node.startedApps[config.App] = bind
 	node.startedMu.Unlock()
 

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -400,18 +400,25 @@ func (node *Node) Apps() []*AppState {
 
 // StartApp starts registered App.
 func (node *Node) StartApp(appName string) error {
-	for _, app := range node.appsConf {
-		if app.App == appName {
-			startCh := make(chan struct{})
-			go func(app AppConfig) {
-				if err := node.SpawnApp(&app, startCh); err != nil {
-					node.logger.Warnf("Failed to start app %s: %s", appName, err)
-				}
-			}(app)
-
-			<-startCh
-			return nil
+	for _, appC := range node.appsConf {
+		if appC.App != appName {
+			continue
 		}
+
+		done := make(chan struct{}, 1)
+		var err error
+
+		go func(appC AppConfig) {
+			if err = node.SpawnApp(&appC, done); err != nil {
+				done <- struct{}{}
+				node.logger.Warnf("Failed to start app %s: %s", appName, err)
+			}
+		}(appC)
+
+		<-done
+		close(done)
+
+		return err
 	}
 
 	return ErrUnknownApp


### PR DESCRIPTION
Fixes #27

 Changes:	
- Ensure node.StartApp returns.
- Improved hypervisor StopApp error message. 
