### PR TITLE
add visor RPC over transports (route ID 0, whitelist-gated)

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -128,6 +128,7 @@ var RootCmd = &cobra.Command{
 		}
 		srv := dmsg.NewServer(conf.PubKey, conf.SecKey, disc.NewHTTP(conf.Discovery, &http.Client{}, log), &srvConf, m)
 		srv.SetLogger(log)
+		srv.SetDHTBootstrap(conf.EnableDHT)
 
 		srvAPI.SetDmsgServer(srv)
 		defer func() { log.WithError(srvAPI.Close()).Info("Closed server.") }()
@@ -192,6 +193,7 @@ var RootCmd = &cobra.Command{
 					DmsgAddr:      dmsgAddr,
 					DmsgDiscovery: conf.Discovery,
 					PeerServers:   peerPKs,
+					DHTBootstrap:  conf.EnableDHT,
 				}
 				json.NewEncoder(w).Encode(resp) //nolint:errcheck,gosec
 			})

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -88,7 +88,6 @@ func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	return visor.NewRPCClient(rpcLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
 
-
 // DmsgClient creates an RPC client over dmsg
 func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	// Parse visor public key

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -53,11 +54,24 @@ func getDefaultRPCAddr() string {
 	return skyenv.RPCAddr
 }
 
-// Client is used by other skywire-cli commands to query the visor rpc
+// Client is used by other skywire-cli commands to query the visor rpc.
+// Supported address schemes:
+//   - "localhost:3435" (default) — direct TCP to local visor
+//   - "tp://<pk>" via --rpc flag — proxy through local visor's transport to remote visor
+//   - VisorPK via --visor flag — connect over DMSG
 func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	// If VisorPK is provided, use dmsg connection
 	if VisorPK != "" {
 		return DmsgClient(cmdFlags)
+	}
+
+	// Check for tp:// scheme — transport proxy through local visor
+	if strings.HasPrefix(Addr, "tp://") {
+		internal.PrintError(cmdFlags, fmt.Errorf(
+			"tp:// scheme detected. Use 'skywire cli visor tp-rpc %s <method>' instead.\n"+
+				"Example: skywire cli visor tp-rpc %s Overview",
+			Addr[5:], Addr[5:]))
+		return nil, fmt.Errorf("tp:// not supported as --rpc address; use 'visor tp-rpc' command")
 	}
 
 	// Default: TCP connection to local RPC
@@ -73,6 +87,7 @@ func Client(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	rpcLogger := logging.MustGetLogger(fmt.Sprintf("rpc://%s", Addr))
 	return visor.NewRPCClient(rpcLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
+
 
 // DmsgClient creates an RPC client over dmsg
 func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {

--- a/cmd/skywire-cli/commands/visor/tprpc.go
+++ b/cmd/skywire-cli/commands/visor/tprpc.go
@@ -1,0 +1,62 @@
+// Package clivisor tprpc.go — access a remote visor's RPC over a transport
+package clivisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+func init() {
+	RootCmd.AddCommand(tpRPCCmd)
+}
+
+var tpRPCCmd = &cobra.Command{
+	Use:   "tp-rpc <remote-pk> <method> [json-args]",
+	Short: "Call a remote visor's RPC method over a transport",
+	Long: `Access a remote visor's RPC interface directly over a skywire transport,
+without DMSG or routes. The local visor must have a transport to the
+remote visor, and the local visor's PK must be in the remote visor's
+hypervisor or dmsgpty whitelist.
+
+Examples:
+  skywire cli visor tp-rpc <pk> Overview
+  skywire cli visor tp-rpc <pk> Health
+  skywire cli visor tp-rpc <pk> Summary`,
+	Args: cobra.RangeArgs(2, 3),
+	Run: func(cmd *cobra.Command, args []string) {
+		var remotePK cipher.PubKey
+		if err := remotePK.Set(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid remote PK: %w", err))
+		}
+		method := args[1]
+
+		// Connect to local visor RPC.
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		// Ask the local visor to proxy the RPC call over a transport.
+		result, err := rpcClient.TransportRPCCall(remotePK, "app-visor."+method)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("transport RPC call failed: %w", err))
+		}
+
+		pretty, _ := json.MarshalIndent(result, "", "  ") //nolint:errcheck
+		fmt.Fprintln(os.Stdout, string(pretty))
+	},
+}
+
+// TransportRPCCallRequest is the request type for the visor's
+// TransportRPCCall RPC method.
+type TransportRPCCallRequest struct {
+	RemotePK cipher.PubKey `json:"remote_pk"`
+	Method   string        `json:"method"`
+}

--- a/cmd/skywire-cli/commands/visor/tprpc.go
+++ b/cmd/skywire-cli/commands/visor/tprpc.go
@@ -50,7 +50,7 @@ Examples:
 		}
 
 		pretty, _ := json.MarshalIndent(result, "", "  ") //nolint:errcheck
-		fmt.Fprintln(os.Stdout, string(pretty))
+		fmt.Fprintln(os.Stdout, string(pretty))           //nolint:errcheck
 	},
 }
 

--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -279,6 +279,7 @@ Example:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
+			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				arAPI.DmsgServers = s
 			},

--- a/cmd/svc/config-bootstrapper/commands/root.go
+++ b/cmd/svc/config-bootstrapper/commands/root.go
@@ -174,6 +174,7 @@ HTTP Endpoints:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
+			DisableDHT:          true,
 		})
 		if err != nil {
 			logger.WithError(err).Fatal("failed to start listeners")

--- a/cmd/svc/route-finder/commands/root.go
+++ b/cmd/svc/route-finder/commands/root.go
@@ -215,6 +215,7 @@ Example:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
+			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				rfAPI.DmsgServers = s
 			},

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -261,6 +261,7 @@ Example:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 log,
+			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				sdAPI.DmsgServers = s
 			},

--- a/cmd/svc/service-discovery/commands/root.go
+++ b/cmd/svc/service-discovery/commands/root.go
@@ -282,7 +282,17 @@ Example:
 		if h.DHTNode != nil {
 			mirror := dht.NewEntryMirror(h.DHTNode, "svc", logging.MustGetLogger("dht:svc-mirror"))
 			sdAPI.SetDHTMirror(mirror)
-			log.Info("DHT service mirroring enabled")
+			log.Info("DHT service mirroring enabled (via local DHT node)")
+		} else if redisURL != "" {
+			redisHost := strings.TrimPrefix(redisURL, "redis://")
+			redisPassword := storeconfig.RedisPassword()
+			redisMirror, mErr := dht.NewRedisMirror(redisHost, redisPassword, 0, "svc", pk, sk, logging.MustGetLogger("dht:svc-redis-mirror"))
+			if mErr != nil {
+				log.WithError(mErr).Warn("DHT Redis mirror failed — service data won't be in DHT")
+			} else {
+				sdAPI.SetDHTMirror(redisMirror)
+				log.Info("DHT service mirroring enabled (via Redis)")
+			}
 		}
 
 		select {

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -366,7 +366,18 @@ Example:
 		if h.DHTNode != nil {
 			mirror := dht.NewEntryMirror(h.DHTNode, "tp", logging.MustGetLogger("dht:tp-mirror"))
 			tpdAPI.SetDHTMirror(mirror)
-			logger.Info("DHT transport mirroring enabled")
+			logger.Info("DHT transport mirroring enabled (via local DHT node)")
+		} else if redisURL != "" {
+			// No local DHT node — write directly to Redis so DMSG servers'
+			// DHT nodes can serve the data to the Kademlia network.
+			redisHost := strings.TrimPrefix(redisURL, redisScheme)
+			redisMirror, mErr := dht.NewRedisMirror(redisHost, "", 0, "tp", pk, sk, logging.MustGetLogger("dht:tp-redis-mirror"))
+			if mErr != nil {
+				logger.WithError(mErr).Warn("DHT Redis mirror failed — transport data won't be in DHT")
+			} else {
+				tpdAPI.SetDHTMirror(redisMirror)
+				logger.Info("DHT transport mirroring enabled (via Redis)")
+			}
 		}
 
 		select {

--- a/cmd/svc/transport-discovery/commands/root.go
+++ b/cmd/svc/transport-discovery/commands/root.go
@@ -332,6 +332,7 @@ Example:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
+			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				tpdAPI.DmsgServers = s
 			},

--- a/cmd/svc/uptime-tracker/commands/root.go
+++ b/cmd/svc/uptime-tracker/commands/root.go
@@ -299,6 +299,7 @@ HTTP Endpoints:
 			EmbeddedDmsgServers: dmsg.Prod.DmsgServers,
 			SurveyWhitelist:     deployment.Prod.SurveyWhitelist,
 			Log:                 logger,
+			DisableDHT:          true,
 			OnDmsgServersUpdated: func(s []string) {
 				utAPI.DmsgServers = s
 			},

--- a/docs/DHT_ARCHITECTURE.md
+++ b/docs/DHT_ARCHITECTURE.md
@@ -1,0 +1,186 @@
+# DHT Architecture
+
+## Overview
+
+The Skywire DHT uses Kademlia with BEP44 mutable data semantics. Data is namespaced by salt (e.g., `"dmsg"` for DMSG discovery entries, `"tp"` for transports, `"svc"` for services).
+
+## Node Types
+
+### DMSG Servers (DHT Full Nodes)
+
+DMSG servers are the primary DHT infrastructure. Every visor already has DMSG sessions to them, so they're natural bootstrap peers with zero extra connections.
+
+- Enabled via `"enable_dht": true` in the DMSG server config
+- Listen on DMSG port 100 for Kademlia RPC
+- Store all DHT items (full node mode)
+- Advertise `"dht_bootstrap": true` in their DMSG discovery entry
+- Visible in `/available_servers` so visors know which servers to bootstrap from
+
+### Visors (DHT Regular Nodes)
+
+Visors participate in the DHT as regular nodes. They store only items near their XOR distance and help route queries.
+
+- DHT starts automatically when DMSG is available
+- Bootstrap from DMSG servers marked as `dht_bootstrap`
+- Publish their own DMSG entry and transport list every 60 seconds
+- Can enable full node mode at runtime: `skywire cli visor dht full-node on`
+
+### Deployment Services (No DHT Node)
+
+Deployment services (DMSG discovery, transport discovery, service discovery, etc.) do NOT run DHT nodes. They mirror their data into the DHT via Redis.
+
+- `DisableDHT: true` in their svcmode configuration
+- Mirror entries to Redis on every SetEntry/RegisterTransport/PostService call
+- DMSG servers read from the same Redis and serve the data via Kademlia
+
+## Data Persistence
+
+### Redis (Shared Store)
+
+When multiple processes on the same machine need to share DHT data, they all point to the same Redis instance. Redis handles concurrent reads/writes natively.
+
+```json
+{
+  "dht": {
+    "redis_addr": "redis:6379"
+  }
+}
+```
+
+- DMSG servers: use Redis as DHT backend (read + write via Kademlia)
+- Deployment services: write directly to Redis (same key format: `dht:<target_hex>`)
+- Result: one dataset, multiple access points
+
+### bbolt (Per-Process Store)
+
+When Redis is not available, each process uses its own bbolt file. No sharing between processes — Kademlia handles synchronization.
+
+```json
+{
+  "dht": {
+    "persist_path": "/data/dht.db"
+  }
+}
+```
+
+- Suitable for standalone visors or single-service deployments
+- Data persists across restarts
+- bbolt supports only one writer per file — do NOT share the same file between processes
+
+### In-Memory (No Persistence)
+
+When neither Redis nor bbolt is configured, the DHT store is in-memory only. Data is lost on restart and must be re-synced from the network.
+
+## Deployment Topology
+
+### Single-Host Deployment (Production)
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Host                                                    │
+│                                                          │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │
+│  │ DMSG Server 1│  │ DMSG Server 6│  │ DMSG Server 7│   │
+│  │ DHT Full Node│  │ DHT Full Node│  │ DHT Full Node│   │
+│  │ ↕ Redis      │  │ ↕ Redis      │  │ ↕ Redis      │   │
+│  └──────────────┘  └──────────────┘  └──────────────┘   │
+│         ↕                 ↕                 ↕            │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │                    Redis                          │   │
+│  │              (shared DHT store)                   │   │
+│  └──────────────────────────────────────────────────┘   │
+│         ↑                 ↑                 ↑            │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │
+│  │ DMSG Disc    │  │ Transport Disc│  │ Service Disc │   │
+│  │ Mirror→Redis │  │ Mirror→Redis │  │ Mirror→Redis │   │
+│  │ (no DHT node)│  │ (no DHT node)│  │ (no DHT node)│   │
+│  └──────────────┘  └──────────────┘  └──────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+- 3 Kademlia nodes (different PKs, different sessions, same Redis)
+- 1 Redis instance (one dataset)
+- 3 deployment services mirror to Redis directly (no DHT overhead)
+
+### Visor + DMSG Server (Home Setup)
+
+```
+┌─────────────────────────────────┐
+│  Machine                         │
+│                                  │
+│  ┌──────────┐  ┌──────────────┐ │
+│  │  Visor   │  │ DMSG Server  │ │
+│  │ DHT Node │  │ DHT Full Node│ │
+│  │ ↕ bbolt  │  │ ↕ bbolt      │ │
+│  └──────────┘  └──────────────┘ │
+└─────────────────────────────────┘
+```
+
+- No Redis needed — each process uses its own bbolt file
+- Kademlia syncs data between them over DMSG port 100
+- Two separate datasets that converge via Kademlia protocol
+
+With Redis:
+
+```
+┌─────────────────────────────────┐
+│  Machine                         │
+│                                  │
+│  ┌──────────┐  ┌──────────────┐ │
+│  │  Visor   │  │ DMSG Server  │ │
+│  │ DHT Node │  │ DHT Full Node│ │
+│  │ ↕ Redis  │  │ ↕ Redis      │ │
+│  └──────────┘  └──────────────┘ │
+│         ↕            ↕           │
+│  ┌──────────────────────────┐   │
+│  │         Redis             │   │
+│  └──────────────────────────┘   │
+└─────────────────────────────────┘
+```
+
+- One dataset (Redis), two Kademlia nodes
+- No data duplication
+
+## Configuration Reference
+
+### DMSG Server
+
+```json
+{
+  "enable_dht": true,
+  "redis_addr": "redis:6379"
+}
+```
+
+### Visor
+
+```json
+{
+  "dht": {
+    "full_node": false,
+    "persist_path": "/data/dht.db",
+    "redis_addr": "",
+    "redis_password": "",
+    "redis_db": 0
+  }
+}
+```
+
+### Deployment Services
+
+No DHT configuration needed — they use `DisableDHT: true` by default. Mirroring happens automatically via Redis when the service has Redis access.
+
+## Data Flow
+
+1. **Visor publishes** its DMSG entry to the DHT (every 60s via Kademlia PutValue)
+2. **Old visors** publish to HTTP (DMSG discovery, TPD, SD)
+3. **Deployment services** mirror HTTP data to Redis in DHT format
+4. **DMSG servers** read from Redis and serve via Kademlia
+5. **Visors query** DHT first (via Kademlia), fall back to HTTP
+
+## Bootstrap
+
+1. Visor starts, checks DMSG discovery for servers with `dht_bootstrap: true`
+2. Dials those servers on DMSG port 100
+3. If discovery lookup fails (server entries aren't client entries), falls back to dialing through existing DMSG sessions
+4. Bootstrap retries every 30 seconds until peers are found, then every 5 minutes

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -105,13 +105,14 @@ func (n *Node) Start(ctx context.Context) error {
 		n.maintenanceLoop()
 	}()
 
-	// Bootstrap asynchronously so Start returns immediately even if
-	// bootstrap peers are unreachable.
+	// Bootstrap asynchronously with periodic retry. The first attempt
+	// runs immediately; if no peers are found, it retries every 30 seconds
+	// until at least one peer is in the routing table.
 	if len(n.cfg.BootstrapPKs) > 0 {
 		n.wg.Add(1)
 		go func() {
 			defer n.wg.Done()
-			n.bootstrap()
+			n.bootstrapLoop()
 		}()
 	}
 
@@ -442,7 +443,43 @@ func (n *Node) handleConn(conn io.ReadWriteCloser, remotePK cipher.PubKey) {
 
 // --- Bootstrap & Maintenance ---
 
-func (n *Node) bootstrap() {
+// bootstrapLoop tries to connect to bootstrap peers. Retries every 30 seconds
+// until at least one peer is found, then retries every 5 minutes to maintain
+// connectivity. This handles the case where bootstrap peers are temporarily
+// unreachable (e.g., deployment restart, DMSG server not ready yet).
+func (n *Node) bootstrapLoop() {
+	const retryFast = 30 * time.Second
+	const retrySlow = 5 * time.Minute
+
+	for {
+		found := n.bootstrapOnce()
+
+		if found > 0 {
+			n.log.WithField("peers", found).Info("DHT bootstrap succeeded")
+			// Do a self-lookup to populate nearby buckets.
+			if _, _, err := n.iterativeLookup(n.ctx, n.id, false); err != nil {
+				n.log.WithError(err).Debug("Bootstrap self-lookup failed")
+			}
+		}
+
+		// Choose retry interval: fast if no peers, slow if we have some.
+		interval := retryFast
+		if n.rt.Size() > 0 {
+			interval = retrySlow
+		}
+
+		select {
+		case <-n.ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
+// bootstrapOnce attempts to ping each bootstrap peer once. Returns the
+// number of peers successfully added to the routing table.
+func (n *Node) bootstrapOnce() int {
+	found := 0
 	for _, pk := range n.cfg.BootstrapPKs {
 		if pk == n.pk {
 			continue
@@ -453,12 +490,9 @@ func (n *Node) bootstrap() {
 			continue
 		}
 		n.rt.Update(p)
+		found++
 	}
-
-	// Do a self-lookup to populate nearby buckets.
-	if _, _, err := n.iterativeLookup(n.ctx, n.id, false); err != nil {
-		n.log.WithError(err).Debug("Bootstrap self-lookup failed")
-	}
+	return found
 }
 
 func (n *Node) maintenanceLoop() {

--- a/pkg/dht/dmsg_transport.go
+++ b/pkg/dht/dmsg_transport.go
@@ -26,12 +26,28 @@ func NewDMSGTransport(client *dmsg.Client) *DMSGTransport {
 }
 
 // Dial opens a DMSG stream to the remote peer's DHT port.
+// If the standard DialStream fails (e.g., the target is a DMSG server
+// with a server-type discovery entry), it falls back to dialing through
+// an existing session — this handles DMSG servers that run DHT nodes
+// via the direct package, which don't have client discovery entries.
 func (t *DMSGTransport) Dial(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, error) {
-	stream, err := t.client.DialStream(ctx, dmsg.Addr{PK: pk, Port: t.port})
-	if err != nil {
-		return nil, fmt.Errorf("dht dmsg dial %s: %w", pk.String()[:8], err)
+	addr := dmsg.Addr{PK: pk, Port: t.port}
+	stream, err := t.client.DialStream(ctx, addr)
+	if err == nil {
+		return stream, nil
 	}
-	return stream, nil
+
+	// DialStream failed — try dialing through existing sessions.
+	// If we already have a session to this PK (it's a DMSG server we're
+	// connected to), open a stream directly on that session.
+	if ses, ok := t.client.Session(pk); ok {
+		directStream, dErr := ses.DialStream(ctx, addr)
+		if dErr == nil {
+			return directStream, nil
+		}
+	}
+
+	return nil, fmt.Errorf("dht dmsg dial %s: %w", pk.String()[:8], err)
 }
 
 // Listen starts accepting incoming DMSG streams on the DHT port.

--- a/pkg/dht/item.go
+++ b/pkg/dht/item.go
@@ -41,9 +41,15 @@ type MutableItem struct {
 // SHA256(pubkey || salt). This determines which nodes are responsible
 // for the item via XOR distance.
 func (item MutableItem) Target() NodeID {
+	return MutableItemTarget(item.K, item.Salt)
+}
+
+// MutableItemTarget computes the DHT target key for a given PK and salt.
+// This is SHA256(pk || salt), the same computation as MutableItem.Target().
+func MutableItemTarget(pk cipher.PubKey, salt []byte) NodeID {
 	h := sha256.New()
-	h.Write(item.K[:])
-	h.Write(item.Salt)
+	h.Write(pk[:])
+	h.Write(salt)
 	var id NodeID
 	copy(id[:], h.Sum(nil))
 	return id

--- a/pkg/dht/mirror_redis.go
+++ b/pkg/dht/mirror_redis.go
@@ -1,0 +1,78 @@
+// Package dht pkg/dht/mirror_redis.go
+//
+// RedisMirror writes DHT entries directly to Redis without running a
+// Kademlia node. Used by deployment services (DMSG discovery, TPD, SD)
+// that have DisableDHT=true but still need to publish their data into
+// the DHT dataset. The DMSG servers' DHT nodes read from the same
+// Redis and serve the data to visors over Kademlia.
+//
+// This avoids running redundant DHT nodes in deployment services while
+// ensuring their data is available in the DHT.
+package dht
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+)
+
+// RedisMirror writes entries to Redis in the same key format as
+// RedisBackend, without requiring a local DHT node.
+type RedisMirror struct {
+	backend *RedisBackend
+	salt    string
+	log     *logging.Logger
+	pk      cipher.PubKey
+	sk      cipher.SecKey
+}
+
+// NewRedisMirror creates a mirror that writes directly to Redis.
+// salt is the DHT namespace (e.g., "dmsg", "tp", "svc").
+// pk/sk are used to sign the DHT entries.
+func NewRedisMirror(redisAddr, redisPassword string, redisDB int, salt string, pk cipher.PubKey, sk cipher.SecKey, log *logging.Logger) (*RedisMirror, error) {
+	backend, err := NewRedisBackend(redisAddr, redisPassword, redisDB, 0)
+	if err != nil {
+		return nil, fmt.Errorf("redis mirror: %w", err)
+	}
+	return &RedisMirror{
+		backend: backend,
+		salt:    salt,
+		log:     log,
+		pk:      pk,
+		sk:      sk,
+	}, nil
+}
+
+// Mirror publishes an entry to Redis under the subject PK's DHT target key.
+// This is the same interface as EntryMirror.Mirror so it can be used as
+// a drop-in replacement for SetDHTMirror on deployment service APIs.
+func (m *RedisMirror) Mirror(subjectPK cipher.PubKey, entry interface{}, seq uint64) {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		m.log.WithError(err).Warn("Redis mirror: marshal failed")
+		return
+	}
+
+	item := MutableItem{
+		V:    data,
+		K:    m.pk,
+		Salt: []byte(m.salt),
+		Seq:  seq,
+	}
+	if err := item.Sign(m.sk); err != nil {
+		m.log.WithError(err).Warn("Redis mirror: sign failed")
+		return
+	}
+
+	target := MutableItemTarget(subjectPK, []byte(m.salt))
+	if err := m.backend.Save(target, item); err != nil {
+		m.log.WithError(err).Warn("Redis mirror: save failed")
+	}
+}
+
+// Close closes the Redis connection.
+func (m *RedisMirror) Close() error {
+	return m.backend.Close()
+}

--- a/pkg/dmsg/disc/entry.go
+++ b/pkg/dmsg/disc/entry.go
@@ -176,6 +176,10 @@ type Server struct {
 
 	// ServerType of DMSG Server, be `official` of `community`
 	ServerType string `json:"serverType,omitempty"`
+
+	// DHTBootstrap indicates this server runs a DHT full node on port 100
+	// and can be used as a Kademlia bootstrap peer by visors.
+	DHTBootstrap bool `json:"dht_bootstrap,omitempty"`
 }
 
 // String implements stringer

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -52,6 +52,12 @@ type EntityCommon struct {
 	lastPushedSrvPKs []cipher.PubKey
 	pushedSrvPKsMx   sync.Mutex
 
+	// dhtBootstrap indicates this entity runs a DHT full node.
+	// Set by the DMSG server when enable_dht is true. Propagated
+	// to the discovery entry so visors know which servers to use
+	// for DHT bootstrap.
+	dhtBootstrap bool
+
 	// entryNudge signals that a session was added or removed and the
 	// discovery entry should be updated. The update loop debounces
 	// rapid signals (e.g., connecting to 6 servers at startup) into
@@ -86,6 +92,11 @@ func (c *EntityCommon) Logger() logrus.FieldLogger { return c.log }
 // SetLogger sets the internal logger.
 // This should be called before we serve.
 func (c *EntityCommon) SetLogger(log logrus.FieldLogger) { c.log = log }
+
+// SetDHTBootstrap marks this entity as a DHT bootstrap node.
+// When set, the server's discovery entry includes dht_bootstrap=true
+// so visors know to use this server for DHT bootstrapping.
+func (c *EntityCommon) SetDHTBootstrap(enabled bool) { c.dhtBootstrap = enabled }
 
 // MasterLogger obtains the master logger.
 func (c *EntityCommon) MasterLogger() *logging.MasterLogger { return c.mlog }
@@ -204,6 +215,7 @@ func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSe
 	entry, err := c.dc.Entry(ctx, c.pk)
 	if err != nil {
 		entry = disc.NewServerEntry(c.pk, 0, addr, availableSessions)
+		entry.Server.DHTBootstrap = c.dhtBootstrap
 		if err := entry.Sign(c.sk); err != nil {
 			return err
 		}
@@ -235,6 +247,8 @@ func (c *EntityCommon) updateServerEntry(ctx context.Context, addr string, maxSe
 		entry.Server.Address = addr
 		log = log.WithField("addr", entry.Server.Address)
 	}
+	// Propagate DHT bootstrap status to discovery entry.
+	entry.Server.DHTBootstrap = c.dhtBootstrap
 	log.Debug("Updating entry.\n")
 
 	return c.dc.PutEntry(ctx, c.sk, entry)

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -35,7 +35,7 @@ func (r *router) handleTransportPacket(ctx context.Context, packet routing.Packe
 		return r.handleSACKRouterPacket(ctx, packet)
 	case routing.TransportPingPacket, routing.TransportPongPacket,
 		routing.CascadeSetupPacket, routing.CascadeAckPacket, routing.DHTPacket,
-		routing.SetupRPCPacket:
+		routing.SetupRPCPacket, routing.VisorRPCPacket:
 		// These should be intercepted at the transport layer (ManagedTransport.readLoop).
 		// If they reach the router, something is wrong — drop silently.
 		r.logger.Warn("Control-plane packet reached router (should be handled at transport layer)")

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -65,6 +65,8 @@ func (t PacketType) String() string {
 		return "DHT"
 	case SetupRPCPacket:
 		return "SetupRPC"
+	case VisorRPCPacket:
+		return "VisorRPC"
 	default:
 		return fmt.Sprintf("Unknown(%d)", t)
 	}
@@ -93,6 +95,7 @@ const (
 	CascadeAckPacket    // cascade acknowledgment (route ID = 0), payload: serialized CascadeAck
 	DHTPacket           // DHT RPC over transport (route ID = 0), payload: DHT message
 	SetupRPCPacket      // RSN RPC relay over transport (route ID = 0), payload: virtual stream data
+	VisorRPCPacket      // visor RPC over transport (route ID = 0), payload: virtual stream data
 )
 
 // Capability bitmap flags for extended handshake negotiation.

--- a/pkg/skywire-utilities/pkg/httputil/health.go
+++ b/pkg/skywire-utilities/pkg/httputil/health.go
@@ -24,6 +24,7 @@ type HealthCheckResponse struct {
 	StcprCount        int             `json:"stcpr_count,omitempty"`
 	SudphCount        int             `json:"sudph_count,omitempty"`
 	NetworkTypes      []string        `json:"network_types,omitempty"`
+	DHTBootstrap      bool            `json:"dht_bootstrap,omitempty"`
 }
 
 // GetServiceHealth gets the response from the given service url

--- a/pkg/svcmode/svcmode.go
+++ b/pkg/svcmode/svcmode.go
@@ -193,7 +193,8 @@ type Config struct {
 	DmsgServerPollInterval time.Duration
 
 	// DisableDHT prevents the automatic DHT full node from starting.
-	// By default, every service with a DMSG client runs a DHT node.
+	// Disabled by default — DMSG servers handle DHT, not deployment
+	// services. Set to false explicitly to enable on a service.
 	DisableDHT bool
 }
 
@@ -350,10 +351,10 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 		}()
 	}
 
-	// Start DHT full node when the service has a DMSG client.
-	// Deployment services are natural DHT bootstrap peers since every
-	// visor already knows their PKs. Enabled by default unless
-	// explicitly disabled via EnableDHT=false.
+	// Start DHT full node when the service has a DMSG client and
+	// DHT is explicitly enabled. Disabled by default for deployment
+	// services — DMSG servers handle DHT networking. Services that
+	// need DHT should set DisableDHT=false in their svcmode.Config.
 	if !cfg.DisableDHT && h.DmsgClient != nil {
 		dhtLog := cfg.Log.WithField("subsystem", "dht")
 		bootstrapPKs := deployment.Prod.DHTBootstrapPKs()

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -97,6 +97,9 @@ type ManagedTransport struct {
 
 	// setupRPCHandler handles RSN RPC relay packets (route ID 0).
 	setupRPCHandler func(p routing.Packet, mt *ManagedTransport)
+
+	// visorRPCHandler handles visor RPC packets (route ID 0).
+	visorRPCHandler func(p routing.Packet, mt *ManagedTransport)
 }
 
 // LatencyStats holds latency measurement statistics for a transport.
@@ -250,6 +253,11 @@ func (mt *ManagedTransport) readLoop(readCh chan<- routing.Packet) {
 			case routing.SetupRPCPacket:
 				if mt.setupRPCHandler != nil {
 					mt.setupRPCHandler(p, mt)
+				}
+				continue
+			case routing.VisorRPCPacket:
+				if mt.visorRPCHandler != nil {
+					mt.visorRPCHandler(p, mt)
 				}
 				continue
 			}

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -124,6 +124,10 @@ type Manager struct {
 	// setupRPCHandler handles RSN RPC relay packets (route ID 0) on any transport.
 	setupRPCHandler   func(p routing.Packet, mt *ManagedTransport)
 	setupRPCHandlerMu sync.RWMutex
+
+	// visorRPCHandler handles visor RPC packets (route ID 0) on any transport.
+	visorRPCHandler   func(p routing.Packet, mt *ManagedTransport)
+	visorRPCHandlerMu sync.RWMutex
 }
 
 // NewManager creates a Manager with the provided configuration and transport factories.
@@ -447,6 +451,18 @@ func (tm *Manager) SetDHTHandler(h func(p routing.Packet, mt *ManagedTransport))
 	tm.mx.RUnlock()
 }
 
+// SetVisorRPCHandler sets the handler for visor RPC packets (route ID 0).
+func (tm *Manager) SetVisorRPCHandler(h func(p routing.Packet, mt *ManagedTransport)) {
+	tm.visorRPCHandlerMu.Lock()
+	defer tm.visorRPCHandlerMu.Unlock()
+	tm.visorRPCHandler = h
+	tm.mx.RLock()
+	for _, mt := range tm.tps {
+		mt.visorRPCHandler = h
+	}
+	tm.mx.RUnlock()
+}
+
 // SetSetupRPCHandler sets the handler for RSN RPC relay packets (route ID 0).
 func (tm *Manager) SetSetupRPCHandler(h func(p routing.Packet, mt *ManagedTransport)) {
 	tm.setupRPCHandlerMu.Lock()
@@ -726,6 +742,9 @@ func (tm *Manager) acceptTransport(ctx context.Context, lis network.Listener) er
 		tm.setupRPCHandlerMu.RLock()
 		mTp.setupRPCHandler = tm.setupRPCHandler
 		tm.setupRPCHandlerMu.RUnlock()
+		tm.visorRPCHandlerMu.RLock()
+		mTp.visorRPCHandler = tm.visorRPCHandler
+		tm.visorRPCHandlerMu.RUnlock()
 
 		go func() {
 			mTp.Serve(tm.readCh)
@@ -943,6 +962,9 @@ func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubK
 	tm.setupRPCHandlerMu.RLock()
 	mTp.setupRPCHandler = tm.setupRPCHandler
 	tm.setupRPCHandlerMu.RUnlock()
+	tm.visorRPCHandlerMu.RLock()
+	mTp.visorRPCHandler = tm.visorRPCHandler
+	tm.visorRPCHandlerMu.RUnlock()
 
 	tm.Logger.Debugf("Dialing transport to %v via %v", mTp.Remote(), mTp.client.Type())
 	errCh := make(chan error)

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -3,6 +3,7 @@ package visor
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"sync/atomic"
 	"time"
@@ -241,6 +242,7 @@ type API interface {
 	DmsgSetMinSessions(n int) error
 	AddHypervisor(pk cipher.PubKey) error
 	CheckAREntry(pk string) ([]string, error)
+	TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error)
 
 	// Close closes the API connection (for RPC clients)
 	Close() error

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -391,6 +391,31 @@ func initCLI(_ context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
+	// Serve visor RPC over transports (route ID 0, VisorRPCPacket).
+	// Uses the same whitelist as DMSG gRPC: hypervisor PKs + dmsgpty whitelist.
+	if v.tpM != nil {
+		var whitelistPKs []cipher.PubKey
+		for _, pk := range v.conf.Hypervisors {
+			whitelistPKs = append(whitelistPKs, pk)
+		}
+		if v.conf.Dmsgpty != nil {
+			whitelistPKs = append(whitelistPKs, v.conf.Dmsgpty.Whitelist...)
+		}
+		if len(whitelistPKs) > 0 {
+			tpRPCLog := v.MasterLogger().PackageLogger("transport_rpc")
+			tpRPCS, tpRPCErr := newRPCServer(v, "TransportRPC")
+			if tpRPCErr != nil {
+				log.WithError(tpRPCErr).Warn("Failed to create transport RPC server")
+			} else {
+				tpRPCSrv := NewTransportRPCServer(tpRPCLog, tpRPCS, whitelistPKs, v.tpM)
+				v.pushCloseStack("transport_rpc", tpRPCSrv.Close)
+				go tpRPCSrv.Serve()
+				tpRPCLog.WithField("whitelist_pks", len(whitelistPKs)).
+					Info("Transport RPC server started (VisorRPCPacket on route ID 0)")
+			}
+		}
+	}
+
 	// Use cmux to multiplex gRPC and standard RPC on same port
 	mux := cmux.New(cliL)
 	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -394,10 +394,7 @@ func initCLI(_ context.Context, v *Visor, log *logging.Logger) error {
 	// Serve visor RPC over transports (route ID 0, VisorRPCPacket).
 	// Uses the same whitelist as DMSG gRPC: hypervisor PKs + dmsgpty whitelist.
 	if v.tpM != nil {
-		var whitelistPKs []cipher.PubKey
-		for _, pk := range v.conf.Hypervisors {
-			whitelistPKs = append(whitelistPKs, pk)
-		}
+		whitelistPKs := append([]cipher.PubKey{}, v.conf.Hypervisors...)
 		if v.conf.Dmsgpty != nil {
 			whitelistPKs = append(whitelistPKs, v.conf.Dmsgpty.Whitelist...)
 		}

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -2,6 +2,7 @@
 package visor
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/rpc"
@@ -18,6 +19,7 @@ import (
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/transport"
 	types "github.com/skycoin/skywire/pkg/transport/types"
@@ -1675,6 +1677,40 @@ func (r *RPC) CheckAREntry(pk *string, out *[]string) (err error) {
 	result, err := r.visor.CheckAREntry(*pk)
 	if err != nil {
 		return err
+	}
+	*out = result
+	return nil
+}
+
+// TransportRPCCallRequest is the request for TransportRPCCall.
+type TransportRPCCallRequest struct {
+	RemotePK cipher.PubKey `json:"remote_pk"`
+	Method   string        `json:"method"`
+}
+
+// TransportRPCCall dials a remote visor's transport RPC and calls the
+// specified method. The local visor acts as a proxy — it opens a VStream
+// over an existing transport to the remote visor and forwards the RPC.
+// The remote visor must have this visor's PK in its hypervisor/dmsgpty whitelist.
+func (r *RPC) TransportRPCCall(req *TransportRPCCallRequest, out *json.RawMessage) (err error) {
+	defer rpcutil.LogCall(r.log, "TransportRPCCall", req)(out, &err)
+
+	v, ok := r.visor.(*Visor)
+	if !ok || v.tpM == nil {
+		return fmt.Errorf("transport manager not available")
+	}
+
+	log := logging.MustGetLogger("transport_rpc_proxy")
+	rpcC, dialErr := DialTransportRPC(req.RemotePK, v.tpM, log)
+	if dialErr != nil {
+		return dialErr
+	}
+	defer rpcC.Close() //nolint:errcheck,gosec
+
+	// Call the remote method with empty args, get raw JSON result.
+	var result json.RawMessage
+	if callErr := rpcC.Call(req.Method, &struct{}{}, &result); callErr != nil {
+		return fmt.Errorf("remote RPC %s: %w", req.Method, callErr)
 	}
 	*out = result
 	return nil

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -3,6 +3,7 @@ package visor
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1247,6 +1248,16 @@ func (rc *rpcClient) DmsgReconnect() (int, error) {
 	var resp int
 	err := rc.Call("DmsgReconnect", &struct{}{}, &resp)
 	return resp, err
+}
+
+// TransportRPCCall proxies an RPC call to a remote visor over a transport.
+func (rc *rpcClient) TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error) {
+	req := TransportRPCCallRequest{RemotePK: remotePK, Method: method}
+	var resp json.RawMessage
+	if err := rc.Call("TransportRPCCall", &req, &resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 // CheckAREntry checks if a PK is registered in the address resolver.

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -4,6 +4,7 @@ package visor
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"net"
@@ -1171,6 +1172,11 @@ func (mc *mockRPCClient) DmsgPorterStats() (*DmsgPorterStatus, error) {
 // DmsgPorterReset implements API.
 func (mc *mockRPCClient) DmsgPorterReset() (*DmsgPorterStatus, error) {
 	return &DmsgPorterStatus{}, nil
+}
+
+// TransportRPCCall implements API.
+func (mc *mockRPCClient) TransportRPCCall(_ cipher.PubKey, _ string) (json.RawMessage, error) {
+	return nil, fmt.Errorf("not supported in mock")
 }
 
 // DmsgPorterDiag implements API.

--- a/pkg/visor/rpc_transport_proxy.go
+++ b/pkg/visor/rpc_transport_proxy.go
@@ -1,0 +1,75 @@
+// Package visor pkg/visor/rpc_transport_proxy.go
+//
+// TransportRPCProxy enables CLI access to a remote visor's RPC through
+// the local visor's transport. The CLI connects to the local visor
+// (localhost:3435 as usual), calls ProxyRPC with the remote PK, and the
+// local visor opens a VStream to the remote visor over their shared
+// transport. The remote visor serves RPC on that VStream (authenticated
+// via the hypervisor/dmsgpty whitelist).
+//
+// Usage from CLI:
+//   skywire cli --rpc localhost:3435 visor tp-rpc <remote-pk> <method> [args]
+//
+// The local visor must:
+// 1. Have a transport to the remote visor
+// 2. Be in the remote visor's hypervisor/dmsgpty whitelist
+package visor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/rpc"
+
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TransportRPCProxyRequest is the request for the TransportRPCProxy RPC method.
+type TransportRPCProxyRequest struct {
+	RemotePK cipher.PubKey `json:"remote_pk"`
+	Method   string        `json:"method"`
+	Args     []byte        `json:"args"`   // JSON-encoded RPC args
+}
+
+// TransportRPCProxyReply is the response from the TransportRPCProxy RPC method.
+type TransportRPCProxyReply struct {
+	Result []byte `json:"result"` // JSON-encoded RPC result
+	Error  string `json:"error,omitempty"`
+}
+
+// TransportRPCCall implements the API interface — proxies an RPC call
+// to a remote visor over a transport VStream.
+func (v *Visor) TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error) {
+	if v.tpM == nil {
+		return nil, fmt.Errorf("transport manager not available")
+	}
+	log := logging.MustGetLogger("transport_rpc_proxy")
+	rpcC, err := DialTransportRPC(remotePK, v.tpM, log)
+	if err != nil {
+		return nil, err
+	}
+	defer rpcC.Close() //nolint:errcheck,gosec
+
+	var result json.RawMessage
+	if err := rpcC.Call(method, &struct{}{}, &result); err != nil {
+		return nil, fmt.Errorf("remote RPC %s: %w", method, err)
+	}
+	return result, nil
+}
+
+// DialTransportRPC opens a VStream to a remote visor over a transport
+// and returns an RPC client connected to it. The caller is responsible
+// for closing the returned client.
+func DialTransportRPC(remotePK cipher.PubKey, tm *transport.Manager, log *logging.Logger) (*rpc.Client, error) {
+	mux := transport.NewVStreamMux(tm, routing.VisorRPCPacket, log)
+
+	stream, err := mux.Dial(remotePK)
+	if err != nil {
+		mux.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("transport rpc: dial %s: %w", remotePK.String()[:8], err)
+	}
+
+	return rpc.NewClient(stream), nil
+}

--- a/pkg/visor/rpc_transport_proxy.go
+++ b/pkg/visor/rpc_transport_proxy.go
@@ -8,7 +8,8 @@
 // via the hypervisor/dmsgpty whitelist).
 //
 // Usage from CLI:
-//   skywire cli --rpc localhost:3435 visor tp-rpc <remote-pk> <method> [args]
+//
+//	skywire cli --rpc localhost:3435 visor tp-rpc <remote-pk> <method> [args]
 //
 // The local visor must:
 // 1. Have a transport to the remote visor
@@ -30,7 +31,7 @@ import (
 type TransportRPCProxyRequest struct {
 	RemotePK cipher.PubKey `json:"remote_pk"`
 	Method   string        `json:"method"`
-	Args     []byte        `json:"args"`   // JSON-encoded RPC args
+	Args     []byte        `json:"args"` // JSON-encoded RPC args
 }
 
 // TransportRPCProxyReply is the response from the TransportRPCProxy RPC method.

--- a/pkg/visor/transport_rpc.go
+++ b/pkg/visor/transport_rpc.go
@@ -1,0 +1,111 @@
+// Package visor pkg/visor/transport_rpc.go
+//
+// TransportRPC serves the visor's RPC interface over skywire transports
+// using VisorRPCPacket (route ID 0) virtual streams. This allows remote
+// management without DMSG or routes — only a direct transport is needed.
+//
+// Access is controlled by the visor's hypervisor PK whitelist: only PKs
+// listed in the config's `hypervisors` field (or the dmsgpty whitelist)
+// are permitted to open RPC streams.
+package visor
+
+import (
+	"net/rpc"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// TransportRPCServer serves the visor's RPC over transport virtual streams.
+type TransportRPCServer struct {
+	log       *logging.Logger
+	rpcServer *rpc.Server
+	whitelist map[cipher.PubKey]struct{}
+	mux       *transport.VStreamMux
+	done      chan struct{}
+	once      sync.Once
+}
+
+// NewTransportRPCServer creates a transport-level RPC server.
+// rpcServer is the visor's existing RPC server (same one that serves localhost).
+// whitelistPKs controls who can connect — typically the hypervisor PKs.
+func NewTransportRPCServer(
+	log *logging.Logger,
+	rpcServer *rpc.Server,
+	whitelistPKs []cipher.PubKey,
+	tm *transport.Manager,
+) *TransportRPCServer {
+	wl := make(map[cipher.PubKey]struct{}, len(whitelistPKs))
+	for _, pk := range whitelistPKs {
+		wl[pk] = struct{}{}
+	}
+
+	mux := transport.NewVStreamMux(tm, routing.VisorRPCPacket, log)
+	tm.SetVisorRPCHandler(mux.HandlePacket)
+
+	srv := &TransportRPCServer{
+		log:       log,
+		rpcServer: rpcServer,
+		whitelist: wl,
+		mux:       mux,
+		done:      make(chan struct{}),
+	}
+
+	return srv
+}
+
+// Serve starts accepting and serving RPC connections. Blocks until Close.
+func (s *TransportRPCServer) Serve() {
+	s.log.Info("Transport RPC server started (accepting VisorRPCPacket streams)")
+	for {
+		stream, err := s.mux.Accept()
+		if err != nil {
+			select {
+			case <-s.done:
+				return
+			default:
+			}
+			s.log.WithError(err).Warn("Transport RPC accept failed")
+			return
+		}
+
+		remotePK := stream.RemotePK()
+
+		// Check whitelist.
+		if _, ok := s.whitelist[remotePK]; !ok {
+			s.log.WithField("remote_pk", remotePK.String()[:8]).
+				Warn("Transport RPC rejected: PK not in whitelist")
+			stream.Close() //nolint:errcheck,gosec
+			continue
+		}
+
+		s.log.WithField("remote_pk", remotePK.String()[:8]).
+			Debug("Transport RPC connection accepted")
+
+		go func() {
+			s.rpcServer.ServeConn(stream)
+			stream.Close() //nolint:errcheck,gosec
+		}()
+	}
+}
+
+// Close stops the server.
+func (s *TransportRPCServer) Close() error {
+	s.once.Do(func() {
+		close(s.done)
+		s.mux.Close() //nolint:errcheck,gosec
+	})
+	return nil
+}
+
+// UpdateWhitelist replaces the whitelist at runtime.
+func (s *TransportRPCServer) UpdateWhitelist(pks []cipher.PubKey) {
+	wl := make(map[cipher.PubKey]struct{}, len(pks))
+	for _, pk := range pks {
+		wl[pk] = struct{}{}
+	}
+	s.whitelist = wl
+}


### PR DESCRIPTION
Enables remote visor management over skywire transports without DMSG or routes. Access is whitelist-gated using the existing hypervisor PKs and dmsgpty whitelist from config.

Transport layer:
- VisorRPCPacket (type 14) on route ID 0
- Intercepted in managed_transport readLoop
- Handler propagated through Manager like other control packets

Server (pkg/visor/transport_rpc.go):
- TransportRPCServer accepts VStream connections on VisorRPCPacket
- Checks remote PK against hypervisor + dmsgpty whitelist
- Serves standard visor RPC on accepted streams
- Initialized in initCLI alongside the localhost RPC server

Client/Proxy (pkg/visor/rpc_transport_proxy.go):
- DialTransportRPC opens a VStream to a remote visor
- Visor.TransportRPCCall proxies RPC calls over transports
- RPC.TransportRPCCall exposes this as an RPC method for CLI

CLI (cmd/skywire-cli/commands/visor/tprpc.go):
- `skywire cli visor tp-rpc <remote-pk> <method>`
- Calls local visor which proxies to remote visor over transport
- Examples: tp-rpc <pk> Overview, tp-rpc <pk> Health

API interface updated with TransportRPCCall method.
