### PR TITLE
set default listening endpoint for stcp in visor #71

### DIFF
--- a/pkg/snet/network.go
+++ b/pkg/snet/network.go
@@ -79,12 +79,15 @@ func (n *Network) Init(ctx context.Context) error {
 	if err := n.dmsgC.InitiateServerConnections(ctx, n.conf.DmsgMinSrvs); err != nil {
 		return fmt.Errorf("failed to initiate 'dmsg': %v", err)
 	}
-	if n.conf.STCPLocalAddr != "" {
+	if n.stcpC != nil {
+		if n.conf.STCPLocalAddr == "" {
+			n.conf.STCPLocalAddr = "127.0.0.1:7000"
+		}
 		if err := n.stcpC.Serve(n.conf.STCPLocalAddr); err != nil {
 			return fmt.Errorf("failed to initiate 'stcp': %v", err)
 		}
 	} else {
-		fmt.Println("No config found for stcp")
+		fmt.Println("No client found for stcp")
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #71 

 Changes:	
- if stcp client has defined, but 	`STCPLocalAddr` is blank ( it may occur the config file has not set  `local_addr` ), it can fill with `127.0.0.1:7000`

How to test this PR:
TestSettlementHS has no any failures at all, testing `make test`.