### PR TITLE
dht: skip p2p transport for bootstrap peers

### DIFF
--- a/cmd/skywire-cli/commands/mdisc/root.go
+++ b/cmd/skywire-cli/commands/mdisc/root.go
@@ -153,11 +153,8 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 var entryCmd = &cobra.Command{
 	Use:   "entry <visor-public-key>",
 	Short: "Fetch an entry",
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) == 0 {
-			internal.Catch(cmd.Flags(), cmd.Help())
-			return
-		}
 		pk := internal.ParsePK(cmd.Flags(), "visor-public-key", args[0])
 		masterLogger.SetLevel(logrus.InfoLevel)
 

--- a/cmd/skywire-cli/commands/survey/root.go
+++ b/cmd/skywire-cli/commands/survey/root.go
@@ -38,7 +38,7 @@ var (
 
 func init() {
 	surveyCmd.Flags().SortFlags = false
-	surveyCmd.Flags().StringVarP(&confPath, "config", "c", "", "optionl config file to use (i.e.: "+skyenv.ConfigName+")")
+	surveyCmd.Flags().StringVarP(&confPath, "config", "c", "", "optional config file to use (i.e.: "+skyenv.ConfigName+")")
 	surveyCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDiscURL, "value of dmsg discovery")
 	//	surveyCmd.Flags().StringVarP(&confArg, "confarg", "C", "", "supply config as argument")
 	//	surveyCmd.Flags().BoolVarP(&stdin, "stdin", "n", false, "read config from stdin")

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -29,6 +29,7 @@ var RootCmd = &cobra.Command{
 func init() {
 	healthCmd.Flags().BoolVar(&directQuery, "direct", false, "query services directly instead of via visor RPC")
 	healthCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+	healthCmd.Flags().Bool(internal.JSONString, false, "print output as JSON")
 	RootCmd.AddCommand(healthCmd)
 }
 
@@ -86,6 +87,11 @@ func extractPK(rawURL string) string {
 }
 
 func printHealthResults(cmd *cobra.Command, results []skyvisor.ServiceHealthEntry) {
+	isJSON, _ := cmd.Flags().GetBool(internal.JSONString) //nolint:errcheck
+	if isJSON {
+		internal.PrintOutput(cmd.Flags(), results, "")
+		return
+	}
 	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "SERVICE\tSTATUS\tLATENCY\tPROTOCOL\tVERSION\tPK") //nolint:errcheck,gosec
 	for _, r := range results {
@@ -109,7 +115,6 @@ func printHealthResults(cmd *cobra.Command, results []skyvisor.ServiceHealthEntr
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n", r.Name, status, latency, transport, ver, pk) //nolint:errcheck,gosec
 	}
 	tw.Flush() //nolint:errcheck,gosec
-	internal.PrintOutput(cmd.Flags(), results, "")
 }
 
 func queryServicesDirect(cmdFlags *pflag.FlagSet) []skyvisor.ServiceHealthEntry {

--- a/go.mod
+++ b/go.mod
@@ -171,7 +171,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.9.1 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jaypipes/pcidb v1.1.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/cloudfoundry-attic/jibber_jabber v0.0.0-20151120183258-bcc4c8345a21
 	github.com/coder/websocket v1.8.14
-	github.com/gdamore/tcell/v2 v2.13.8
+	github.com/gdamore/tcell/v2 v2.13.9
 	github.com/gizak/termui/v3 v3.1.0
 	github.com/itchyny/gojq v0.12.19
 	github.com/kr/pretty v0.3.1
@@ -126,7 +126,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
-	github.com/anatol/smart.go v0.0.0-20260314002218-4abf60ecc43c // indirect
+	github.com/anatol/smart.go v0.0.0-20260419142952-c2af97cbb53f // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
@@ -145,7 +145,7 @@ require (
 	github.com/disintegration/imaging v1.6.2 // indirect
 	github.com/distatus/battery v0.10.0 // indirect; pin to v0.10.0 for gotop compatibility
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/droundy/goopt v0.0.0-20220217183150-48d6390ad4d1 // indirect
@@ -241,7 +241,7 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	howett.net/plist v1.0.2-0.20250314012144-ee69052608d9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/anatol/smart.go v0.0.0-20260314002218-4abf60ecc43c h1:BwsMFienOo2Ww4iSJBrgJNotDkSGa6LRaeQqtPFXtTI=
-github.com/anatol/smart.go v0.0.0-20260314002218-4abf60ecc43c/go.mod h1:ukYit5s/IEmWOGZokOlZs6bIvV5xD4bly0SFawzj7+8=
+github.com/anatol/smart.go v0.0.0-20260419142952-c2af97cbb53f h1:3z5Dn22OIlZS4qO8pm1K1/sYmUfaFVdARQFCD29h/Es=
+github.com/anatol/smart.go v0.0.0-20260419142952-c2af97cbb53f/go.mod h1:ukYit5s/IEmWOGZokOlZs6bIvV5xD4bly0SFawzj7+8=
 github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6 h1:zdaWj/ncXyzpPH3YqACvJXMrJxkkILrnWbjHojHBctc=
 github.com/anatol/vmtest v0.0.0-20250627153117-302402d269a6/go.mod h1:m5pN88x7ZnEDGXZldwg7RCX+EikR9qz/iSI2GzXq++Y=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -234,8 +234,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.1.6/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -282,8 +282,8 @@ github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uh
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
 github.com/gdamore/tcell/v2 v2.1.0/go.mod h1:vSVL/GV5mCSlPC6thFP5kfOFdM9MGZcalipmpTxTgQA=
-github.com/gdamore/tcell/v2 v2.13.8 h1:Mys/Kl5wfC/GcC5Cx4C2BIQH9dbnhnkPgS9/wF3RlfU=
-github.com/gdamore/tcell/v2 v2.13.8/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
+github.com/gdamore/tcell/v2 v2.13.9 h1:uI5l3DYPcFvHINKlGft+en23evOKL+dwtD21QR8ejVA=
+github.com/gdamore/tcell/v2 v2.13.9/go.mod h1:+Wfe208WDdB7INEtCsNrAN6O2m+wsTPk1RAovjaILlo=
 github.com/gen2brain/dlgs v0.0.0-20220603100644-40c77870fa8d h1:dHYKX8CBAs1zSGXm3q3M15CLAEwPEkwrK1ed8FCo+Xo=
 github.com/gen2brain/dlgs v0.0.0-20220603100644-40c77870fa8d/go.mod h1:/eFcjDXaU2THSOOqLxOPETIbHETnamk8FA/hMjhg/gU=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -1383,8 +1383,8 @@ google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
 google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 h1:RmoJA1ujG+/lRGNfUnOMfhCy5EipVMyvUE+KNbPbTlw=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:XF8+t6QQiS0o9ArVan/HW8Q7cycNPGsJf6GA2nXxYAg=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/go.sum
+++ b/go.sum
@@ -504,8 +504,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/james-barrow/golang-ipc v1.2.4 h1:d4NXRQxq6OWviWU8uAaob8R0YZGy/PhAkXGLpBNpkA4=

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -251,7 +251,13 @@ func rpcCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, rpcTimeout)
 }
 
-// dial tries the primary transport, then extra transports.
+// dialPrimary dials using only the primary transport (DMSG).
+// Used for bootstrap peers (DMSG servers) where p2p transports will never exist.
+func (n *Node) dialPrimary(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, error) {
+	return n.tp.Dial(ctx, pk)
+}
+
+// dial tries p2p transports first, then falls back to DMSG.
 // Skips peers in the negative cache (failed DHT dial recently).
 func (n *Node) dial(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, error) {
 	// Check negative cache.
@@ -262,17 +268,29 @@ func (n *Node) dial(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, 
 	}
 	n.noDHTMu.RUnlock()
 
+	// Skip p2p transports for bootstrap peers (DMSG servers) — there
+	// will never be a direct STCPR/SUDPH transport to them.
+	isBootstrap := false
+	for _, bpk := range n.cfg.BootstrapPKs {
+		if bpk == pk {
+			isBootstrap = true
+			break
+		}
+	}
+
 	// Prefer p2p transports (STCPR/SUDPH) over DMSG — direct, lower
 	// latency, doesn't burden DMSG servers. Fall back to DMSG only
 	// when no direct transport exists.
 	var err error
-	for _, tp := range n.extraTransports {
-		conn, err2 := tp.Dial(ctx, pk)
-		if err2 == nil {
-			return conn, nil
-		}
-		if err == nil {
-			err = err2
+	if !isBootstrap {
+		for _, tp := range n.extraTransports {
+			conn, err2 := tp.Dial(ctx, pk)
+			if err2 == nil {
+				return conn, nil
+			}
+			if err == nil {
+				err = err2
+			}
 		}
 	}
 	conn, dmsgErr := n.tp.Dial(ctx, pk)

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -251,12 +251,6 @@ func rpcCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, rpcTimeout)
 }
 
-// dialPrimary dials using only the primary transport (DMSG).
-// Used for bootstrap peers (DMSG servers) where p2p transports will never exist.
-func (n *Node) dialPrimary(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, error) {
-	return n.tp.Dial(ctx, pk)
-}
-
 // dial tries p2p transports first, then falls back to DMSG.
 // Skips peers in the negative cache (failed DHT dial recently).
 func (n *Node) dial(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, error) {

--- a/vendor/github.com/anatol/smart.go/sata_linux.go
+++ b/vendor/github.com/anatol/smart.go/sata_linux.go
@@ -20,12 +20,40 @@ func OpenSata(name string) (*SataDevice, error) {
 		return nil, err
 	}
 
-	if !bytes.Equal(i.VendorIdent[:], []byte(_SATA_IDENT)) {
+	// Check if this is a direct access block device (Peripheral & 0x1f == 0)
+	// This is required for SAT (SCSI ATA Translation) devices
+	deviceType := i.Peripheral & 0x1f
+	if deviceType != 0 {
 		unix.Close(fd)
-		return nil, fmt.Errorf("it is not a SATA device")
+		return nil, fmt.Errorf("not a direct access block device (type=%d)", deviceType)
 	}
 
+	// Try to detect if this is a SATA device
+	// Standard SAT devices report "ATA     " in VendorIdent
+	// However, some USB bridges don't properly implement this and report
+	// the actual drive vendor instead. In such cases, we try ATA IDENTIFY
+	// to see if the device responds.
+	isLikelySAT := bytes.Equal(i.VendorIdent[:], []byte(_SATA_IDENT))
+
 	dev := SataDevice{fd: fd}
+
+	// For standard SAT identifiers, proceed directly
+	// For other direct access devices, try ATA IDENTIFY to see if it's a SAT device
+	if !isLikelySAT {
+		// Try ATA IDENTIFY to test if this device supports ATA commands
+		// This handles USB bridges that don't report "ATA     " properly
+		respBuf := make([]byte, 512)
+		cdb := cdb16{_SCSI_ATA_PASSTHRU_16}
+		cdb[1] = 0x08                  // ATA protocol: bits [4:1] = 4 (PIO data-in), bit 0 = 0 (multiple commands)
+		cdb[2] = 0x0e                  // BYT_BLOK=1 (transfer length in 512-byte blocks), T_LENGTH=2 (from sector count field), T_DIR=1 (from device)
+		cdb[14] = _ATA_IDENTIFY_DEVICE // command
+
+		// If ATA IDENTIFY succeeds, this is a SAT device
+		if err := scsiSendCdb(fd, cdb[:], respBuf); err != nil {
+			unix.Close(fd)
+			return nil, fmt.Errorf("device does not respond to ATA IDENTIFY (not a SATA/SAT device): %w", err)
+		}
+	}
 
 	id, err := dev.Identify()
 	if err != nil {

--- a/vendor/github.com/anatol/smart.go/scsi_linux.go
+++ b/vendor/github.com/anatol/smart.go/scsi_linux.go
@@ -35,11 +35,6 @@ func OpenScsi(name string) (*ScsiDevice, error) {
 		return nil, fmt.Errorf("not a direct access block device")
 	}
 
-	if bytes.Equal(i.VendorIdent[:], []byte(_SATA_IDENT)) {
-		unix.Close(fd)
-		return nil, fmt.Errorf("it is SATA device")
-	}
-
 	return &scsi, nil
 }
 

--- a/vendor/github.com/anatol/smart.go/smart.go
+++ b/vendor/github.com/anatol/smart.go/smart.go
@@ -3,6 +3,7 @@ package smart
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // ErrOSUnsupported is returned on unsupported operating systems.
@@ -31,14 +32,24 @@ type Device interface {
 }
 
 func Open(path string) (Device, error) {
-	n, nvmeErr := OpenNVMe(path)
-	if nvmeErr == nil {
-		_, _, err := n.Identify()
+	var nvmeErr error
+
+	// Only probe NVMe for paths that look like NVMe devices (/dev/nvme*).
+	// Sending NVMe admin ioctls to USB block devices permanently breaks
+	// the UAS transport on some bridges (e.g. Realtek RTL9201B), causing
+	// all subsequent SCSI commands to fail with DID_ERROR.
+	if strings.Contains(path, "/nvme") {
+		n, err := OpenNVMe(path)
 		if err == nil {
-			return n, nil
+			_, _, idErr := n.Identify()
+			if idErr == nil {
+				return n, nil
+			}
+			n.Close()
+			nvmeErr = fmt.Errorf("nvme identify: %w", idErr)
+		} else {
+			nvmeErr = err
 		}
-		n.Close()
-		nvmeErr = fmt.Errorf("nvme identify: %w", err)
 	}
 
 	a, sataErr := OpenSata(path)
@@ -51,5 +62,8 @@ func Open(path string) (Device, error) {
 		return s, nil
 	}
 
-	return nil, errors.Join(nvmeErr, sataErr, scsiErr)
+	if nvmeErr != nil {
+		return nil, errors.Join(nvmeErr, sataErr, scsiErr)
+	}
+	return nil, errors.Join(sataErr, scsiErr)
 }

--- a/vendor/github.com/dlclark/regexp2/README.md
+++ b/vendor/github.com/dlclark/regexp2/README.md
@@ -69,7 +69,7 @@ The internals of `regexp2` always operate on `[]rune` so `Index` and `Length` da
 | --- | --- | --- |
 | Catastrophic backtracking possible | no, constant execution time guarantees | yes, if your pattern is at risk you can use the `re.MatchTimeout` field |
 | Python-style capture groups `(?P<name>re)` | yes | no (yes in RE2 compat mode) |
-| .NET-style capture groups `(?<name>re)` or `(?'name're)` | no | yes |
+| .NET-style capture groups `(?<name>re)` or `(?'name're)` | yes | yes |
 | comments `(?#comment)` | no | yes |
 | branch numbering reset `(?\|a\|b)` | no | no |
 | possessive match `(?>re)` | no | yes |

--- a/vendor/github.com/dlclark/regexp2/runner.go
+++ b/vendor/github.com/dlclark/regexp2/runner.go
@@ -313,12 +313,9 @@ func (r *runner) execute() error {
 					}
 				} else {
 					// The inner expression found an empty match, so we'll go directly to 'back2' if we
-					// backtrack.  In this case, we need to push something on the stack, since back2 pops.
-					// However, in the case of ()+? or similar, this empty match may be legitimate, so push the text
-					// position associated with that empty match.
-					r.stackPush(oldMarkPos)
-
-					r.trackPushNeg1(r.stackPeek()) // Save old mark
+					// backtrack. Don't touch the grouping stack here; instead, record the old mark and
+					// a flag indicating that backtracking doesn't need to pop a grouping stack frame.
+					r.trackPushNeg2(oldMarkPos, 0)
 				}
 				r.advance(1)
 				continue
@@ -334,18 +331,22 @@ func (r *runner) execute() error {
 
 			r.trackPopN(2)
 			pos := r.trackPeekN(1)
-			r.trackPushNeg1(r.trackPeek()) // Save old mark
-			r.stackPush(pos)               // Make new mark
-			r.textto(pos)                  // Recall position
-			r.goTo(r.operand(0))           // Loop
+			r.trackPushNeg2(r.trackPeek(), 1) // Save old mark, note that we pushed a new mark
+			r.stackPush(pos)                  // Make new mark
+			r.textto(pos)                     // Recall position
+			r.goTo(r.operand(0))              // Loop
 			continue
 
 		case syntax.Lazybranchmark | syntax.Back2:
 			// The lazy loop has failed.  We'll do a true backtrack and
 			// start over before the lazy loop.
-			r.stackPop()
-			r.trackPop()
-			r.stackPush(r.trackPeek()) // Recall old mark
+			r.trackPopN(2)
+			oldMark := r.trackPeek()
+			needsPop := r.trackPeekN(1)
+			if needsPop != 0 {
+				r.stackPop()
+			}
+			r.stackPush(oldMark) // Recall old mark
 			break
 
 		case syntax.Setcount:

--- a/vendor/github.com/gdamore/tcell/v2/input.go
+++ b/vendor/github.com/gdamore/tcell/v2/input.go
@@ -502,7 +502,15 @@ func (ip *inputProcessor) scan() {
 			}
 		case inpStateCsi:
 			// usual case for incoming keys
-			if r >= 0x30 && r <= 0x3F { // parameter bytes
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = inpStateEsc
+				if len(ip.buf) == 0 && ip.nested == nil {
+					ip.expire = time.Now().Add(time.Millisecond * 50)
+					ip.timer = time.AfterFunc(time.Millisecond*60, ip.escTimeout)
+				}
+			} else if r >= 0x30 && r <= 0x3F { // parameter bytes
 				ip.csiParams = append(ip.csiParams, byte(r))
 			} else if r >= 0x20 && r <= 0x2F { // intermediate bytes, rarely used
 				ip.csiInterm = append(ip.csiInterm, byte(r))
@@ -518,7 +526,15 @@ func (ip *inputProcessor) scan() {
 
 		case inpStateSs3: // typically application mode keys or older terminals
 			ip.state = inpStateInit
-			if k, ok := ss3Keys[r]; ok {
+			if r == '\x1b' {
+				// Per ECMA-48 §5.3.1, ESC restarts the escape
+				// sequence machine from any intermediate state.
+				ip.state = inpStateEsc
+				if len(ip.buf) == 0 && ip.nested == nil {
+					ip.expire = time.Now().Add(time.Millisecond * 50)
+					ip.timer = time.AfterFunc(time.Millisecond*60, ip.escTimeout)
+				}
+			} else if k, ok := ss3Keys[r]; ok {
 				ip.post(NewEventKey(k, 0, ModNone))
 			}
 

--- a/vendor/github.com/gdamore/tcell/v2/simulation.go
+++ b/vendor/github.com/gdamore/tcell/v2/simulation.go
@@ -143,6 +143,10 @@ func (s *simscreen) Init() error {
 
 func (s *simscreen) Fini() {
 	s.Lock()
+	if s.fini {
+		s.Unlock()
+		return
+	}
 	s.fini = true
 	s.back.Resize(0, 0)
 	s.Unlock()

--- a/vendor/github.com/gdamore/tcell/v2/style.go
+++ b/vendor/github.com/gdamore/tcell/v2/style.go
@@ -14,6 +14,11 @@
 
 package tcell
 
+import (
+	"strings"
+	"unicode/utf8"
+)
+
 // Style represents a complete text style, including both foreground color,
 // background color, and additional attributes such as "bold" or "underline".
 //
@@ -187,7 +192,7 @@ func (s Style) Attributes(attrs AttrMask) Style {
 // link to that Url.  If the Url is empty, then this mode is turned off.
 func (s Style) Url(url string) Style {
 	s2 := s
-	s2.url = url
+	s2.url = stripOSCControls(url)
 	return s2
 }
 
@@ -197,6 +202,31 @@ func (s Style) Url(url string) Style {
 // were one Url, even if it spans multiple lines.
 func (s Style) UrlId(id string) Style {
 	s2 := s
-	s2.urlId = "id=" + id
+	s2.urlId = "id=" + stripOSCControls(id)
 	return s2
+}
+
+func stripOSCControls(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			c := s[i]
+			if c <= 0x1f || c == 0x7f || (c >= 0x80 && c <= 0x9f) {
+				i++
+				continue
+			}
+			_ = b.WriteByte(c)
+			i++
+			continue
+		}
+		if r <= 0x1f || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			i += size
+			continue
+		}
+		b.WriteString(s[i : i+size])
+		i += size
+	}
+	return b.String()
 }

--- a/vendor/github.com/jackc/pgx/v5/CHANGELOG.md
+++ b/vendor/github.com/jackc/pgx/v5/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 5.9.2 (April 18, 2026)
+
+Fix SQL Injection via placeholder confusion with dollar quoted string literals (GHSA-j88v-2chj-qfwx)
+
+SQL injection can occur when:
+
+1. The non-default simple protocol is used.
+2. A dollar quoted string literal is used in the SQL query.
+3. That query contains text that would be would be interpreted outside as a placeholder outside of a string literal.
+4. The value of that placeholder is controllable by the attacker.
+
+e.g.
+
+```go
+attackValue := `$tag$; drop table canary; --`
+_, err = tx.Exec(ctx, `select $tag$ $1 $tag$, $1`, pgx.QueryExecModeSimpleProtocol, attackValue)
+```
+
+This is unlikely to occur outside of a contrived scenario.
+
 # 5.9.1 (March 22, 2026)
 
 * Fix: batch result format corruption when using cached prepared statements (reported by Dirkjan Bussink)

--- a/vendor/github.com/jackc/pgx/v5/batch.go
+++ b/vendor/github.com/jackc/pgx/v5/batch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// QueuedQuery is a query that has been queued for execution via a Batch.
+// QueuedQuery is a query that has been queued for execution via a [Batch].
 type QueuedQuery struct {
 	SQL       string
 	Arguments []any
@@ -46,7 +46,7 @@ func (qq *QueuedQuery) QueryRow(fn func(row Row) error) {
 //
 // Note: for simple batch insert uses where it is not required to handle
 // each potential error individually, it's sufficient to not set any callbacks,
-// and just handle the return value of BatchResults.Close.
+// and just handle the return value of [BatchResults.Close].
 func (qq *QueuedQuery) Exec(fn func(ct pgconn.CommandTag) error) {
 	qq.Fn = func(br BatchResults) error {
 		ct, err := br.Exec()
@@ -65,12 +65,13 @@ type Batch struct {
 }
 
 // Queue queues a query to batch b. query can be an SQL query or the name of a prepared statement. The only pgx option
-// argument that is supported is QueryRewriter. Queries are executed using the connection's DefaultQueryExecMode.
+// argument that is supported is [QueryRewriter]. Queries are executed using the connection's DefaultQueryExecMode
+// (see [ConnConfig.DefaultQueryExecMode]).
 //
-// While query can contain multiple statements if the connection's DefaultQueryExecMode is QueryModeSimple, this should
-// be avoided. QueuedQuery.Fn must not be set as it will only be called for the first query. That is, QueuedQuery.Query,
-// QueuedQuery.QueryRow, and QueuedQuery.Exec must not be called. In addition, any error messages or tracing that
-// include the current query may reference the wrong query.
+// While query can contain multiple statements if the connection's DefaultQueryExecMode is [QueryExecModeSimpleProtocol],
+// this should be avoided. QueuedQuery.Fn must not be set as it will only be called for the first query. That is,
+// [QueuedQuery.Query], [QueuedQuery.QueryRow], and [QueuedQuery.Exec] must not be called. In addition, any error
+// messages or tracing that include the current query may reference the wrong query.
 func (b *Batch) Queue(query string, arguments ...any) *QueuedQuery {
 	qq := &QueuedQuery{
 		SQL:       query,
@@ -86,20 +87,20 @@ func (b *Batch) Len() int {
 }
 
 type BatchResults interface {
-	// Exec reads the results from the next query in the batch as if the query has been sent with Conn.Exec. Prefer
+	// Exec reads the results from the next query in the batch as if the query has been sent with [Conn.Exec]. Prefer
 	// calling Exec on the QueuedQuery, or just calling Close.
 	Exec() (pgconn.CommandTag, error)
 
-	// Query reads the results from the next query in the batch as if the query has been sent with Conn.Query. Prefer
-	// calling Query on the QueuedQuery.
+	// Query reads the results from the next query in the batch as if the query has been sent with [Conn.Query]. Prefer
+	// calling [QueuedQuery.Query].
 	Query() (Rows, error)
 
-	// QueryRow reads the results from the next query in the batch as if the query has been sent with Conn.QueryRow.
-	// Prefer calling QueryRow on the QueuedQuery.
+	// QueryRow reads the results from the next query in the batch as if the query has been sent with [Conn.QueryRow].
+	// Prefer calling [QueuedQuery.QueryRow].
 	QueryRow() Row
 
 	// Close closes the batch operation. All unread results are read and any callback functions registered with
-	// QueuedQuery.Query, QueuedQuery.QueryRow, or QueuedQuery.Exec will be called. If a callback function returns an
+	// [QueuedQuery.Query], [QueuedQuery.QueryRow], or [QueuedQuery.Exec] will be called. If a callback function returns an
 	// error or the batch encounters an error subsequent callback functions will not be called.
 	//
 	// For simple batch inserts inside a transaction or similar queries, it's sufficient to not set any callbacks,

--- a/vendor/github.com/jackc/pgx/v5/conn.go
+++ b/vendor/github.com/jackc/pgx/v5/conn.go
@@ -17,8 +17,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// ConnConfig contains all the options used to establish a connection. It must be created by ParseConfig and
-// then it can be modified. A manually initialized ConnConfig will cause ConnectConfig to panic.
+// ConnConfig contains all the options used to establish a connection. It must be created by [ParseConfig] and
+// then it can be modified. A manually initialized ConnConfig will cause [ConnectConfig] to panic.
 type ConnConfig struct {
 	pgconn.Config
 
@@ -37,8 +37,8 @@ type ConnConfig struct {
 
 	// DefaultQueryExecMode controls the default mode for executing queries. By default pgx uses the extended protocol
 	// and automatically prepares and caches prepared statements. However, this may be incompatible with proxies such as
-	// PGBouncer. In this case it may be preferable to use QueryExecModeExec or QueryExecModeSimpleProtocol. The same
-	// functionality can be controlled on a per query basis by passing a QueryExecMode as the first query argument.
+	// PGBouncer. In this case it may be preferable to use [QueryExecModeExec] or [QueryExecModeSimpleProtocol]. The same
+	// functionality can be controlled on a per query basis by passing a [QueryExecMode] as the first query argument.
 	DefaultQueryExecMode QueryExecMode
 
 	createdByParseConfig bool // Used to enforce created by ParseConfig rule.
@@ -131,7 +131,7 @@ var (
 )
 
 // Connect establishes a connection with a PostgreSQL server with a connection string. See
-// pgconn.Connect for details.
+// [pgconn.Connect] for details.
 func Connect(ctx context.Context, connString string) (*Conn, error) {
 	connConfig, err := ParseConfig(connString)
 	if err != nil {
@@ -141,7 +141,7 @@ func Connect(ctx context.Context, connString string) (*Conn, error) {
 }
 
 // ConnectWithOptions behaves exactly like Connect with the addition of options. At the present options is only used to
-// provide a GetSSLPassword function.
+// provide a [pgconn.GetSSLPasswordFunc] function.
 func ConnectWithOptions(ctx context.Context, connString string, options ParseConfigOptions) (*Conn, error) {
 	connConfig, err := ParseConfigWithOptions(connString, options)
 	if err != nil {
@@ -151,7 +151,7 @@ func ConnectWithOptions(ctx context.Context, connString string, options ParseCon
 }
 
 // ConnectConfig establishes a connection with a PostgreSQL server with a configuration struct.
-// connConfig must have been created by ParseConfig.
+// connConfig must have been created by [ParseConfig].
 func ConnectConfig(ctx context.Context, connConfig *ConnConfig) (*Conn, error) {
 	// In general this improves safety. In particular avoid the config.Config.OnNotification mutation from affecting other
 	// connections with the same config. See https://github.com/jackc/pgx/issues/618.
@@ -160,8 +160,8 @@ func ConnectConfig(ctx context.Context, connConfig *ConnConfig) (*Conn, error) {
 	return connect(ctx, connConfig)
 }
 
-// ParseConfigWithOptions behaves exactly as ParseConfig does with the addition of options. At the present options is
-// only used to provide a GetSSLPassword function.
+// ParseConfigWithOptions behaves exactly as [ParseConfig] does with the addition of options. At the present options is
+// only used to provide a [pgconn.GetSSLPasswordFunc] function.
 func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*ConnConfig, error) {
 	config, err := pgconn.ParseConfigWithOptions(connString, options.ParseConfigOptions)
 	if err != nil {
@@ -308,8 +308,8 @@ func (c *Conn) Close(ctx context.Context) error {
 }
 
 // Prepare creates a prepared statement with name and sql. sql can contain placeholders for bound parameters. These
-// placeholders are referenced positionally as $1, $2, etc. name can be used instead of sql with Query, QueryRow, and
-// Exec to execute the statement. It can also be used with Batch.Queue.
+// placeholders are referenced positionally as $1, $2, etc. name can be used instead of sql with [Conn.Query],
+// [Conn.QueryRow], and [Conn.Exec] to execute the statement. It can also be used with [Batch.Queue].
 //
 // The underlying PostgreSQL identifier for the prepared statement will be name if name != sql or a digest of sql if
 // name == sql.
@@ -933,7 +933,7 @@ func (c *Conn) QueryRow(ctx context.Context, sql string, args ...any) Row {
 }
 
 // SendBatch sends all queued queries to the server at once. All queries are run in an implicit transaction unless
-// explicit transaction control statements are executed. The returned BatchResults must be closed before the connection
+// explicit transaction control statements are executed. The returned [BatchResults] must be closed before the connection
 // is used again.
 //
 // Depending on the QueryExecMode, all queries may be prepared before any are executed. This means that creating a table
@@ -1277,7 +1277,7 @@ func (c *Conn) sanitizeForSimpleQuery(sql string, args ...any) (string, error) {
 	return sanitize.SanitizeSQL(sql, valueArgs...)
 }
 
-// LoadType inspects the database for typeName and produces a pgtype.Type suitable for registration. typeName must be
+// LoadType inspects the database for typeName and produces a [pgtype.Type] suitable for registration. typeName must be
 // the name of a type where the underlying type(s) is already understood by pgx. It is for derived types. In particular,
 // typeName must be one of the following:
 //   - An array type name of a type that is already registered. e.g. "_foo" when "foo" is registered.

--- a/vendor/github.com/jackc/pgx/v5/copy_from.go
+++ b/vendor/github.com/jackc/pgx/v5/copy_from.go
@@ -10,8 +10,8 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// CopyFromRows returns a CopyFromSource interface over the provided rows slice
-// making it usable by *Conn.CopyFrom.
+// CopyFromRows returns a [CopyFromSource] interface over the provided rows slice
+// making it usable by [Conn.CopyFrom].
 func CopyFromRows(rows [][]any) CopyFromSource {
 	return &copyFromRows{rows: rows, idx: -1}
 }
@@ -34,8 +34,8 @@ func (ctr *copyFromRows) Err() error {
 	return nil
 }
 
-// CopyFromSlice returns a CopyFromSource interface over a dynamic func
-// making it usable by *Conn.CopyFrom.
+// CopyFromSlice returns a [CopyFromSource] interface over a dynamic func
+// making it usable by [Conn.CopyFrom].
 func CopyFromSlice(length int, next func(int) ([]any, error)) CopyFromSource {
 	return &copyFromSlice{next: next, idx: -1, len: length}
 }
@@ -64,7 +64,7 @@ func (cts *copyFromSlice) Err() error {
 	return cts.err
 }
 
-// CopyFromFunc returns a CopyFromSource interface that relies on nxtf for values.
+// CopyFromFunc returns a [CopyFromSource] interface that relies on nxtf for values.
 // nxtf returns rows until it either signals an 'end of data' by returning row=nil and err=nil,
 // or it returns an error. If nxtf returns an error, the copy is aborted.
 func CopyFromFunc(nxtf func() (row []any, err error)) CopyFromSource {
@@ -91,7 +91,7 @@ func (g *copyFromFunc) Err() error {
 	return g.err
 }
 
-// CopyFromSource is the interface used by *Conn.CopyFrom as the source for copy data.
+// CopyFromSource is the interface used by [Conn.CopyFrom] as the source for copy data.
 type CopyFromSource interface {
 	// Next returns true if there is another row and makes the next row data
 	// available to Values(). When there are no more rows available or an error
@@ -260,8 +260,8 @@ func (ct *copyFrom) buildCopyBuf(buf []byte, sd *pgconn.StatementDescription) (b
 // CopyFrom requires all values use the binary format. A pgtype.Type that supports the binary format must be registered
 // for the type of each column. Almost all types implemented by pgx support the binary format.
 //
-// Even though enum types appear to be strings they still must be registered to use with CopyFrom. This can be done with
-// Conn.LoadType and pgtype.Map.RegisterType.
+// Even though enum types appear to be strings they still must be registered to use with [Conn.CopyFrom]. This can be done with
+// [Conn.LoadType] and [pgtype.Map.RegisterType].
 func (c *Conn) CopyFrom(ctx context.Context, tableName Identifier, columnNames []string, rowSrc CopyFromSource) (int64, error) {
 	ct := &copyFrom{
 		conn:          c,

--- a/vendor/github.com/jackc/pgx/v5/doc.go
+++ b/vendor/github.com/jackc/pgx/v5/doc.go
@@ -1,8 +1,8 @@
 // Package pgx is a PostgreSQL database driver.
 /*
-pgx provides a native PostgreSQL driver and can act as a database/sql driver. The native PostgreSQL interface is similar
-to the database/sql interface while providing better speed and access to PostgreSQL specific features. Use
-github.com/jackc/pgx/v5/stdlib to use pgx as a database/sql compatible driver. See that package's documentation for
+pgx provides a native PostgreSQL driver and can act as a [database/sql/driver]. The native PostgreSQL interface is similar
+to the [database/sql] interface while providing better speed and access to PostgreSQL specific features. Use
+[github.com/jackc/pgx/v5/stdlib] to use pgx as a database/sql compatible driver. See that package's documentation for
 details.
 
 Establishing a Connection
@@ -19,15 +19,15 @@ string.
 Connection Pool
 
 [*pgx.Conn] represents a single connection to the database and is not concurrency safe. Use package
-github.com/jackc/pgx/v5/pgxpool for a concurrency safe connection pool.
+[github.com/jackc/pgx/v5/pgxpool] for a concurrency safe connection pool.
 
 Query Interface
 
-pgx implements Query in the familiar database/sql style. However, pgx provides generic functions such as CollectRows and
-ForEachRow that are a simpler and safer way of processing rows than manually calling defer rows.Close(), rows.Next(),
-rows.Scan, and rows.Err().
+pgx implements [Conn.Query] in the familiar database/sql style. However, pgx provides generic functions such as [CollectRows] and
+[ForEachRow] that are a simpler and safer way of processing rows than manually calling defer [Rows.Close], [Rows.Next],
+[Rows.Scan], and [Rows.Err].
 
-CollectRows can be used collect all returned rows into a slice.
+[CollectRows] can be used collect all returned rows into a slice.
 
     rows, _ := conn.Query(context.Background(), "select generate_series(1,$1)", 5)
     numbers, err := pgx.CollectRows(rows, pgx.RowTo[int32])
@@ -36,7 +36,7 @@ CollectRows can be used collect all returned rows into a slice.
     }
     // numbers => [1 2 3 4 5]
 
-ForEachRow can be used to execute a callback function for every row. This is often easier than iterating over rows
+[ForEachRow] can be used to execute a callback function for every row. This is often easier than iterating over rows
 directly.
 
     var sum, n int32
@@ -49,7 +49,7 @@ directly.
       return err
     }
 
-pgx also implements QueryRow in the same style as database/sql.
+pgx also implements [Conn.QueryRow] in the same style as database/sql.
 
     var name string
     var weight int64
@@ -58,7 +58,7 @@ pgx also implements QueryRow in the same style as database/sql.
         return err
     }
 
-Use Exec to execute a query that does not return a result set.
+Use [Conn.Exec] to execute a query that does not return a result set.
 
     commandTag, err := conn.Exec(context.Background(), "delete from widgets where id=$1", 42)
     if err != nil {
@@ -70,13 +70,13 @@ Use Exec to execute a query that does not return a result set.
 
 PostgreSQL Data Types
 
-pgx uses the pgtype package to converting Go values to and from PostgreSQL values. It supports many PostgreSQL types
+pgx uses the [pgtype] package to converting Go values to and from PostgreSQL values. It supports many PostgreSQL types
 directly and is customizable and extendable. User defined data types such as enums, domains,  and composite types may
 require type registration. See that package's documentation for details.
 
 Transactions
 
-Transactions are started by calling Begin.
+Transactions are started by calling [Conn.Begin].
 
     tx, err := conn.Begin(context.Background())
     if err != nil {
@@ -96,13 +96,13 @@ Transactions are started by calling Begin.
         return err
     }
 
-The Tx returned from Begin also implements the Begin method. This can be used to implement pseudo nested transactions.
+The [Tx] returned from [Conn.Begin] also implements the [Tx.Begin] method. This can be used to implement pseudo nested transactions.
 These are internally implemented with savepoints.
 
-Use BeginTx to control the transaction mode. BeginTx also can be used to ensure a new transaction is created instead of
+Use [Conn.BeginTx] to control the transaction mode. [Conn.BeginTx] also can be used to ensure a new transaction is created instead of
 a pseudo nested transaction.
 
-BeginFunc and BeginTxFunc are functions that begin a transaction, execute a function, and commit or rollback the
+[BeginFunc] and [BeginTxFunc] are functions that begin a transaction, execute a function, and commit or rollback the
 transaction depending on the return value of the function. These can be simpler and less error prone to use.
 
     err = pgx.BeginFunc(context.Background(), conn, func(tx pgx.Tx) error {
@@ -115,16 +115,16 @@ transaction depending on the return value of the function. These can be simpler 
 
 Prepared Statements
 
-Prepared statements can be manually created with the Prepare method. However, this is rarely necessary because pgx
-includes an automatic statement cache by default. Queries run through the normal Query, QueryRow, and Exec functions are
-automatically prepared on first execution and the prepared statement is reused on subsequent executions. See ParseConfig
-for information on how to customize or disable the statement cache.
+Prepared statements can be manually created with the [Conn.Prepare] method. However, this is rarely necessary because pgx
+includes an automatic statement cache by default. Queries run through the normal [Conn.Query], [Conn.QueryRow], and [Conn.Exec]
+functions are automatically prepared on first execution and the prepared statement is reused on subsequent executions.
+See [ParseConfig] for information on how to customize or disable the statement cache.
 
 Copy Protocol
 
-Use CopyFrom to efficiently insert multiple rows at a time using the PostgreSQL copy protocol. CopyFrom accepts a
-CopyFromSource interface. If the data is already in a [][]any use CopyFromRows to wrap it in a CopyFromSource interface.
-Or implement CopyFromSource to avoid buffering the entire data set in memory.
+Use [Conn.CopyFrom] to efficiently insert multiple rows at a time using the PostgreSQL copy protocol. [Conn.CopyFrom] accepts a
+[CopyFromSource] interface. If the data is already in a [][]any use [CopyFromRows] to wrap it in a [CopyFromSource] interface.
+Or implement [CopyFromSource] to avoid buffering the entire data set in memory.
 
     rows := [][]any{
         {"John", "Smith", int32(36)},
@@ -138,7 +138,7 @@ Or implement CopyFromSource to avoid buffering the entire data set in memory.
         pgx.CopyFromRows(rows),
     )
 
-When you already have a typed array using CopyFromSlice can be more convenient.
+When you already have a typed array using [CopyFromSlice] can be more convenient.
 
     rows := []User{
         {"John", "Smith", 36},
@@ -158,7 +158,7 @@ CopyFrom can be faster than an insert with as few as 5 rows.
 
 Listen and Notify
 
-pgx can listen to the PostgreSQL notification system with the `Conn.WaitForNotification` method. It blocks until a
+pgx can listen to the PostgreSQL notification system with the [Conn.WaitForNotification] method. It blocks until a
 notification is received or the context is canceled.
 
     _, err := conn.Exec(context.Background(), "listen channelname")
@@ -175,20 +175,25 @@ notification is received or the context is canceled.
 
 Tracing and Logging
 
-pgx supports tracing by setting ConnConfig.Tracer. To combine several tracers you can use the multitracer.Tracer.
+pgx supports tracing by setting [ConnConfig.Tracer]. To combine several tracers you can use the [github.com/jackc/pgx/v5/multitracer.Tracer].
 
-In addition, the tracelog package provides the TraceLog type which lets a traditional logger act as a Tracer.
+In addition, the [github.com/jackc/pgx/v5/tracelog] package provides the [github.com/jackc/pgx/v5/tracelog.TraceLog] type which lets a
+traditional logger act as a [QueryTracer].
 
-For debug tracing of the actual PostgreSQL wire protocol messages see github.com/jackc/pgx/v5/pgproto3.
+For debug tracing of the actual PostgreSQL wire protocol messages see [github.com/jackc/pgx/v5/pgproto3].
 
 Lower Level PostgreSQL Functionality
 
-github.com/jackc/pgx/v5/pgconn contains a lower level PostgreSQL driver roughly at the level of libpq. pgx.Conn is
-implemented on top of pgconn. The Conn.PgConn() method can be used to access this lower layer.
+[github.com/jackc/pgx/v5/pgconn] contains a lower level PostgreSQL driver roughly at the level of libpq. [Conn] is
+implemented on top of [pgconn.PgConn]. The [Conn.PgConn] method can be used to access this lower layer.
 
 PgBouncer
 
 By default pgx automatically uses prepared statements. Prepared statements are incompatible with PgBouncer. This can be
-disabled by setting a different QueryExecMode in ConnConfig.DefaultQueryExecMode.
+disabled by setting a different [QueryExecMode] in [ConnConfig.DefaultQueryExecMode].
 */
 package pgx
+
+import (
+	_ "github.com/jackc/pgx/v5/pgconn" // Just for allowing godoc to resolve "pgconn"
+)

--- a/vendor/github.com/jackc/pgx/v5/internal/sanitize/sanitize.go
+++ b/vendor/github.com/jackc/pgx/v5/internal/sanitize/sanitize.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -202,12 +203,13 @@ func QuoteBytes(dst, buf []byte) []byte {
 }
 
 type sqlLexer struct {
-	src     string
-	start   int
-	pos     int
-	nested  int // multiline comment nesting level.
-	stateFn stateFn
-	parts   []Part
+	src       string
+	start     int
+	pos       int
+	nested    int    // multiline comment nesting level.
+	dollarTag string // active tag while inside a dollar-quoted string (may be empty for $$).
+	stateFn   stateFn
+	parts     []Part
 }
 
 type stateFn func(*sqlLexer) stateFn
@@ -236,6 +238,15 @@ func rawState(l *sqlLexer) stateFn {
 				}
 				l.start = l.pos
 				return placeholderState
+			}
+			// PostgreSQL dollar-quoted string: $[tag]$...$[tag]$. The $ was
+			// just consumed; try to match the rest of the opening tag.
+			// Without this, placeholders embedded inside dollar-quoted
+			// literals would be incorrectly substituted.
+			if tagLen, ok := scanDollarQuoteTag(l.src[l.pos:]); ok {
+				l.dollarTag = l.src[l.pos : l.pos+tagLen]
+				l.pos += tagLen + 1 // advance past tag and closing '$'
+				return dollarQuoteState
 			}
 		case '-':
 			nextRune, width := utf8.DecodeRuneInString(l.src[l.pos:])
@@ -319,8 +330,16 @@ func placeholderState(l *sqlLexer) stateFn {
 		l.pos += width
 
 		if '0' <= r && r <= '9' {
-			num *= 10
-			num += int(r - '0')
+			// Clamp rather than silently wrap on pathological input like
+			// "$92233720368547758070" which would otherwise overflow int and
+			// could land on a valid args index. Any value above MaxInt32 far
+			// exceeds any plausible args length, so Sanitize will correctly
+			// return "insufficient arguments".
+			if num > (math.MaxInt32-9)/10 {
+				num = math.MaxInt32
+			} else {
+				num = num*10 + int(r-'0')
+			}
 		} else {
 			l.parts = append(l.parts, num)
 			l.pos -= width
@@ -328,6 +347,68 @@ func placeholderState(l *sqlLexer) stateFn {
 			return rawState
 		}
 	}
+}
+
+// dollarQuoteState consumes the body of a PostgreSQL dollar-quoted string
+// ($[tag]$...$[tag]$). The opening tag (including its terminating '$') has
+// already been consumed.
+func dollarQuoteState(l *sqlLexer) stateFn {
+	closer := "$" + l.dollarTag + "$"
+	idx := strings.Index(l.src[l.pos:], closer)
+	if idx < 0 {
+		// Unterminated — mirror the behavior of other quoted-string states by
+		// consuming the remaining input into the current part and stopping.
+		if len(l.src)-l.start > 0 {
+			l.parts = append(l.parts, l.src[l.start:])
+			l.start = len(l.src)
+		}
+		l.pos = len(l.src)
+		return nil
+	}
+	l.pos += idx + len(closer)
+	l.dollarTag = ""
+	return rawState
+}
+
+// scanDollarQuoteTag checks whether src begins with an optional dollar-quoted
+// string tag followed by a closing '$'. src must point just past the opening
+// '$'. Returns the byte length of the tag (zero for an anonymous $$) and
+// whether a valid tag was found.
+//
+// Tag grammar matches the PostgreSQL lexer (scan.l):
+//
+//	dolq_start: [A-Za-z_\x80-\xff]
+//	dolq_cont:  [A-Za-z0-9_\x80-\xff]
+func scanDollarQuoteTag(src string) (int, bool) {
+	first := true
+	for i := 0; i < len(src); {
+		r, w := utf8.DecodeRuneInString(src[i:])
+		if r == '$' {
+			return i, true
+		}
+		if !isDollarTagRune(r, first) {
+			return 0, false
+		}
+		first = false
+		i += w
+	}
+	return 0, false
+}
+
+func isDollarTagRune(r rune, first bool) bool {
+	switch {
+	case r == '_':
+		return true
+	case 'a' <= r && r <= 'z':
+		return true
+	case 'A' <= r && r <= 'Z':
+		return true
+	case !first && '0' <= r && r <= '9':
+		return true
+	case r >= 0x80 && r != utf8.RuneError:
+		return true
+	}
+	return false
 }
 
 func escapeStringState(l *sqlLexer) stateFn {

--- a/vendor/github.com/jackc/pgx/v5/pgconn/config.go
+++ b/vendor/github.com/jackc/pgx/v5/pgconn/config.go
@@ -454,23 +454,37 @@ func ParseConfigWithOptions(connString string, options ParseConfigOptions) (*Con
 
 	minProto, err := parseProtocolVersion(settings["min_protocol_version"])
 	if err != nil {
-		return nil, &ParseConfigError{ConnString: connString, msg: "invalid min_protocol_version", err: err}
+		return nil, &ParseConfigError{ConnString: connString, msg: fmt.Sprintf("invalid min_protocol_version: %q", settings["min_protocol_version"]), err: err}
 	}
 	maxProto, err := parseProtocolVersion(settings["max_protocol_version"])
 	if err != nil {
-		return nil, &ParseConfigError{ConnString: connString, msg: "invalid max_protocol_version", err: err}
-	}
-	if minProto > maxProto {
-		return nil, &ParseConfigError{ConnString: connString, msg: "min_protocol_version cannot be greater than max_protocol_version"}
+		return nil, &ParseConfigError{ConnString: connString, msg: fmt.Sprintf("invalid max_protocol_version: %q", settings["max_protocol_version"]), err: err}
 	}
 
 	config.MinProtocolVersion = settings["min_protocol_version"]
 	config.MaxProtocolVersion = settings["max_protocol_version"]
+
 	if config.MinProtocolVersion == "" {
 		config.MinProtocolVersion = "3.0"
 	}
+
+	// When max_protocol_version is not explicitly set, default based on
+	// min_protocol_version. This matches libpq behavior: if min > 3.0,
+	// default max to latest; otherwise default to 3.0 for compatibility
+	// with older servers/poolers that don't support NegotiateProtocolVersion.
 	if config.MaxProtocolVersion == "" {
-		config.MaxProtocolVersion = "3.0"
+		if minProto > pgproto3.ProtocolVersion30 {
+			config.MaxProtocolVersion = "latest"
+		} else {
+			config.MaxProtocolVersion = "3.0"
+		}
+	}
+
+	// Only error when max_protocol_version was explicitly set and conflicts
+	// with min_protocol_version. When max_protocol_version is not explicitly
+	// set, the auto-raise logic above already ensures a valid default.
+	if minProto > maxProto && settings["max_protocol_version"] != "" {
+		return nil, &ParseConfigError{ConnString: connString, msg: "min_protocol_version cannot be greater than max_protocol_version"}
 	}
 
 	switch channelBinding := settings["channel_binding"]; channelBinding {

--- a/vendor/github.com/jackc/pgx/v5/pgconn/pgconn.go
+++ b/vendor/github.com/jackc/pgx/v5/pgconn/pgconn.go
@@ -538,7 +538,7 @@ func (pgConn *PgConn) signalMessage() chan struct{} {
 }
 
 // ReceiveMessage receives one wire protocol message from the PostgreSQL server. It must only be used when the
-// connection is not busy. e.g. It is an error to call ReceiveMessage while reading the result of a query. The messages
+// connection is not busy. e.g. It is an error to call [PgConn.ReceiveMessage] while reading the result of a query. The messages
 // are still handled by the core pgconn message handling system so receiving a NotificationResponse will still trigger
 // the OnNotification callback.
 //
@@ -1125,7 +1125,7 @@ func (pgConn *PgConn) WaitForNotification(ctx context.Context) error {
 // implicitly wrapped in a transaction unless a transaction is already in progress or SQL contains transaction control
 // statements.
 //
-// Prefer ExecParams unless executing arbitrary SQL that may contain multiple queries.
+// Prefer [PgConn.ExecParams] unless executing arbitrary SQL that may contain multiple queries.
 func (pgConn *PgConn) Exec(ctx context.Context, sql string) *MultiResultReader {
 	if err := pgConn.lock(); err != nil {
 		return &MultiResultReader{
@@ -1183,7 +1183,7 @@ func (pgConn *PgConn) Exec(ctx context.Context, sql string) *MultiResultReader {
 // resultFormats is a slice of format codes determining for each result column whether it is encoded in text or
 // binary format. If resultFormats is nil all results will be in text format.
 //
-// ResultReader must be closed before PgConn can be used again.
+// [ResultReader] must be closed before [PgConn] can be used again.
 func (pgConn *PgConn) ExecParams(ctx context.Context, sql string, paramValues [][]byte, paramOIDs []uint32, paramFormats, resultFormats []int16) *ResultReader {
 	result := pgConn.execExtendedPrefix(ctx, paramValues)
 	if result.closed {
@@ -1209,7 +1209,7 @@ func (pgConn *PgConn) ExecParams(ctx context.Context, sql string, paramValues []
 // resultFormats is a slice of format codes determining for each result column whether it is encoded in text or
 // binary format. If resultFormats is nil all results will be in text format.
 //
-// ResultReader must be closed before PgConn can be used again.
+// [ResultReader] must be closed before [PgConn] can be used again.
 func (pgConn *PgConn) ExecPrepared(ctx context.Context, stmtName string, paramValues [][]byte, paramFormats, resultFormats []int16) *ResultReader {
 	result := pgConn.execExtendedPrefix(ctx, paramValues)
 	if result.closed {
@@ -1225,20 +1225,20 @@ func (pgConn *PgConn) ExecPrepared(ctx context.Context, stmtName string, paramVa
 
 // ExecStatement enqueues the execution of a prepared statement via the PostgreSQL extended query protocol.
 //
-// This differs from ExecPrepared in that it takes a *StatementDescription instead of the prepared statement name.
-// Because it has the *StatementDescription it can avoid the Describe Portal message that ExecPrepared must send to get
+// This differs from [PgConn.ExecPrepared] in that it takes a [*StatementDescription] instead of the prepared statement name.
+// Because it has the [*StatementDescription] it can avoid the Describe Portal message that [PgConn.ExecPrepared] must send to get
 // the result column descriptions.
 //
 // paramValues are the parameter values. It must be encoded in the format given by paramFormats.
 //
 // paramFormats is a slice of format codes determining for each paramValue column whether it is encoded in text or
-// binary format. If paramFormats is nil all params are text format. ExecPrepared will panic if len(paramFormats) is not
+// binary format. If paramFormats is nil all params are text format. ExecStatement will panic if len(paramFormats) is not
 // 0, 1, or len(paramValues).
 //
 // resultFormats is a slice of format codes determining for each result column whether it is encoded in text or binary
 // format. If resultFormats is nil all results will be in text format.
 //
-// ResultReader must be closed before PgConn can be used again.
+// [ResultReader] must be closed before [PgConn] can be used again.
 func (pgConn *PgConn) ExecStatement(ctx context.Context, statementDescription *StatementDescription, paramValues [][]byte, paramFormats, resultFormats []int16) *ResultReader {
 	result := pgConn.execExtendedPrefix(ctx, paramValues)
 	if result.closed {

--- a/vendor/github.com/jackc/pgx/v5/pgproto3/startup_message.go
+++ b/vendor/github.com/jackc/pgx/v5/pgproto3/startup_message.go
@@ -13,6 +13,7 @@ import (
 const (
 	ProtocolVersion30     = 196608            // 3.0
 	ProtocolVersion32     = 196610            // 3.2
+	ProtocolVersionLatest = ProtocolVersion32 // Latest is 3.2
 	ProtocolVersionNumber = ProtocolVersion30 // Default is still 3.0
 )
 

--- a/vendor/github.com/jackc/pgx/v5/pgtype/doc.go
+++ b/vendor/github.com/jackc/pgx/v5/pgtype/doc.go
@@ -1,10 +1,10 @@
 // Package pgtype converts between Go and PostgreSQL values.
 /*
-The primary type is the Map type. It is a map of PostgreSQL types identified by OID (object ID) to a Codec. A Codec is
-responsible for converting between Go and PostgreSQL values. NewMap creates a Map with all supported standard PostgreSQL
-types already registered. Additional types can be registered with Map.RegisterType.
+The primary type is the [Map] type. It is a map of PostgreSQL types identified by OID (object ID) to a [Codec]. A [Codec] is
+responsible for converting between Go and PostgreSQL values. [NewMap] creates a [Map] with all supported standard PostgreSQL
+types already registered. Additional types can be registered with [Map.RegisterType].
 
-Use Map.Scan and Map.Encode to decode PostgreSQL values to Go and encode Go values to PostgreSQL respectively.
+Use [Map.Scan] and [Map.Encode] to decode PostgreSQL values to Go and encode Go values to PostgreSQL respectively.
 
 Base Type Mapping
 
@@ -63,8 +63,8 @@ pgtype automatically marshals and unmarshals data from json and jsonb PostgreSQL
 Extending Existing PostgreSQL Type Support
 
 Generally, all Codecs will support interfaces that can be implemented to enable scanning and encoding. For example,
-PointCodec can use any Go type that implements the PointScanner and PointValuer interfaces. So rather than use
-pgtype.Point and application can directly use its own point type with pgtype as long as it implements those interfaces.
+[PointCodec] can use any Go type that implements the [PointScanner] and [PointValuer] interfaces. So rather than use
+[Point] an application can directly use its own point type with pgtype as long as it implements those interfaces.
 
 See example_custom_type_test.go for an example of a custom type for the PostgreSQL point type.
 
@@ -77,10 +77,10 @@ New PostgreSQL Type Support
 
 pgtype uses the PostgreSQL OID to determine how to encode or decode a value. pgtype supports array, composite, domain,
 and enum types. However, any type created in PostgreSQL with CREATE TYPE will receive a new OID. This means that the OID
-of each new PostgreSQL type must be registered for pgtype to handle values of that type with the correct Codec.
+of each new PostgreSQL type must be registered for pgtype to handle values of that type with the correct [Codec].
 
-The pgx.Conn LoadType method can return a *Type for array, composite, domain, and enum types by inspecting the database
-metadata. This *Type can then be registered with Map.RegisterType.
+The [github.com/jackc/pgx/v5.Conn.LoadType] method can return a [*Type] for array, composite, domain, and enum types by
+inspecting the database metadata. This [*Type] can then be registered with [Map.RegisterType].
 
 For example, the following function could be called after a connection is established:
 
@@ -106,30 +106,30 @@ For example, the following function could be called after a connection is establ
 A type cannot be registered unless all types it depends on are already registered. e.g. An array type cannot be
 registered until its element type is registered.
 
-ArrayCodec implements support for arrays. If pgtype supports type T then it can easily support []T by registering an
-ArrayCodec for the appropriate PostgreSQL OID. In addition, Array[T] type can support multi-dimensional arrays.
+[ArrayCodec] implements support for arrays. If pgtype supports type T then it can easily support []T by registering an
+[ArrayCodec] for the appropriate PostgreSQL OID. In addition, [Array] type can support multi-dimensional arrays.
 
-CompositeCodec implements support for PostgreSQL composite types. Go structs can be scanned into if the public fields of
-the struct are in the exact order and type of the PostgreSQL type or by implementing CompositeIndexScanner and
-CompositeIndexGetter.
+[CompositeCodec] implements support for PostgreSQL composite types. Go structs can be scanned into if the public fields of
+the struct are in the exact order and type of the PostgreSQL type or by implementing [CompositeIndexScanner] and
+[CompositeIndexGetter].
 
 Domain types are treated as their underlying type if the underlying type and the domain type are registered.
 
-PostgreSQL enums can usually be treated as text. However, EnumCodec implements support for interning strings which can
+PostgreSQL enums can usually be treated as text. However, [EnumCodec] implements support for interning strings which can
 reduce memory usage.
 
 While pgtype will often still work with unregistered types it is highly recommended that all types be registered due to
 an improvement in performance and the elimination of certain edge cases.
 
 If an entirely new PostgreSQL type (e.g. PostGIS types) is used then the application or a library can create a new
-Codec. Then the OID / Codec mapping can be registered with Map.RegisterType. There is no difference between a Codec
-defined and registered by the application and a Codec built in to pgtype. See any of the Codecs in pgtype for Codec
+[Codec]. Then the OID / [Codec] mapping can be registered with [Map.RegisterType]. There is no difference between a [Codec]
+defined and registered by the application and a [Codec] built in to pgtype. See any of the [Codec]s in pgtype for [Codec]
 examples and for examples of type registration.
 
 Encoding Unknown Types
 
 pgtype works best when the OID of the PostgreSQL type is known. But in some cases such as using the simple protocol the
-OID is unknown. In this case Map.RegisterDefaultPgType can be used to register an assumed OID for a particular Go type.
+OID is unknown. In this case [Map.RegisterDefaultPgType] can be used to register an assumed OID for a particular Go type.
 
 Renamed Types
 
@@ -137,18 +137,18 @@ If pgtype does not recognize a type and that type is a renamed simple type simpl
 as if it is the underlying type. It currently cannot automatically detect the underlying type of renamed structs (eg.g.
 type MyTime time.Time).
 
-Compatibility with database/sql
+Compatibility with [database/sql]
 
-pgtype also includes support for custom types implementing the database/sql.Scanner and database/sql/driver.Valuer
+pgtype also includes support for custom types implementing the [database/sql.Scanner] and [database/sql/driver.Valuer]
 interfaces.
 
 Encoding Typed Nils
 
-pgtype encodes untyped and typed nils (e.g. nil and []byte(nil)) to the SQL NULL value without going through the Codec
-system. This means that Codecs and other encoding logic do not have to handle nil or *T(nil).
+pgtype encodes untyped and typed nils (e.g. nil and []byte(nil)) to the SQL NULL value without going through the [Codec]
+system. This means that [Codec]s and other encoding logic do not have to handle nil or *T(nil).
 
-However, database/sql compatibility requires Value to be called on T(nil) when T implements driver.Valuer. Therefore,
-driver.Valuer values are only considered NULL when *T(nil) where driver.Valuer is implemented on T not on *T. See
+However, [database/sql] compatibility requires Value to be called on T(nil) when T implements [database/sql/driver.Valuer]. Therefore,
+[database/sql/driver.Valuer] values are only considered NULL when *T(nil) where [database/sql/driver.Valuer] is implemented on T not on *T. See
 https://github.com/golang/go/issues/8415 and
 https://github.com/golang/go/commit/0ce1d79a6a771f7449ec493b993ed2a720917870.
 
@@ -159,38 +159,38 @@ example_child_records_test.go for an example.
 
 Overview of Scanning Implementation
 
-The first step is to use the OID to lookup the correct Codec. The Map will call the Codec's PlanScan method to get a
-plan for scanning into the Go value. A Codec will support scanning into one or more Go types. Oftentime these Go types
-are interfaces rather than explicit types. For example, PointCodec can use any Go type that implements the PointScanner
-and PointValuer interfaces.
+The first step is to use the OID to lookup the correct [Codec]. The [Map] will call the [Codec.PlanScan] method to get a
+plan for scanning into the Go value. A [Codec] will support scanning into one or more Go types. Oftentime these Go types
+are interfaces rather than explicit types. For example, [PointCodec] can use any Go type that implements the [PointScanner]
+and [PointValuer] interfaces.
 
-If a Go value is not supported directly by a Codec then Map will try see if it is a sql.Scanner. If is then that
-interface will be used to scan the value. Most sql.Scanners require the input to be in the text format (e.g. UUIDs and
+If a Go value is not supported directly by a [Codec] then [Map] will try see if it is a [database/sql.Scanner]. If is then that
+interface will be used to scan the value. Most [database/sql.Scanner]s require the input to be in the text format (e.g. UUIDs and
 numeric). However, pgx will typically have received the value in the binary format. In this case the binary value will be
-parsed, reencoded as text, and then passed to the sql.Scanner. This may incur additional overhead for query results with
+parsed, reencoded as text, and then passed to the [database/sql.Scanner]. This may incur additional overhead for query results with
 a large number of affected values.
 
-If a Go value is not supported directly by a Codec then Map will try wrapping it with additional logic and try again.
-For example, Int8Codec does not support scanning into a renamed type (e.g. type myInt64 int64). But Map will detect that
+If a Go value is not supported directly by a [Codec] then [Map] will try wrapping it with additional logic and try again.
+For example, [Int8Codec] does not support scanning into a renamed type (e.g. type myInt64 int64). But [Map] will detect that
 myInt64 is a renamed type and create a plan that converts the value to the underlying int64 type and then passes that to
-the Codec (see TryFindUnderlyingTypeScanPlan).
+the [Codec] (see [TryFindUnderlyingTypeScanPlan]).
 
-These plan wrappers are contained in Map.TryWrapScanPlanFuncs. By default these contain shared logic to handle renamed
+These plan wrappers are contained in [Map.TryWrapScanPlanFuncs]. By default these contain shared logic to handle renamed
 types, pointers to pointers, slices, composite types, etc. Additional plan wrappers can be added to seamlessly integrate
 types that do not support pgx directly. For example, the before mentioned
 https://github.com/jackc/pgx-shopspring-decimal package detects decimal.Decimal values, wraps them in something
-implementing NumericScanner and passes that to the Codec.
+implementing [NumericScanner] and passes that to the [Codec].
 
-Map.Scan and Map.Encode are convenience methods that wrap Map.PlanScan and Map.PlanEncode.  Determining how to scan or
+[Map.Scan] and [Map.Encode] are convenience methods that wrap [Map.PlanScan] and [Map.PlanEncode].  Determining how to scan or
 encode a particular type may be a time consuming operation. Hence the planning and execution steps of a conversion are
 internally separated.
 
 Reducing Compiled Binary Size
 
-pgx.QueryExecModeExec and pgx.QueryExecModeSimpleProtocol require the default PostgreSQL type to be registered for each
-Go type used as a query parameter. By default pgx does this for all supported types and their array variants. If an
-application does not use those query execution modes or manually registers the default PostgreSQL type for the types it
-uses as query parameters it can use the build tag nopgxregisterdefaulttypes. This omits the default type registration
-and reduces the compiled binary size by ~2MB.
+[github.com/jackc/pgx/v5.QueryExecModeExec] and [github.com/jackc/pgx/v5.QueryExecModeSimpleProtocol] require the default
+PostgreSQL type to be registered for each Go type used as a query parameter. By default pgx does this for all supported
+types and their array variants. If an application does not use those query execution modes or manually registers the default
+PostgreSQL type for the types it uses as query parameters it can use the build tag nopgxregisterdefaulttypes. This omits
+the default type registration and reduces the compiled binary size by ~2MB.
 */
 package pgtype

--- a/vendor/github.com/jackc/pgx/v5/pgtype/pgtype.go
+++ b/vendor/github.com/jackc/pgx/v5/pgtype/pgtype.go
@@ -156,7 +156,7 @@ const (
 	BinaryFormatCode = 1
 )
 
-// A Codec converts between Go and PostgreSQL values. A Codec must not be mutated after it is registered with a Map.
+// A Codec converts between Go and PostgreSQL values. A Codec must not be mutated after it is registered with a [Map].
 type Codec interface {
 	// FormatSupported returns true if the format is supported.
 	FormatSupported(int16) bool
@@ -187,7 +187,7 @@ func (e *nullAssignmentError) Error() string {
 	return fmt.Sprintf("cannot assign NULL to %T", e.dst)
 }
 
-// Type represents a PostgreSQL data type. It must not be mutated after it is registered with a Map.
+// Type represents a PostgreSQL data type. It must not be mutated after it is registered with a [Map].
 type Type struct {
 	Codec Codec
 	Name  string
@@ -243,6 +243,7 @@ func NewMap() *Map {
 			TryWrapDerefPointerEncodePlan,
 			TryWrapBuiltinTypeEncodePlan,
 			TryWrapFindUnderlyingTypeEncodePlan,
+			TryWrapStringerEncodePlan,
 			TryWrapStructEncodePlan,
 			TryWrapSliceEncodePlan,
 			TryWrapMultiDimSliceEncodePlan,
@@ -268,7 +269,7 @@ func (m *Map) RegisterTypes(types []*Type) {
 	}
 }
 
-// RegisterType registers a data type with the Map. t must not be mutated after it is registered.
+// RegisterType registers a data type with the [Map]. t must not be mutated after it is registered.
 func (m *Map) RegisterType(t *Type) {
 	m.oidToType[t.OID] = t
 	m.nameToType[t.Name] = t
@@ -294,7 +295,7 @@ func (m *Map) RegisterDefaultPgType(value any, name string) {
 	}
 }
 
-// TypeForOID returns the Type registered for the given OID. The returned Type must not be mutated.
+// TypeForOID returns the [Type] registered for the given OID. The returned [Type] must not be mutated.
 func (m *Map) TypeForOID(oid uint32) (*Type, bool) {
 	if dt, ok := m.oidToType[oid]; ok {
 		return dt, true
@@ -304,7 +305,7 @@ func (m *Map) TypeForOID(oid uint32) (*Type, bool) {
 	return dt, ok
 }
 
-// TypeForName returns the Type registered for the given name. The returned Type must not be mutated.
+// TypeForName returns the [Type] registered for the given name. The returned [Type] must not be mutated.
 func (m *Map) TypeForName(name string) (*Type, bool) {
 	if dt, ok := m.nameToType[name]; ok {
 		return dt, true
@@ -323,8 +324,8 @@ func (m *Map) buildReflectTypeToType() {
 	}
 }
 
-// TypeForValue finds a data type suitable for v. Use RegisterType to register types that can encode and decode
-// themselves. Use RegisterDefaultPgType to register that can be handled by a registered data type.  The returned Type
+// TypeForValue finds a data type suitable for v. Use [Map.RegisterType] to register types that can encode and decode
+// themselves. Use [Map.RegisterDefaultPgType] to register that can be handled by a registered data type.  The returned [Type]
 // must not be mutated.
 func (m *Map) TypeForValue(v any) (*Type, bool) {
 	if m.reflectTypeToType == nil {
@@ -1446,6 +1447,24 @@ func TryWrapFindUnderlyingTypeEncodePlan(value any) (plan WrappedEncodePlanNextS
 	return nil, nil, false
 }
 
+// TryWrapStringerEncodePlan tries to wrap a fmt.Stringer type with a wrapper that provides TextValuer. This is
+// intentionally a separate function from TryWrapBuiltinTypeEncodePlan so it can be ordered after
+// TryWrapFindUnderlyingTypeEncodePlan. This ensures that named types with an underlying builtin type (e.g. type MyEnum
+// int32 with a String() method) prefer encoding via the underlying type's codec (e.g. as an integer) rather than via
+// Stringer. Stringer is only used as a fallback when no type-specific encoding plan succeeds.
+// (https://github.com/jackc/pgx/discussions/2527)
+func TryWrapStringerEncodePlan(value any) (plan WrappedEncodePlanNextSetter, nextValue any, ok bool) {
+	if _, ok := value.(driver.Valuer); ok {
+		return nil, nil, false
+	}
+
+	if s, ok := value.(fmt.Stringer); ok {
+		return &wrapFmtStringerEncodePlan{}, fmtStringerWrapper{s}, true
+	}
+
+	return nil, nil, false
+}
+
 type WrappedEncodePlanNextSetter interface {
 	SetNext(EncodePlan)
 	EncodePlan
@@ -1506,8 +1525,6 @@ func TryWrapBuiltinTypeEncodePlan(value any) (plan WrappedEncodePlanNextSetter, 
 		return &wrapByte16EncodePlan{}, byte16Wrapper(value), true
 	case []byte:
 		return &wrapByteSliceEncodePlan{}, byteSliceWrapper(value), true
-	case fmt.Stringer:
-		return &wrapFmtStringerEncodePlan{}, fmtStringerWrapper{value}, true
 	}
 
 	return nil, nil, false

--- a/vendor/github.com/jackc/pgx/v5/pgxpool/pool.go
+++ b/vendor/github.com/jackc/pgx/v5/pgxpool/pool.go
@@ -122,7 +122,7 @@ type ShouldPingParams struct {
 type Config struct {
 	ConnConfig *pgx.ConnConfig
 
-	// BeforeConnect is called before a new connection is made. It is passed a copy of the underlying pgx.ConnConfig and
+	// BeforeConnect is called before a new connection is made. It is passed a copy of the underlying [pgx.ConnConfig] and
 	// will not impact any existing open connections.
 	BeforeConnect func(context.Context, *pgx.ConnConfig) error
 
@@ -218,7 +218,7 @@ func New(ctx context.Context, connString string) (*Pool, error) {
 	return NewWithConfig(ctx, config)
 }
 
-// NewWithConfig creates a new Pool. config must have been created by [ParseConfig].
+// NewWithConfig creates a new [Pool]. config must have been created by [ParseConfig].
 func NewWithConfig(ctx context.Context, config *Config) (*Pool, error) {
 	// Default values are set in ParseConfig. Enforce initial creation by ParseConfig rather than setting defaults from
 	// zero values.
@@ -453,7 +453,7 @@ func ParseConfig(connString string) (*Config, error) {
 	return config, nil
 }
 
-// Close closes all connections in the pool and rejects future Acquire calls. Blocks until all connections are returned
+// Close closes all connections in the pool and rejects future [Pool.Acquire] calls. Blocks until all connections are returned
 // to pool and closed.
 func (p *Pool) Close() {
 	p.closeOnce.Do(func() {
@@ -595,7 +595,7 @@ func (p *Pool) createIdleResources(parentCtx context.Context, targetResources in
 	return firstError
 }
 
-// Acquire returns a connection (*Conn) from the Pool
+// Acquire returns a connection ([Conn]) from the [Pool].
 func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 	if p.acquireTracer != nil {
 		ctx = p.acquireTracer.TraceAcquireStart(ctx, p, TraceAcquireStartData{})
@@ -657,8 +657,8 @@ func (p *Pool) Acquire(ctx context.Context) (c *Conn, err error) {
 	return nil, errors.New("pgxpool: too many failed attempts acquiring connection; likely bug in PrepareConn, BeforeAcquire, or ShouldPing hook")
 }
 
-// AcquireFunc acquires a *Conn and calls f with that *Conn. ctx will only affect the Acquire. It has no effect on the
-// call of f. The return value is either an error acquiring the *Conn or the return value of f. The *Conn is
+// AcquireFunc acquires a [Conn] and calls f with that [Conn]. ctx will only affect the [Pool.Acquire]. It has no effect on the
+// call of f. The return value is either an error acquiring the [Conn] or the return value of f. The [Conn] is
 // automatically released after the call of f.
 func (p *Pool) AcquireFunc(ctx context.Context, f func(*Conn) error) error {
 	conn, err := p.Acquire(ctx)
@@ -699,7 +699,7 @@ func (p *Pool) Reset() {
 	p.p.Reset()
 }
 
-// Config returns a copy of config that was used to initialize this pool.
+// Config returns a copy of config that was used to initialize this [Pool].
 func (p *Pool) Config() *Config { return p.config.Copy() }
 
 // Stat returns a pgxpool.Stat struct with a snapshot of Pool statistics.
@@ -712,10 +712,10 @@ func (p *Pool) Stat() *Stat {
 	}
 }
 
-// Exec acquires a connection from the Pool and executes the given SQL.
+// Exec acquires a connection from the [Pool] and executes the given SQL.
 // SQL can be either a prepared statement name or an SQL string.
 // Arguments should be referenced positionally from the SQL string as $1, $2, etc.
-// The acquired connection is returned to the pool when the Exec function returns.
+// The acquired connection is returned to the pool when the [Pool.Exec] function returns.
 func (p *Pool) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
 	c, err := p.Acquire(ctx)
 	if err != nil {
@@ -726,15 +726,15 @@ func (p *Pool) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.C
 	return c.Exec(ctx, sql, arguments...)
 }
 
-// Query acquires a connection and executes a query that returns pgx.Rows.
+// Query acquires a connection and executes a query that returns [pgx.Rows].
 // Arguments should be referenced positionally from the SQL string as $1, $2, etc.
-// See pgx.Rows documentation to close the returned Rows and return the acquired connection to the Pool.
+// See [pgx.Rows] documentation to close the returned [pgx.Rows] and return the acquired connection to the [Pool].
 //
-// If there is an error, the returned pgx.Rows will be returned in an error state.
-// If preferred, ignore the error returned from Query and handle errors using the returned pgx.Rows.
+// If there is an error, the returned [pgx.Rows] will be returned in an error state.
+// If preferred, ignore the error returned from [Pool.Query] and handle errors using the returned [pgx.Rows].
 //
-// For extra control over how the query is executed, the types QuerySimpleProtocol, QueryResultFormats, and
-// QueryResultFormatsByOID may be used as the first args to control exactly how the query is executed. This is rarely
+// For extra control over how the query is executed, the types [pgx.QueryExecMode], [pgx.QueryResultFormats], and
+// [pgx.QueryResultFormatsByOID] may be used as the first args to control exactly how the query is executed. This is rarely
 // needed. See the documentation for those types for details.
 func (p *Pool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
 	c, err := p.Acquire(ctx)
@@ -752,16 +752,16 @@ func (p *Pool) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, er
 }
 
 // QueryRow acquires a connection and executes a query that is expected
-// to return at most one row (pgx.Row). Errors are deferred until pgx.Row's
-// Scan method is called. If the query selects no rows, pgx.Row's Scan will
-// return ErrNoRows. Otherwise, pgx.Row's Scan scans the first selected row
-// and discards the rest. The acquired connection is returned to the Pool when
-// pgx.Row's Scan method is called.
+// to return at most one row ([pgx.Row]). Errors are deferred until [pgx.Row]'s
+// Scan method is called. If the query selects no rows, [pgx.Row]'s Scan will
+// return [pgx.ErrNoRows]. Otherwise, [pgx.Row]'s Scan scans the first selected row
+// and discards the rest. The acquired connection is returned to the [Pool] when
+// [pgx.Row]'s Scan method is called.
 //
 // Arguments should be referenced positionally from the SQL string as $1, $2, etc.
 //
-// For extra control over how the query is executed, the types QuerySimpleProtocol, QueryResultFormats, and
-// QueryResultFormatsByOID may be used as the first args to control exactly how the query is executed. This is rarely
+// For extra control over how the query is executed, the types [pgx.QueryExecMode], [pgx.QueryResultFormats], and
+// [pgx.QueryResultFormatsByOID] may be used as the first args to control exactly how the query is executed. This is rarely
 // needed. See the documentation for those types for details.
 func (p *Pool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
 	c, err := p.Acquire(ctx)
@@ -783,18 +783,18 @@ func (p *Pool) SendBatch(ctx context.Context, b *pgx.Batch) pgx.BatchResults {
 	return &poolBatchResults{br: br, c: c}
 }
 
-// Begin acquires a connection from the Pool and starts a transaction. Unlike database/sql, the context only affects the begin command. i.e. there is no
-// auto-rollback on context cancellation. Begin initiates a transaction block without explicitly setting a transaction mode for the block (see BeginTx with TxOptions if transaction mode is required).
-// *pgxpool.Tx is returned, which implements the pgx.Tx interface.
-// Commit or Rollback must be called on the returned transaction to finalize the transaction block.
+// Begin acquires a connection from the [Pool] and starts a transaction. Unlike [database/sql], the context only affects the begin command. i.e. there is no
+// auto-rollback on context cancellation. Begin initiates a transaction block without explicitly setting a transaction mode for the block (see [Pool.BeginTx] with [pgx.TxOptions] if transaction mode is required).
+// [*Tx] is returned, which implements the [pgx.Tx] interface.
+// [Tx.Commit] or [Tx.Rollback] must be called on the returned transaction to finalize the transaction block.
 func (p *Pool) Begin(ctx context.Context) (pgx.Tx, error) {
 	return p.BeginTx(ctx, pgx.TxOptions{})
 }
 
-// BeginTx acquires a connection from the Pool and starts a transaction with pgx.TxOptions determining the transaction mode.
-// Unlike database/sql, the context only affects the begin command. i.e. there is no auto-rollback on context cancellation.
-// *pgxpool.Tx is returned, which implements the pgx.Tx interface.
-// Commit or Rollback must be called on the returned transaction to finalize the transaction block.
+// BeginTx acquires a connection from the [Pool] and starts a transaction with [pgx.TxOptions] determining the transaction mode.
+// Unlike [database/sql], the context only affects the begin command. i.e. there is no auto-rollback on context cancellation.
+// [*Tx] is returned, which implements the [pgx.Tx] interface.
+// [Tx.Commit] or [Tx.Rollback] must be called on the returned transaction to finalize the transaction block.
 func (p *Pool) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
 	c, err := p.Acquire(ctx)
 	if err != nil {
@@ -820,8 +820,8 @@ func (p *Pool) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNam
 	return c.Conn().CopyFrom(ctx, tableName, columnNames, rowSrc)
 }
 
-// Ping acquires a connection from the Pool and executes an empty sql statement against it.
-// If the sql returns without error, the database Ping is considered successful, otherwise, the error is returned.
+// Ping acquires a connection from the [Pool] and executes an empty sql statement against it.
+// If the sql returns without error, the database [Pool.Ping] is considered successful, otherwise, the error is returned.
 func (p *Pool) Ping(ctx context.Context) error {
 	c, err := p.Acquire(ctx)
 	if err != nil {

--- a/vendor/github.com/jackc/pgx/v5/rows.go
+++ b/vendor/github.com/jackc/pgx/v5/rows.go
@@ -13,12 +13,12 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// Rows is the result set returned from *Conn.Query. Rows must be closed before
-// the *Conn can be used again. Rows are closed by explicitly calling Close(),
-// calling Next() until it returns false, or when a fatal error occurs.
+// Rows is the result set returned from [Conn.Query]. Rows must be closed before
+// the [Conn] can be used again. Rows are closed by explicitly calling [Rows.Close],
+// calling [Rows.Next] until it returns false, or when a fatal error occurs.
 //
-// Once a Rows is closed the only methods that may be called are Close(), Err(),
-// and CommandTag().
+// Once a Rows is closed the only methods that may be called are [Rows.Close], [Rows.Err],
+// and [Rows.CommandTag].
 //
 // Rows is an interface instead of a struct to allow tests to mock Query. However,
 // adding a method to an interface is technically a breaking change. Because of this
@@ -46,9 +46,9 @@ type Rows interface {
 	// having been read or due to an error).
 	//
 	// Callers should check rows.Err() after rows.Next() returns false to detect whether result-set reading ended
-	// prematurely due to an error. See Conn.Query for details.
+	// prematurely due to an error. See [Conn.Query] for details.
 	//
-	// For simpler error handling, consider using the higher-level pgx v5 CollectRows() and ForEachRow() helpers instead.
+	// For simpler error handling, consider using the higher-level pgx v5 [CollectRows()] and [ForEachRow()] helpers instead.
 	Next() bool
 
 	// Scan reads the values from the current row into dest values positionally. dest can include pointers to core types,
@@ -70,7 +70,7 @@ type Rows interface {
 	Conn() *Conn
 }
 
-// Row is a convenience wrapper over Rows that is returned by QueryRow.
+// Row is a convenience wrapper over [Rows] that is returned by [Conn.QueryRow].
 //
 // Row is an interface instead of a struct to allow tests to mock QueryRow. However,
 // adding a method to an interface is technically a breaking change. Because of this
@@ -358,7 +358,7 @@ func (e ScanArgError) Unwrap() error {
 	return e.Err
 }
 
-// ScanRow decodes raw row data into dest. It can be used to scan rows read from the lower level pgconn interface.
+// ScanRow decodes raw row data into dest. It can be used to scan rows read from the lower level [pgconn] interface.
 //
 // typeMap - OID to Go type mapping.
 // fieldDescriptions - OID and format of values
@@ -386,8 +386,8 @@ func ScanRow(typeMap *pgtype.Map, fieldDescriptions []pgconn.FieldDescription, v
 	return nil
 }
 
-// RowsFromResultReader returns a Rows that will read from values resultReader and decode with typeMap. It can be used
-// to read from the lower level pgconn interface.
+// RowsFromResultReader returns a [Rows] that will read from values resultReader and decode with typeMap. It can be used
+// to read from the lower level [pgconn] interface.
 func RowsFromResultReader(typeMap *pgtype.Map, resultReader *pgconn.ResultReader) Rows {
 	return &baseRows{
 		typeMap:      typeMap,
@@ -460,7 +460,7 @@ func CollectRows[T any](rows Rows, fn RowToFunc[T]) ([]T, error) {
 }
 
 // CollectOneRow calls fn for the first row in rows and returns the result. If no rows are found returns an error where errors.Is(ErrNoRows) is true.
-// CollectOneRow is to CollectRows as QueryRow is to Query.
+// CollectOneRow is to [CollectRows] as [Conn.QueryRow] is to [Conn.Query].
 //
 // This function closes the rows automatically on return.
 func CollectOneRow[T any](rows Rows, fn RowToFunc[T]) (T, error) {

--- a/vendor/github.com/jackc/pgx/v5/tx.go
+++ b/vendor/github.com/jackc/pgx/v5/tx.go
@@ -89,13 +89,13 @@ var ErrTxClosed = errors.New("tx is closed")
 // it is treated as ROLLBACK.
 var ErrTxCommitRollback = errors.New("commit unexpectedly resulted in rollback")
 
-// Begin starts a transaction. Unlike database/sql, the context only affects the begin command. i.e. there is no
+// Begin starts a transaction. Unlike [database/sql], the context only affects the begin command. i.e. there is no
 // auto-rollback on context cancellation.
 func (c *Conn) Begin(ctx context.Context) (Tx, error) {
 	return c.BeginTx(ctx, TxOptions{})
 }
 
-// BeginTx starts a transaction with txOptions determining the transaction mode. Unlike database/sql, the context only
+// BeginTx starts a transaction with txOptions determining the transaction mode. Unlike [database/sql], the context only
 // affects the begin command. i.e. there is no auto-rollback on context cancellation.
 func (c *Conn) BeginTx(ctx context.Context, txOptions TxOptions) (Tx, error) {
 	_, err := c.Exec(ctx, txOptions.beginSQL())
@@ -385,8 +385,8 @@ func (sp *dbSimulatedNestedTx) Conn() *Conn {
 	return sp.tx.Conn()
 }
 
-// BeginFunc calls Begin on db and then calls fn. If fn does not return an error then it calls Commit on db. If fn
-// returns an error it calls Rollback on db. The context will be used when executing the transaction control statements
+// BeginFunc calls Begin on db and then calls fn. If fn does not return an error then it calls [Tx.Commit] on db. If fn
+// returns an error it calls [Tx.Rollback] on db. The context will be used when executing the transaction control statements
 // (BEGIN, ROLLBACK, and COMMIT) but does not otherwise affect the execution of fn.
 func BeginFunc(
 	ctx context.Context,
@@ -404,8 +404,8 @@ func BeginFunc(
 	return beginFuncExec(ctx, tx, fn)
 }
 
-// BeginTxFunc calls BeginTx on db and then calls fn. If fn does not return an error then it calls Commit on db. If fn
-// returns an error it calls Rollback on db. The context will be used when executing the transaction control statements
+// BeginTxFunc calls BeginTx on db and then calls fn. If fn does not return an error then it calls [Tx.Commit] on db. If fn
+// returns an error it calls [Tx.Rollback] on db. The context will be used when executing the transaction control statements
 // (BEGIN, ROLLBACK, and COMMIT) but does not otherwise affect the execution of fn.
 func BeginTxFunc(
 	ctx context.Context,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/alecthomas/chroma/lexers/x
 github.com/alecthomas/chroma/lexers/y
 github.com/alecthomas/chroma/lexers/z
 github.com/alecthomas/chroma/styles
-# github.com/anatol/smart.go v0.0.0-20260314002218-4abf60ecc43c
+# github.com/anatol/smart.go v0.0.0-20260419142952-c2af97cbb53f
 ## explicit; go 1.26
 github.com/anatol/smart.go
 # github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
@@ -246,7 +246,7 @@ github.com/distatus/battery
 # github.com/distribution/reference v0.6.0
 ## explicit; go 1.20
 github.com/distribution/reference
-# github.com/dlclark/regexp2 v1.11.5
+# github.com/dlclark/regexp2 v1.12.0
 ## explicit; go 1.13
 github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
@@ -319,7 +319,7 @@ github.com/gabriel-vasile/mimetype/internal/scan
 # github.com/gdamore/encoding v1.0.1
 ## explicit; go 1.9
 github.com/gdamore/encoding
-# github.com/gdamore/tcell/v2 v2.13.8
+# github.com/gdamore/tcell/v2 v2.13.9
 ## explicit; go 1.24.0
 github.com/gdamore/tcell/v2
 github.com/gdamore/tcell/v2/terminfo
@@ -508,7 +508,7 @@ github.com/jackc/pgpassfile
 # github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761
 ## explicit; go 1.14
 github.com/jackc/pgservicefile
-# github.com/jackc/pgx/v5 v5.9.1
+# github.com/jackc/pgx/v5 v5.9.2
 ## explicit; go 1.25.0
 github.com/jackc/pgx/v5
 github.com/jackc/pgx/v5/internal/iobufpool
@@ -1149,7 +1149,7 @@ golang.zx2c4.com/wireguard/rwcancel
 golang.zx2c4.com/wireguard/tun
 # google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
 ## explicit; go 1.25.0
-# google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478
+# google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529
 ## explicit; go 1.25.0
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.80.0


### PR DESCRIPTION
## Summary
- Skip p2p transport (STCPR/SUDPH) dial attempts when connecting to bootstrap peers (DMSG servers), since there will never be a direct transport to them
- Eliminates noisy "no transport to X" debug log spam during bootstrap cycles
- Adds `dialPrimary` method for explicit DMSG-only dialing

## Test plan
- [ ] Verify bootstrap succeeds without "dht transport: no transport to" log lines
- [ ] Confirm regular peer DHT sync still prefers p2p transports when available