### PR TITLE
add uptime tracker URL

### DIFF
--- a/cmd/skywire-cli/commands/node/gen-config.go
+++ b/cmd/skywire-cli/commands/node/gen-config.go
@@ -131,7 +131,7 @@ func defaultConfig() *visor.Config {
 
 	conf.Hypervisors = []visor.HypervisorConfig{}
 
-	conf.Uptime.Tracker = ""
+	conf.Uptime.Tracker = "uptime-tracker.skywire.skycoin.com"
 
 	conf.AppsPath = "./apps"
 	conf.LocalPath = "./local"


### PR DESCRIPTION
Adds Uptime tracker URL to `skywire-cli node gen-config`. 