### PR TITLE
remove hardcoded service URLs, use deployment.Prod constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ CLAUDE.md
 /cxo
 dump.rdb
 skywire-new
+skywire.conf

--- a/cmd/skywire-cli/commands/tp/tp-netinfo.go
+++ b/cmd/skywire-cli/commands/tp/tp-netinfo.go
@@ -23,11 +23,7 @@ func init() {
 }
 
 func tpdBaseURL() string {
-	base := deployment.Prod.TransportDiscovery
-	if base == "" {
-		base = "http://tpd.skywire.skycoin.com"
-	}
-	return strings.TrimRight(base, "/")
+	return strings.TrimRight(deployment.Prod.TransportDiscovery, "/")
 }
 
 var tpdHealthCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/tp/tp-stats.go
+++ b/cmd/skywire-cli/commands/tp/tp-stats.go
@@ -48,11 +48,7 @@ Examples:
   skywire cli tp tpd-stats --type stcpr --min 5
   skywire cli tp tpd-stats --json`,
 	Run: func(cmd *cobra.Command, _ []string) {
-		tpdURL := deployment.Prod.TransportDiscovery
-		if tpdURL == "" {
-			tpdURL = "http://tpd.skywire.skycoin.com"
-		}
-		statsURL := strings.TrimRight(tpdURL, "/") + "/all-transports/per-key-stats"
+		statsURL := strings.TrimRight(deployment.Prod.TransportDiscovery, "/") + "/all-transports/per-key-stats"
 
 		body, err := clirpc.FetchServiceURL(cmd.Flags(), statsURL)
 		if err != nil {

--- a/cmd/skywire-cli/commands/visor/ip.go
+++ b/cmd/skywire-cli/commands/visor/ip.go
@@ -72,9 +72,6 @@ func getStunServers(cmdFlags *pflag.FlagSet) ([]string, error) {
 	var info stunInfo
 
 	confURL := deployment.ProdConf.Conf
-	if confURL == "" {
-		confURL = "http://conf.skywire.skycoin.com"
-	}
 	body, err := clirpc.FetchServiceURL(cmdFlags, confURL+"/")
 	if err != nil {
 		return info.Stun, err

--- a/cmd/svc/network-monitor/commands/root.go
+++ b/cmd/svc/network-monitor/commands/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
+	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/network-monitor/api"
 	"github.com/skycoin/skywire/pkg/network-monitor/store"
 	nm "github.com/skycoin/skywire/pkg/network-monitor/types"
@@ -112,11 +113,11 @@ GET /status - nm.Status
 func init() {
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9080", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
-	RootCmd.Flags().StringVar(&sdURL, "sd-url", "http://sd.skycoin.com", "url to service discovery\n\r")
-	RootCmd.Flags().StringVar(&arURL, "ar-url", "http://ar.skywire.skycoin.com", "url to address resolver\n\r")
-	RootCmd.Flags().StringVar(&utURL, "ut-url", "http://ut.skywire.skycoin.com", "url to uptime tracker visor data\n\r")
-	RootCmd.Flags().StringVar(&tpdURL, "tpd-url", "http://tpd.skywire.skycoin.com", "url to transport discovery\n\r")
-	RootCmd.Flags().StringVar(&dmsgdURL, "dmsgd-url", "http://dmsgd.skywire.skycoin.com", "url to dmsg discovery\n\r")
+	RootCmd.Flags().StringVar(&sdURL, "sd-url", deployment.Prod.ServiceDiscovery, "url to service discovery\n\r")
+	RootCmd.Flags().StringVar(&arURL, "ar-url", deployment.Prod.AddressResolver, "url to address resolver\n\r")
+	RootCmd.Flags().StringVar(&utURL, "ut-url", deployment.Prod.UptimeTracker, "url to uptime tracker visor data\n\r")
+	RootCmd.Flags().StringVar(&tpdURL, "tpd-url", deployment.Prod.TransportDiscovery, "url to transport discovery\n\r")
+	RootCmd.Flags().StringVar(&dmsgdURL, "dmsgd-url", deployment.Prod.DmsgDiscovery, "url to dmsg discovery\n\r")
 	RootCmd.Flags().IntVarP(&cleaningDelay, "cleaning-delay", "d", 75, "time for delay between each service cleaning routine\n\r")
 	RootCmd.Flags().StringVar(&pk, "pk", "", "pk of network monitor")
 	RootCmd.Flags().StringVar(&sk, "sk", "", "sk of network monitor")

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -157,6 +157,10 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 			if err != nil {
 				return nil, fmt.Errorf("skynet transport dial: %w", err)
 			}
+			log.WithField("pk", t.pk.Hex()[:16]+"...").
+				WithField("port", t.port).
+				WithField("addr", addr).
+				Debug("skynet transport: dialing")
 			conn, err := dialer.DialSkynet(dialCtx, t.pk, t.port)
 			if err != nil {
 				return nil, fmt.Errorf("skynet dial: %w", err)

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -177,6 +177,8 @@ func (v *Visor) DeregisterTCPPort(localPort int) error {
 	if v.forwardedPorts.Get(localPort) == nil {
 		return fmt.Errorf("port :%v not registered", localPort)
 	}
+	// Stop DMSG listener if running.
+	v.stopDmsgForwarder(localPort)
 	// Remove from both the rich store and legacy allowed map.
 	v.allowed.mu.Lock()
 	delete(v.allowed.ports, localPort)
@@ -215,6 +217,10 @@ func (v *Visor) RegisterForwardedPort(p ForwardedPort) error {
 		v.allowed.mu.Lock()
 		v.allowed.ports[p.Port] = true
 		v.allowed.mu.Unlock()
+	}
+	// Create a DMSG listener for this port so .dmsg:<port> works.
+	if p.DMSG {
+		v.startDmsgForwarder(p.Port, p.LocalPort)
 	}
 	return nil
 }
@@ -369,4 +375,91 @@ func shutdownDmsgDependentComponents(v *Visor, log *logging.Logger) error {
 		return fmt.Errorf("encountered %d errors during shutdown", len(errs))
 	}
 	return nil
+}
+
+// startDmsgForwarder creates a DMSG listener on the given port and
+// forwards accepted connections to localhost:localPort. This enables
+// .dmsg:<port> access to forwarded ports.
+func (v *Visor) startDmsgForwarder(port, localPort int) {
+	if v.dmsgC == nil {
+		return
+	}
+	if localPort == 0 {
+		localPort = port
+	}
+
+	v.dmsgFwdMu.Lock()
+	defer v.dmsgFwdMu.Unlock()
+
+	// Already running for this port.
+	if _, ok := v.dmsgFwdListeners[port]; ok {
+		return
+	}
+
+	lis, err := v.dmsgC.Listen(uint16(port)) //nolint:gosec
+	if err != nil {
+		v.log.WithError(err).WithField("port", port).Warn("Failed to create DMSG listener for forwarded port")
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	v.dmsgFwdListeners[port] = cancel
+
+	go func() {
+		defer lis.Close() //nolint:errcheck
+		log := v.log.WithField("dmsg_fwd", port)
+		log.WithField("local", localPort).Info("DMSG forwarder started")
+		for {
+			conn, err := lis.Accept()
+			if err != nil {
+				select {
+				case <-ctx.Done():
+					log.Debug("DMSG forwarder stopped")
+					return
+				default:
+				}
+				log.WithError(err).Debug("DMSG forwarder accept error")
+				return
+			}
+			go func() {
+				defer conn.Close() //nolint:errcheck
+				local, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", localPort))
+				if err != nil {
+					log.WithError(err).Debug("Failed to dial local port")
+					return
+				}
+				defer local.Close() //nolint:errcheck
+				// Bidirectional pipe.
+				done := make(chan struct{}, 2)
+				pipe := func(dst, src net.Conn) {
+					buf := make([]byte, 32*1024)
+					for {
+						n, rErr := src.Read(buf)
+						if n > 0 {
+							if _, wErr := dst.Write(buf[:n]); wErr != nil {
+								break
+							}
+						}
+						if rErr != nil {
+							break
+						}
+					}
+					done <- struct{}{}
+				}
+				go pipe(local, conn)
+				go pipe(conn, local)
+				<-done
+			}()
+		}
+	}()
+}
+
+// stopDmsgForwarder cancels the DMSG listener goroutine for the given port.
+func (v *Visor) stopDmsgForwarder(port int) {
+	v.dmsgFwdMu.Lock()
+	defer v.dmsgFwdMu.Unlock()
+	if cancel, ok := v.dmsgFwdListeners[port]; ok {
+		cancel()
+		delete(v.dmsgFwdListeners, port)
+	}
 }

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -402,7 +402,7 @@ func (v *Visor) startDmsgForwarder(port, localPort int) {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored in dmsgFwdListeners
 	v.dmsgFwdListeners[port] = cancel
 
 	go func() {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -132,6 +132,11 @@ type Visor struct {
 	// Rich port forwarding with metadata, whitelist, landing page integration
 	forwardedPorts *ForwardedPorts
 
+	// DMSG listeners for forwarded ports (dmsg=true). Each entry is a
+	// cancel function that stops the listener goroutine.
+	dmsgFwdMu        sync.Mutex
+	dmsgFwdListeners map[int]context.CancelFunc
+
 	// Service handler registry — maps ports to connection handlers
 	// so the sky-forwarding server can dispatch without localhost TCP.
 	services *ServiceRegistry
@@ -405,7 +410,8 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1) (*Visor, bool) {
 			ports: make(map[int]bool),
 			mu:    new(sync.RWMutex),
 		},
-		forwardedPorts: NewForwardedPorts(filepath.Join(conf.LocalPath, "forwarded_ports.json")),
+		forwardedPorts:   NewForwardedPorts(filepath.Join(conf.LocalPath, "forwarded_ports.json")),
+		dmsgFwdListeners: make(map[int]context.CancelFunc),
 		dmsgTracker: dtmState{
 			ready: make(chan struct{}),
 		},


### PR DESCRIPTION
- visor/ip.go: remove conf.skywire.skycoin.com fallback
- tp-netinfo.go, tp-stats.go: remove tpd.skywire.skycoin.com fallback
- network-monitor: use deployment.Prod for all 5 flag defaults
