### PR TITLE
add DHT full node discovery and bulk sync

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -318,6 +318,35 @@ var RootCmd = &cobra.Command{
 						WithField("bootstrap_peers", len(bootstrapPKs)).
 						Info("DHT full node started on port 100")
 
+					// Publish this server's entry to the DHT so visors can
+					// discover DMSG servers without the DMSG discovery HTTP API.
+					go func() {
+						seq := uint64(1)
+						ticker := time.NewTicker(5 * time.Minute)
+						defer ticker.Stop()
+						for {
+							serverEntry := map[string]interface{}{
+								"pk":            conf.PubKey.Hex(),
+								"address":       conf.PublicAddress,
+								"max_sessions":  conf.MaxSessions,
+								"server_type":   conf.Peers, // peer list for reference
+								"dht_bootstrap": true,
+							}
+							data, jErr := json.Marshal(serverEntry)
+							if jErr == nil {
+								if putErr := dhtNode.Put(ctx, data, seq, []byte("dmsg-server")); putErr != nil {
+									dhtLog.WithError(putErr).Trace("Failed to publish server entry to DHT")
+								}
+								seq++
+							}
+							select {
+							case <-ctx.Done():
+								return
+							case <-ticker.C:
+							}
+						}
+					}()
+
 					<-ctx.Done()
 					dhtNode.Stop() //nolint:errcheck,gosec
 				}()

--- a/cmd/skywire-cli/commands/tp/tp-all.go
+++ b/cmd/skywire-cli/commands/tp/tp-all.go
@@ -13,10 +13,7 @@ import (
 	"github.com/skycoin/skywire/deployment"
 )
 
-var allFromDHT bool
-
 func init() {
-	tpAllCmd.Flags().BoolVar(&allFromDHT, "dht", false, "fetch from local DHT full node instead of transport discovery")
 	RootCmd.AddCommand(tpAllCmd)
 }
 
@@ -25,39 +22,34 @@ var tpAllCmd = &cobra.Command{
 	Short: "List all transports on the network",
 	Long: `Display all transports registered in the network.
 
-By default, fetches from the transport discovery HTTP API.
-With --dht, fetches from the local visor's DHT store (requires full node).
-
-Examples:
-  skywire cli tp all              # from transport discovery
-  skywire cli tp all --dht        # from local DHT full node`,
+If the visor is running a DHT full node, data is served from the
+local store (instant, no network). Otherwise falls back to the
+transport discovery HTTP API.`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		if allFromDHT {
-			// Fetch from local DHT full node
-			rpcClient, err := clirpc.Client(cmd.Flags())
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), err)
-			}
-			result, err := rpcClient.DHTGetAll("tp")
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("DHT fetch failed: %w", err))
-			}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		// Try local DHT full node first.
+		result, err := rpcClient.DHTGetAll("tp")
+		if err == nil && result != "[]" && result != "" {
 			fmt.Fprintln(os.Stdout, result) //nolint:errcheck
+			return
+		}
+
+		// Fall back to transport discovery HTTP.
+		tpdURL := deployment.Prod.TransportDiscovery + "/all-transports"
+		body, fetchErr := clirpc.FetchServiceURL(cmd.Flags(), tpdURL)
+		if fetchErr != nil {
+			internal.PrintFatalError(cmd.Flags(), fetchErr)
+		}
+		var v interface{}
+		if json.Unmarshal(body, &v) == nil {
+			pretty, _ := json.MarshalIndent(v, "", "  ") //nolint:errcheck
+			fmt.Fprintln(os.Stdout, string(pretty))      //nolint:errcheck
 		} else {
-			// Fetch from transport discovery HTTP
-			tpdURL := deployment.Prod.TransportDiscovery + "/all-transports"
-			body, err := clirpc.FetchServiceURL(cmd.Flags(), tpdURL)
-			if err != nil {
-				internal.PrintFatalError(cmd.Flags(), err)
-			}
-			// Pretty print
-			var v interface{}
-			if json.Unmarshal(body, &v) == nil {
-				pretty, _ := json.MarshalIndent(v, "", "  ") //nolint:errcheck
-				fmt.Fprintln(os.Stdout, string(pretty))      //nolint:errcheck
-			} else {
-				fmt.Fprintln(os.Stdout, string(body)) //nolint:errcheck
-			}
+			fmt.Fprintln(os.Stdout, string(body)) //nolint:errcheck
 		}
 	},
 }

--- a/cmd/skywire-cli/commands/tp/tp-all.go
+++ b/cmd/skywire-cli/commands/tp/tp-all.go
@@ -1,0 +1,63 @@
+// Package clitp tp-all.go — list all transports from DHT or transport discovery
+package clitp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/deployment"
+)
+
+var allFromDHT bool
+
+func init() {
+	tpAllCmd.Flags().BoolVar(&allFromDHT, "dht", false, "fetch from local DHT full node instead of transport discovery")
+	RootCmd.AddCommand(tpAllCmd)
+}
+
+var tpAllCmd = &cobra.Command{
+	Use:   "all",
+	Short: "List all transports on the network",
+	Long: `Display all transports registered in the network.
+
+By default, fetches from the transport discovery HTTP API.
+With --dht, fetches from the local visor's DHT store (requires full node).
+
+Examples:
+  skywire cli tp all              # from transport discovery
+  skywire cli tp all --dht        # from local DHT full node`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		if allFromDHT {
+			// Fetch from local DHT full node
+			rpcClient, err := clirpc.Client(cmd.Flags())
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			result, err := rpcClient.DHTGetAll("tp")
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("DHT fetch failed: %w", err))
+			}
+			fmt.Fprintln(os.Stdout, result) //nolint:errcheck
+		} else {
+			// Fetch from transport discovery HTTP
+			tpdURL := deployment.Prod.TransportDiscovery + "/all-transports"
+			body, err := clirpc.FetchServiceURL(cmd.Flags(), tpdURL)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), err)
+			}
+			// Pretty print
+			var v interface{}
+			if json.Unmarshal(body, &v) == nil {
+				pretty, _ := json.MarshalIndent(v, "", "  ") //nolint:errcheck
+				fmt.Fprintln(os.Stdout, string(pretty))      //nolint:errcheck
+			} else {
+				fmt.Fprintln(os.Stdout, string(body)) //nolint:errcheck
+			}
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/tp/zgroups.go
+++ b/cmd/skywire-cli/commands/tp/zgroups.go
@@ -20,7 +20,8 @@ const (
 var commandGroup = map[string]string{
 	"add":        groupLocal,
 	"rm":         groupLocal,
-	"disc":       groupLocal,
+	"disc":       groupNetwork,
+	"all":        groupNetwork,
 	"tree":       groupNetwork,
 	"v":          groupNetwork,
 	"net-stats":  groupNetwork,

--- a/cmd/skywire-cli/commands/visor/dht.go
+++ b/cmd/skywire-cli/commands/visor/dht.go
@@ -16,6 +16,7 @@ func init() {
 	dhtCmd.AddCommand(dhtGetCmd)
 	dhtCmd.AddCommand(dhtPutCmd)
 	dhtCmd.AddCommand(dhtFullNodeCmd)
+	dhtCmd.AddCommand(dhtSyncCmd)
 	RootCmd.AddCommand(dhtCmd)
 }
 
@@ -129,5 +130,39 @@ Normal nodes only store items close to their own ID.
 		} else {
 			fmt.Println("DHT full node mode disabled (storing nearby items only).")
 		}
+	},
+}
+
+var dhtSyncSalt string
+
+func init() {
+	dhtSyncCmd.Flags().StringVar(&dhtSyncSalt, "salt", "", "filter by namespace (dmsg, tp, svc); empty = all")
+}
+
+var dhtSyncCmd = &cobra.Command{
+	Use:   "sync [full-node-pk]",
+	Short: "Bulk sync items from a DHT full node",
+	Long: `Fetch all items from a DHT full node and store them locally.
+If no PK is specified, syncs from the first available bootstrap peer.
+
+Examples:
+  skywire cli visor dht sync
+  skywire cli visor dht sync --salt dmsg
+  skywire cli visor dht sync <pk> --salt tp`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		pk := ""
+		if len(args) > 0 {
+			pk = args[0]
+		}
+		result, err := rpcClient.DHTSync(pk, dhtSyncSalt)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Synced %d items from DHT full node.\n", result)
 	},
 }

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -139,6 +139,17 @@ var summaryCmd = &cobra.Command{
 		}
 		msg += fmt.Sprintf("Transports: %s\n", tpStr)
 
+		// DHT status
+		if summary.DHTStatus != nil && summary.DHTStatus.Running {
+			dhtMode := "regular"
+			if summary.DHTStatus.FullNode {
+				dhtMode = "full node"
+			}
+			msg += fmt.Sprintf("DHT: %s (%d peers, %d items)\n", dhtMode, summary.DHTStatus.Peers, summary.DHTStatus.StoredItems)
+		} else {
+			msg += "DHT: not running\n"
+		}
+
 		msg += fmt.Sprintf("Visor Version: %s\nConfig Version: %s\nUptime Tracker: %s\nTime Online: %f seconds\nBuild Tag: %s\n",
 			summary.Overview.BuildInfo.Version, summary.ConfigVersion, summary.Health.ServicesHealth, summary.Uptime, summary.BuildTag)
 

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -343,6 +343,32 @@ func (n *Node) rpcPutMirror(ctx context.Context, p Peer, item MutableItem, targe
 	return nil
 }
 
+// GetItemsFrom fetches a batch of items from a specific peer.
+// Used for bulk sync from a full node.
+func (n *Node) GetItemsFrom(ctx context.Context, pk cipher.PubKey, salt string, sinceSeq uint64, limit int) (*GetItemsResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second) // longer timeout for bulk data
+	defer cancel()
+
+	conn, err := n.dial(ctx, pk)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close() //nolint:errcheck,gosec
+
+	req := GetItemsRequest{
+		SenderID: n.id,
+		SenderPK: n.pk,
+		Salt:     salt,
+		SinceSeq: sinceSeq,
+		Limit:    limit,
+	}
+	var resp GetItemsResponse
+	if err := rpcCall(ctx, conn, methodGetItems, req, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
 func (n *Node) rpcPing(ctx context.Context, p Peer) error {
 	ctx, cancel := rpcCtx(ctx)
 	defer cancel()
@@ -438,6 +464,16 @@ func (n *Node) handleConn(conn io.ReadWriteCloser, remotePK cipher.PubKey) {
 			resp.Error = putErr.Error()
 		}
 		writeMsg(conn, methodPutValue, resp) //nolint:errcheck,gosec
+
+	case methodGetItems:
+		var req GetItemsRequest
+		if json.Unmarshal(data, &req) != nil {
+			return
+		}
+		n.rt.Update(Peer{ID: req.SenderID, PK: req.SenderPK})
+		items, hasMore := n.store.GetItems(req.Salt, req.SinceSeq, req.Limit)
+		resp := GetItemsResponse{Items: items, HasMore: hasMore}
+		writeMsg(conn, methodGetItems, resp) //nolint:errcheck,gosec
 	}
 }
 

--- a/pkg/dht/fullnode_advert.go
+++ b/pkg/dht/fullnode_advert.go
@@ -1,0 +1,90 @@
+// Package dht pkg/dht/fullnode_advert.go
+//
+// Full node advertisement: full DHT nodes publish their PK under a
+// well-known DHT key so regular visors can discover them for bulk sync.
+//
+// The well-known key is SHA256("dht-full-nodes"). Full nodes publish
+// a signed list of their PK to this key periodically. Visors looking
+// for full nodes do a single GetValue on this key and get back a list
+// of PKs they can call GetItems on.
+//
+// Since multiple full nodes publish to the same key, and BEP44 only
+// stores one item per target, each full node publishes its OWN PK
+// under a unique salt: "fullnode:<pk_hex[:16]>". This way each full
+// node has its own entry, and a visor can discover them by doing
+// GetValue lookups with known salt prefixes, or by querying the
+// bootstrap peers (DMSG servers) which are always full nodes.
+package dht
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+)
+
+// FullNodeAdvert is the entry a full node publishes to advertise itself.
+type FullNodeAdvert struct {
+	PK          cipher.PubKey `json:"pk"`
+	StoredItems int           `json:"stored_items"`
+	FullNode    bool          `json:"full_node"`
+	Timestamp   int64         `json:"ts"`
+}
+
+// AdvertiseFullNode periodically publishes this node's full-node status
+// to the DHT. Other visors can discover full nodes by querying bootstrap
+// peers or doing GetValue with the "fullnode" salt.
+func AdvertiseFullNode(ctx context.Context, node *Node, log *logging.Logger) {
+	if !node.store.IsFullNode() {
+		return
+	}
+
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	seq := uint64(1)
+	for {
+		advert := FullNodeAdvert{
+			PK:          node.pk,
+			StoredItems: node.store.Len(),
+			FullNode:    true,
+			Timestamp:   time.Now().UnixNano(),
+		}
+		data, err := json.Marshal(advert)
+		if err == nil {
+			if putErr := node.Put(ctx, data, seq, []byte("fullnode")); putErr != nil {
+				log.WithError(putErr).Trace("DHT: advertise full node failed")
+			}
+			seq++
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// FindFullNodes queries bootstrap peers for full node advertisements.
+// Returns a list of PKs that are running DHT full nodes.
+func FindFullNodes(ctx context.Context, node *Node) []cipher.PubKey {
+	// Full nodes are the bootstrap peers (DMSG servers) plus any
+	// visors advertising via the "fullnode" salt. Query bootstrap
+	// peers since they're always full nodes.
+	var fullNodes []cipher.PubKey
+	for _, bp := range node.cfg.BootstrapPKs {
+		if bp == node.pk {
+			continue
+		}
+		fullNodes = append(fullNodes, bp)
+	}
+
+	// Also check the routing table for peers that responded to our
+	// queries — they might be full nodes too.
+	// (In practice, the bootstrap peers are sufficient for now.)
+
+	return fullNodes
+}

--- a/pkg/dht/rpc.go
+++ b/pkg/dht/rpc.go
@@ -17,6 +17,7 @@ const (
 	methodFindNode uint8 = 2
 	methodGetValue uint8 = 3
 	methodPutValue uint8 = 4
+	methodGetItems uint8 = 5
 )
 
 // rpcTimeout is the deadline for a single RPC round-trip.
@@ -74,6 +75,28 @@ type PutValueRequest struct {
 type PutValueResponse struct {
 	Stored bool   `json:"stored"`
 	Error  string `json:"error,omitempty"`
+}
+
+// GetItemsRequest asks a full node for a batch of stored items.
+// Used for bulk sync: "give me items I don't have."
+type GetItemsRequest struct {
+	SenderID NodeID        `json:"sender_id"`
+	SenderPK cipher.PubKey `json:"sender_pk"`
+	// Salt filters items by namespace (e.g., "dmsg", "tp", "svc").
+	// Empty means all items.
+	Salt string `json:"salt,omitempty"`
+	// SinceSeq returns only items with Seq > SinceSeq.
+	// 0 means return all items.
+	SinceSeq uint64 `json:"since_seq,omitempty"`
+	// Limit caps the number of items returned (0 = default 1000).
+	Limit int `json:"limit,omitempty"`
+}
+
+// GetItemsResponse returns a batch of stored items.
+type GetItemsResponse struct {
+	Items []MutableItem `json:"items"`
+	// HasMore indicates there are more items available beyond this batch.
+	HasMore bool `json:"has_more,omitempty"`
 }
 
 // Transport is the interface for sending/receiving DHT RPC messages.

--- a/pkg/dht/store.go
+++ b/pkg/dht/store.go
@@ -248,6 +248,32 @@ func (s *Store) Refresh(target NodeID) {
 	}
 }
 
+// GetItems returns items matching the given salt filter and sequence threshold.
+// If salt is empty, all items are returned. Only items with Seq > sinceSeq
+// are included. Results are capped at limit (default 1000).
+func (s *Store) GetItems(salt string, sinceSeq uint64, limit int) ([]MutableItem, bool) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var items []MutableItem
+	for _, si := range s.items {
+		if salt != "" && string(si.item.Salt) != salt {
+			continue
+		}
+		if si.item.Seq <= sinceSeq {
+			continue
+		}
+		items = append(items, si.item)
+		if len(items) >= limit+1 {
+			return items[:limit], true // hasMore
+		}
+	}
+	return items, false
+}
+
 // Len returns the number of stored items.
 func (s *Store) Len() int {
 	s.mu.RLock()

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -107,6 +107,10 @@ type Manager struct {
 	delQueueMu sync.Mutex
 	delNudge   chan struct{}
 
+	// dhtHandlesRegistration, when true, skips HTTP TPD re-registration
+	// because the DHT publish loop handles transport data distribution.
+	dhtHandlesRegistration bool
+
 	// arDeregistered tracks whether the visor has deregistered from AR
 	// due to ar_transport_limit being reached. Once true, it stays true
 	// until the visor restarts.
@@ -319,7 +323,27 @@ func (tm *Manager) flushDeletionQueue() {
 	}
 }
 
+// SetDHTHandlesRegistration tells the transport manager that the DHT is
+// handling transport publication. When true, HTTP re-registration with
+// the transport discovery is skipped, reducing load on the deployment server.
+func (tm *Manager) SetDHTHandlesRegistration(enabled bool) {
+	tm.mx.Lock()
+	defer tm.mx.Unlock()
+	tm.dhtHandlesRegistration = enabled
+	if enabled {
+		tm.Logger.Info("Transport registration via DHT — skipping TPD HTTP re-registration")
+	}
+}
+
 func (tm *Manager) reRegisterTransports(ctx context.Context) {
+	// Skip HTTP re-registration when DHT handles transport publishing.
+	tm.mx.RLock()
+	skip := tm.dhtHandlesRegistration
+	tm.mx.RUnlock()
+	if skip {
+		return
+	}
+
 	tm.mx.RLock()
 	entries := make([]*SignedEntry, 0, len(tm.tps))
 	for _, tp := range tm.tps {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -368,6 +368,15 @@ type Summary struct {
 	ConfigVersion        string                           `json:"config_version"`
 	PublicAutoconnect    bool                             `json:"public_autoconnect"`
 	IsPublic             bool                             `json:"is_public"`
+	DHTStatus            *DHTStatusSummary                `json:"dht_status,omitempty"`
+}
+
+// DHTStatusSummary is a compact DHT status for visor info/summary.
+type DHTStatusSummary struct {
+	Running     bool `json:"running"`
+	FullNode    bool `json:"full_node"`
+	Peers       int  `json:"peers"`
+	StoredItems int  `json:"stored_items"`
 }
 
 // HealthInfo carries information about visor's services health.

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -243,6 +243,7 @@ type API interface {
 	AddHypervisor(pk cipher.PubKey) error
 	CheckAREntry(pk string) ([]string, error)
 	TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error)
+	DHTSync(remotePK string, salt string) (int, error)
 
 	// Close closes the API connection (for RPC clients)
 	Close() error

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -244,6 +244,7 @@ type API interface {
 	CheckAREntry(pk string) ([]string, error)
 	TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error)
 	DHTSync(remotePK string, salt string) (int, error)
+	DHTGetAll(salt string) (string, error)
 
 	// Close closes the API connection (for RPC clients)
 	Close() error

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -1,8 +1,12 @@
 package visor
 
 import (
+	"context"
 	"fmt"
+	"time"
 
+	"github.com/skycoin/skywire/pkg/dht"
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/netutil"
 )
 
@@ -57,6 +61,45 @@ func (v *Visor) DmsgReconnect() (int, error) {
 		return 0, fmt.Errorf("DMSG client not running")
 	}
 	return v.dmsgC.ForceReconnect(), nil
+}
+
+// DHTSync fetches items from a DHT full node and stores them locally.
+// If remotePK is empty, uses the first available bootstrap peer.
+func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
+	if v.dhtNode == nil {
+		return 0, fmt.Errorf("DHT node not running")
+	}
+
+	var targetPK cipher.PubKey
+	if remotePK != "" {
+		if err := targetPK.Set(remotePK); err != nil {
+			return 0, fmt.Errorf("invalid PK: %w", err)
+		}
+	} else {
+		// Use first available bootstrap peer.
+		fullNodes := dht.FindFullNodes(context.Background(), v.dhtNode)
+		if len(fullNodes) == 0 {
+			return 0, fmt.Errorf("no full nodes available")
+		}
+		targetPK = fullNodes[0]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := v.dhtNode.GetItemsFrom(ctx, targetPK, salt, 0, 0)
+	if err != nil {
+		return 0, fmt.Errorf("sync from %s: %w", targetPK.String()[:8], err)
+	}
+
+	stored := 0
+	for _, item := range resp.Items {
+		if putErr := v.dhtNode.Store().Put(item); putErr == nil {
+			stored++
+		}
+	}
+
+	return stored, nil
 }
 
 // DmsgPorterDiag returns detailed diagnostic information about ephemeral

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -2,6 +2,7 @@ package visor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -100,6 +101,29 @@ func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 	}
 
 	return stored, nil
+}
+
+// DHTGetAll returns all DHT items matching the given salt as a JSON string.
+// Requires the visor to have a DHT node (full or regular).
+func (v *Visor) DHTGetAll(salt string) (string, error) {
+	if v.dhtNode == nil {
+		return "", fmt.Errorf("DHT node not running")
+	}
+	items, _ := v.dhtNode.Store().GetItems(salt, 0, 0)
+	if len(items) == 0 {
+		return "[]", nil
+	}
+
+	// Decode each item's value and collect into an array.
+	var results []json.RawMessage
+	for _, item := range items {
+		results = append(results, json.RawMessage(item.V))
+	}
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal DHT items: %w", err)
+	}
+	return string(data), nil
 }
 
 // DmsgPorterDiag returns detailed diagnostic information about ephemeral

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -175,6 +175,17 @@ func (v *Visor) Summary() (*Summary, error) {
 		v.log.Warn(err)
 	}
 
+	// DHT status
+	var dhtStatus *DHTStatusSummary
+	if v.dhtNode != nil {
+		dhtStatus = &DHTStatusSummary{
+			Running:     true,
+			FullNode:    v.dhtNode.Store().IsFullNode(),
+			Peers:       v.dhtNode.RoutingTable().Size(),
+			StoredItems: v.dhtNode.Store().Len(),
+		}
+	}
+
 	summary := &Summary{
 		Overview:             overview,
 		Health:               health,
@@ -190,6 +201,7 @@ func (v *Visor) Summary() (*Summary, error) {
 		DmsgStats:            dmsgStatValue,
 		ConnectedDmsgServers: connectedDmsgServers,
 		DMSGServers:          dmsgServers,
+		DHTStatus:            dhtStatus,
 	}
 
 	return summary, nil

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -101,6 +101,11 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 		WithField("full_node", fullNode).
 		Info("DHT node started")
 
+	// Advertise this node as a full node so other visors can discover it.
+	if fullNode {
+		go dht.AdvertiseFullNode(ctx, node, log)
+	}
+
 	// Wrap discovery clients with DHT hybrid clients so reads try
 	// DHT first, fall back to HTTP. Writes go to both.
 	discAdapter := dht.NewDiscAdapter(node, log)

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -122,7 +122,27 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 	v.initLock.Unlock()
 
 	// Start background publish: mirror visor's entries to the DHT.
-	go dhtPublishLoop(ctx, v, node, log)
+	// Once the DHT has peers, tell the transport manager to skip
+	// HTTP re-registration — the DHT handles transport discovery.
+	go func() {
+		dhtPublishLoop(ctx, v, node, log)
+	}()
+	go func() {
+		// Wait for DHT to bootstrap before switching off HTTP registration.
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if node.RoutingTable().Size() > 0 && v.tpM != nil {
+					v.tpM.SetDHTHandlesRegistration(true)
+					return
+				}
+			}
+		}
+	}()
 
 	return nil
 }

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -1682,6 +1682,17 @@ func (r *RPC) CheckAREntry(pk *string, out *[]string) (err error) {
 	return nil
 }
 
+// DHTGetAll returns all DHT items matching a salt as JSON.
+func (r *RPC) DHTGetAll(salt *string, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "DHTGetAll", salt)(out, &err)
+	result, err := r.visor.DHTGetAll(*salt)
+	if err != nil {
+		return err
+	}
+	*out = result
+	return nil
+}
+
 // DHTSyncRequest is the request for DHTSync.
 type DHTSyncRequest struct {
 	RemotePK string `json:"remote_pk"`

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -1682,6 +1682,23 @@ func (r *RPC) CheckAREntry(pk *string, out *[]string) (err error) {
 	return nil
 }
 
+// DHTSyncRequest is the request for DHTSync.
+type DHTSyncRequest struct {
+	RemotePK string `json:"remote_pk"`
+	Salt     string `json:"salt"`
+}
+
+// DHTSync syncs items from a DHT full node.
+func (r *RPC) DHTSync(req *DHTSyncRequest, out *int) (err error) {
+	defer rpcutil.LogCall(r.log, "DHTSync", req)(out, &err)
+	n, err := r.visor.DHTSync(req.RemotePK, req.Salt)
+	if err != nil {
+		return err
+	}
+	*out = n
+	return nil
+}
+
 // TransportRPCCallRequest is the request for TransportRPCCall.
 type TransportRPCCallRequest struct {
 	RemotePK cipher.PubKey `json:"remote_pk"`

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1250,6 +1250,15 @@ func (rc *rpcClient) DmsgReconnect() (int, error) {
 	return resp, err
 }
 
+// DHTGetAll returns all DHT items matching a salt as JSON.
+func (rc *rpcClient) DHTGetAll(salt string) (string, error) {
+	var resp string
+	if err := rc.Call("DHTGetAll", &salt, &resp); err != nil {
+		return "", err
+	}
+	return resp, nil
+}
+
 // DHTSync syncs items from a DHT full node.
 func (rc *rpcClient) DHTSync(remotePK string, salt string) (int, error) {
 	req := DHTSyncRequest{RemotePK: remotePK, Salt: salt}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1250,6 +1250,16 @@ func (rc *rpcClient) DmsgReconnect() (int, error) {
 	return resp, err
 }
 
+// DHTSync syncs items from a DHT full node.
+func (rc *rpcClient) DHTSync(remotePK string, salt string) (int, error) {
+	req := DHTSyncRequest{RemotePK: remotePK, Salt: salt}
+	var resp int
+	if err := rc.Call("DHTSync", &req, &resp); err != nil {
+		return 0, err
+	}
+	return resp, nil
+}
+
 // TransportRPCCall proxies an RPC call to a remote visor over a transport.
 func (rc *rpcClient) TransportRPCCall(remotePK cipher.PubKey, method string) (json.RawMessage, error) {
 	req := TransportRPCCallRequest{RemotePK: remotePK, Method: method}

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1174,6 +1174,11 @@ func (mc *mockRPCClient) DmsgPorterReset() (*DmsgPorterStatus, error) {
 	return &DmsgPorterStatus{}, nil
 }
 
+// DHTGetAll implements API.
+func (mc *mockRPCClient) DHTGetAll(_ string) (string, error) {
+	return "[]", nil
+}
+
 // DHTSync implements API.
 func (mc *mockRPCClient) DHTSync(_ string, _ string) (int, error) {
 	return 0, fmt.Errorf("not supported in mock")

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1174,6 +1174,11 @@ func (mc *mockRPCClient) DmsgPorterReset() (*DmsgPorterStatus, error) {
 	return &DmsgPorterStatus{}, nil
 }
 
+// DHTSync implements API.
+func (mc *mockRPCClient) DHTSync(_ string, _ string) (int, error) {
+	return 0, fmt.Errorf("not supported in mock")
+}
+
 // TransportRPCCall implements API.
 func (mc *mockRPCClient) TransportRPCCall(_ cipher.PubKey, _ string) (json.RawMessage, error) {
 	return nil, fmt.Errorf("not supported in mock")


### PR DESCRIPTION
GetItems RPC (method 5):
- New DHT RPC for bulk data sync from full nodes
- Supports salt filtering (dmsg, tp, svc) and sequence threshold
- Paginated with limit + hasMore indicator
- 30-second timeout for bulk transfers

Store.GetItems():
- Query items by salt namespace and minimum sequence number
- Returns batch with hasMore flag for pagination

Full node advertisement:
- Full nodes publish their PK under salt "fullnode" every 5 minutes
- FindFullNodes() returns bootstrap peers as known full nodes
- AdvertiseFullNode() goroutine started for full-node visors

Visor DHTSync API:
- DHTSync(remotePK, salt) fetches and stores items from a full node
- If no PK specified, uses first available bootstrap peer
- RPC method, rpc_client, and mock implemented

CLI command:
- `skywire cli visor dht sync` — sync from default bootstrap peer
- `skywire cli visor dht sync <pk>` — sync from specific full node
- `--salt` flag filters by namespace (dmsg, tp, svc)
