### PR TITLE
add DHT → discovery pusher: mirror DHT writes to HTTP discoveries

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -319,6 +319,22 @@ var RootCmd = &cobra.Command{
 						WithField("bootstrap_peers", len(bootstrapPKs)).
 						Info("DHT full node started on port 100")
 
+					// Mirror DHT writes back to HTTP discoveries so they
+					// stay in sync when visors publish directly to the DHT.
+					discEndpoints := map[string]string{
+						"dmsg": conf.Discovery,
+					}
+					// TPD and SD URLs from environment (same as other services)
+					if tpdURL := os.Getenv("TPD_URL"); tpdURL != "" {
+						discEndpoints["tp"] = tpdURL
+					}
+					if sdURL := os.Getenv("SD_URL"); sdURL != "" {
+						discEndpoints["svc"] = sdURL
+					}
+					pusher := dht.NewDiscoveryPusher(discEndpoints, logging.MustGetLogger("dht:disc-pusher"))
+					dhtNode.Store().SetOnPut(pusher.OnPut)
+					dhtLog.Info("DHT→discovery pusher enabled")
+
 					// Publish this server's entry to the DHT so visors can
 					// discover DMSG servers without the DMSG discovery HTTP API.
 					go func() {

--- a/pkg/dht/mirror_to_disc.go
+++ b/pkg/dht/mirror_to_disc.go
@@ -1,0 +1,106 @@
+// Package dht pkg/dht/mirror_to_disc.go
+//
+// DiscoveryPusher mirrors DHT writes back to HTTP discovery services.
+// Runs on DMSG servers: when a visor publishes an entry to the DHT,
+// the pusher forwards it to the appropriate discovery (DMSG disc, TPD,
+// or SD) so the HTTP APIs stay in sync without visors needing to
+// register with them directly.
+package dht
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
+)
+
+// DiscoveryPusher pushes DHT items to HTTP discovery services based on salt.
+type DiscoveryPusher struct {
+	// endpoints maps salt → discovery base URL (e.g., "dmsg" → "http://dmsgd:9090")
+	endpoints map[string]string
+	client    *http.Client
+	log       *logging.Logger
+}
+
+// NewDiscoveryPusher creates a pusher that forwards DHT items to discoveries.
+// endpoints maps salt names to discovery base URLs:
+//
+//	"dmsg" → DMSG discovery SetEntry URL
+//	"tp"   → Transport discovery register URL
+//	"svc"  → Service discovery register URL
+func NewDiscoveryPusher(endpoints map[string]string, log *logging.Logger) *DiscoveryPusher {
+	return &DiscoveryPusher{
+		endpoints: endpoints,
+		client:    &http.Client{Timeout: 10 * time.Second},
+		log:       log,
+	}
+}
+
+// OnPut is the callback for Store.SetOnPut. It examines the item's salt
+// and pushes the value to the corresponding discovery endpoint.
+func (p *DiscoveryPusher) OnPut(target NodeID, item MutableItem) {
+	salt := string(item.Salt)
+	baseURL, ok := p.endpoints[salt]
+	if !ok || baseURL == "" {
+		return // no endpoint for this salt
+	}
+
+	// The item.V contains the JSON-encoded discovery entry.
+	// Forward it to the discovery's registration endpoint.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		var endpoint string
+		switch salt {
+		case "dmsg":
+			// DMSG discovery: POST /dmsg-discovery/entry/
+			endpoint = baseURL + "/dmsg-discovery/entry/"
+		case "tp":
+			// Transport discovery: POST /transports/
+			endpoint = baseURL + "/transports/"
+		case "svc":
+			// Service discovery: POST /api/services
+			endpoint = baseURL + "/api/services"
+		default:
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(item.V))
+		if err != nil {
+			p.log.WithError(err).WithField("salt", salt).Debug("DHT→discovery: failed to create request")
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			p.log.WithError(err).WithField("salt", salt).Debug("DHT→discovery: request failed")
+			return
+		}
+		io.Copy(io.Discard, resp.Body) //nolint:errcheck
+		resp.Body.Close()              //nolint:errcheck
+
+		if resp.StatusCode >= 300 {
+			p.log.WithField("salt", salt).
+				WithField("status", resp.StatusCode).
+				WithField("target", fmt.Sprintf("%x", target[:8])).
+				Debug("DHT→discovery: non-OK response")
+		}
+	}()
+}
+
+// OnPutJSON is like OnPut but re-encodes the item value before sending.
+// Use when the discovery expects a different format than what's in the DHT.
+func (p *DiscoveryPusher) OnPutJSON(target NodeID, item MutableItem) {
+	// Verify the value is valid JSON before forwarding.
+	if !json.Valid(item.V) {
+		return
+	}
+	p.OnPut(target, item)
+}

--- a/pkg/dht/store.go
+++ b/pkg/dht/store.go
@@ -69,6 +69,9 @@ type Store struct {
 	ttl            time.Duration
 	trust          *TrustPolicy
 	backend        Backend
+	// onPut is called (outside the lock) after a new/updated item is stored.
+	// Used by DMSG servers to mirror DHT writes back to HTTP discoveries.
+	onPut func(target NodeID, item MutableItem)
 }
 
 type storedItem struct {
@@ -91,6 +94,14 @@ func NewStore(maxItems int, ttl time.Duration) *Store {
 		trust:          NewTrustPolicy(nil, nil),
 		backend:        memBackend{},
 	}
+}
+
+// SetOnPut registers a callback that fires after each successful Put/PutMirror.
+// The callback receives the storage target and item. Called outside the store lock.
+func (s *Store) SetOnPut(fn func(target NodeID, item MutableItem)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onPut = fn
 }
 
 // SetBackend configures a persistence backend and rehydrates the store
@@ -151,11 +162,11 @@ func (s *Store) PutMirror(target NodeID, item MutableItem) {
 		return
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Accept if newer than existing, or if no existing item.
 	if existing, ok := s.items[target]; ok {
 		if item.Seq <= existing.item.Seq {
+			s.mu.Unlock()
 			return
 		}
 	}
@@ -163,7 +174,13 @@ func (s *Store) PutMirror(target NodeID, item MutableItem) {
 		item:     item,
 		storedAt: time.Now(),
 	}
-	s.backend.Save(target, item) //nolint:errcheck,gosec,gosec
+	s.backend.Save(target, item) //nolint:errcheck,gosec
+
+	cb := s.onPut
+	s.mu.Unlock()
+	if cb != nil {
+		cb(target, item)
+	}
 }
 
 // Put stores an item, enforcing monotonic sequence numbers, trust
@@ -176,13 +193,13 @@ func (s *Store) Put(item MutableItem) error {
 	target := item.Target()
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	tier := s.trust.Classify(item.K)
 
 	// Enforce monotonic sequence.
 	if existing, ok := s.items[target]; ok {
 		if item.Seq <= existing.item.Seq {
+			s.mu.Unlock()
 			return ErrSeqNotMonotonic
 		}
 	}
@@ -195,8 +212,8 @@ func (s *Store) Put(item MutableItem) error {
 				count++
 			}
 		}
-		// Allow update of existing item (same target) without counting.
 		if _, isUpdate := s.items[target]; !isUpdate && count >= s.rateLimitPerPK {
+			s.mu.Unlock()
 			return ErrRateLimited
 		}
 	}
@@ -207,16 +224,18 @@ func (s *Store) Put(item MutableItem) error {
 	}
 	s.backend.Save(target, item) //nolint:errcheck,gosec
 
-	// Evict public items if the public pool is over capacity.
 	if tier == TierPublic {
 		s.evictPublicPool()
 	}
-
-	// Global capacity check.
 	if s.maxItems > 0 && len(s.items) > s.maxItems {
 		s.evictOldestPublic()
 	}
 
+	cb := s.onPut
+	s.mu.Unlock()
+	if cb != nil {
+		cb(target, item)
+	}
 	return nil
 }
 


### PR DESCRIPTION
When a visor publishes an entry to the DHT (via Put or PutMirror), the DMSG server's onPut callback forwards it to the appropriate HTTP discovery based on salt (dmsg→DMSG disc, tp→TPD, svc→SD).

This enables the transition to DHT-first writes: visors can publish to the DHT only, and the DMSG servers keep the HTTP discoveries in sync automatically. The HTTP discovery APIs become read-only caches populated from the DHT.

- Add Store.SetOnPut callback (fires outside lock after successful store)
- Add DiscoveryPusher that maps salt → discovery endpoint
- Wire into DMSG server startup with discovery URL from config
