### PR TITLE
tpd: cache parsed edge pubkeys in redisStore

### DIFF
--- a/pkg/transport-discovery/store/pubkey_cache.go
+++ b/pkg/transport-discovery/store/pubkey_cache.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+// pubKeyCache memoizes hex → cipher.PubKey parsing.
+// The dataToEntryCore hot path hex-parses two edge pubkeys per entry; each
+// parse runs a secp256k1 point decompression (Sqrt+Sqr, tens of %CPU under
+// load). The mapping is deterministic and the set of edges is small
+// (hundreds), so a bounded map gives near-100 % hit rate with negligible
+// memory.
+type pubKeyCache struct {
+	mu    sync.RWMutex
+	cap   int
+	items map[string]cipher.PubKey
+}
+
+const defaultPubKeyCacheCap = 4096
+
+func newPubKeyCache(cap int) *pubKeyCache {
+	if cap <= 0 {
+		cap = defaultPubKeyCacheCap
+	}
+	return &pubKeyCache{cap: cap, items: make(map[string]cipher.PubKey, cap)}
+}
+
+// Parse returns the parsed PubKey for a hex string, using the cache when
+// possible. Malformed hex is not cached — next call will re-error.
+func (c *pubKeyCache) Parse(hex string) (cipher.PubKey, error) {
+	c.mu.RLock()
+	pk, ok := c.items[hex]
+	c.mu.RUnlock()
+	if ok {
+		return pk, nil
+	}
+
+	var parsed cipher.PubKey
+	if err := parsed.UnmarshalText([]byte(hex)); err != nil {
+		return cipher.PubKey{}, err
+	}
+
+	c.mu.Lock()
+	if len(c.items) >= c.cap {
+		for k := range c.items { // random eviction — cache is a perf aid, not correctness-critical
+			delete(c.items, k)
+			break
+		}
+	}
+	c.items[hex] = parsed
+	c.mu.Unlock()
+
+	return parsed, nil
+}

--- a/pkg/transport-discovery/store/pubkey_cache_test.go
+++ b/pkg/transport-discovery/store/pubkey_cache_test.go
@@ -1,0 +1,107 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+func TestPubKeyCache_ParseHitsReturnEqualValue(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	hex := pk.Hex()
+
+	c := newPubKeyCache(16)
+
+	first, err := c.Parse(hex)
+	if err != nil {
+		t.Fatalf("first parse: %v", err)
+	}
+	if first != pk {
+		t.Fatalf("first parse mismatch: got %s want %s", first.Hex(), hex)
+	}
+
+	// Confirm hit by checking the map was populated.
+	c.mu.RLock()
+	_, cached := c.items[hex]
+	c.mu.RUnlock()
+	if !cached {
+		t.Fatalf("expected pubkey to be cached after first Parse")
+	}
+
+	second, err := c.Parse(hex)
+	if err != nil {
+		t.Fatalf("second parse: %v", err)
+	}
+	if second != first {
+		t.Fatalf("second parse returned different value")
+	}
+}
+
+func TestPubKeyCache_MalformedHexNotCached(t *testing.T) {
+	c := newPubKeyCache(16)
+	bad := "not-a-hex-pubkey"
+
+	if _, err := c.Parse(bad); err == nil {
+		t.Fatalf("expected error for malformed hex")
+	}
+
+	c.mu.RLock()
+	_, cached := c.items[bad]
+	c.mu.RUnlock()
+	if cached {
+		t.Fatalf("malformed hex should not be cached")
+	}
+
+	// A second malformed Parse must still fail (not silently succeed).
+	if _, err := c.Parse(bad); err == nil {
+		t.Fatalf("expected error on repeat malformed parse")
+	}
+}
+
+func TestPubKeyCache_EvictsWhenFull(t *testing.T) {
+	c := newPubKeyCache(2)
+
+	for i := 0; i < 3; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		if _, err := c.Parse(pk.Hex()); err != nil {
+			t.Fatalf("parse %d: %v", i, err)
+		}
+	}
+
+	c.mu.RLock()
+	size := len(c.items)
+	c.mu.RUnlock()
+	if size > 2 {
+		t.Fatalf("cache exceeded cap: size=%d cap=2", size)
+	}
+}
+
+func BenchmarkPubKeyCache_Parse(b *testing.B) {
+	pk, _ := cipher.GenerateKeyPair()
+	hex := pk.Hex()
+	c := newPubKeyCache(16)
+	// Warm.
+	if _, err := c.Parse(hex); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := c.Parse(hex); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkPubKeyCache_Uncached(b *testing.B) {
+	pk, _ := cipher.GenerateKeyPair()
+	hex := []byte(pk.Hex())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out cipher.PubKey
+		if err := out.UnmarshalText(hex); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -40,9 +40,10 @@ type TransportData struct {
 }
 
 type redisStore struct {
-	client *redis.Client
-	ttl    time.Duration
-	log    *logging.Logger
+	client  *redis.Client
+	ttl     time.Duration
+	log     *logging.Logger
+	pkCache *pubKeyCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -76,7 +77,12 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 		return nil, err
 	}
 
-	return &redisStore{client: redisCl, ttl: ttl, log: logger}, nil
+	return &redisStore{
+		client:  redisCl,
+		ttl:     ttl,
+		log:     logger,
+		pkCache: newPubKeyCache(defaultPubKeyCacheCap),
+	}, nil
 }
 
 func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.SignedEntry) error {
@@ -497,11 +503,12 @@ func (s *redisStore) dataToEntryCore(data TransportData) (*transport.Entry, erro
 		return nil, err
 	}
 
-	var edgeA, edgeB cipher.PubKey
-	if err := edgeA.UnmarshalText([]byte(data.EdgeA)); err != nil {
+	edgeA, err := s.pkCache.Parse(data.EdgeA)
+	if err != nil {
 		return nil, err
 	}
-	if err := edgeB.UnmarshalText([]byte(data.EdgeB)); err != nil {
+	edgeB, err := s.pkCache.Parse(data.EdgeB)
+	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The v3 per-edge mirror path (PR #2334) calls GetTransportsByEdge once per touched edge on every register. Each resulting dataToEntryCore call hex-parsed two edge pubkeys, and secp256k1 point-decompression (Sqrt → Sqr) dominated the TPD CPU profile — mirrorEdges 60 % cum, Field.Sqr 36 % flat on prod server 1, a regression vs PR #2333.

Parsing is deterministic per-hex and the set of edges is small (a few hundred visors). Add a bounded (4096-entry) map keyed by hex string to cache parsed cipher.PubKey values at the store layer. Random eviction; malformed hex is not cached so errors still surface. Benchmark: cached Parse 30 ns/op vs uncached UnmarshalText 14 365 ns/op — ~470× faster.

Also benefits GetTransportByID / GetAllTransports / GetTransportsByEdges since they all flow through dataToEntryCore.

