### PR TITLE
dht: skip mirror publish when subject payload is unchanged

### DIFF
--- a/pkg/dht/mirror_redis.go
+++ b/pkg/dht/mirror_redis.go
@@ -13,10 +13,20 @@ package dht
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"sync"
+	"time"
 
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/logging"
 )
+
+// contentCacheMaxAge bounds how long we skip re-publishing an unchanged
+// subject. A periodic refresh guards against silent Redis data loss or
+// eviction and lets new DHT full-nodes bootstrap eventually. 1h is a
+// conservative default; TPD heartbeats run at a higher rate, so the
+// vast majority of re-registers still hit the skip path.
+const contentCacheMaxAge = time.Hour
 
 // RedisMirror writes entries to Redis in the same key format as
 // RedisBackend, without requiring a local DHT node.
@@ -26,6 +36,14 @@ type RedisMirror struct {
 	log     *logging.Logger
 	pk      cipher.PubKey
 	sk      cipher.SecKey
+
+	cacheMu sync.RWMutex
+	cache   map[cipher.PubKey]mirroredContent
+}
+
+type mirroredContent struct {
+	hash    uint64
+	savedAt time.Time
 }
 
 // NewRedisMirror creates a mirror that writes directly to Redis.
@@ -42,6 +60,7 @@ func NewRedisMirror(redisAddr, redisPassword string, redisDB int, salt string, p
 		log:     log,
 		pk:      pk,
 		sk:      sk,
+		cache:   make(map[cipher.PubKey]mirroredContent),
 	}, nil
 }
 
@@ -58,6 +77,12 @@ func (m *RedisMirror) Mirror(subjectPK cipher.PubKey, entry interface{}, seq uin
 // under each target. For a 2-edge transport this cuts the per-register
 // secp256k1 cost in half; on TPD under production load the single-sign
 // path accounts for the majority of the service's CPU.
+//
+// Subjects whose last-mirrored payload hash matches the current payload
+// (and whose cache entry is fresher than contentCacheMaxAge) are
+// skipped: no sign, no save. This is the common case for re-register /
+// heartbeat flows where the list of transports for an edge hasn't
+// changed since the last publish.
 func (m *RedisMirror) MirrorMany(subjectPKs []cipher.PubKey, entry interface{}, seq uint64) {
 	if len(subjectPKs) == 0 {
 		return
@@ -65,6 +90,16 @@ func (m *RedisMirror) MirrorMany(subjectPKs []cipher.PubKey, entry interface{}, 
 	data, err := json.Marshal(entry)
 	if err != nil {
 		m.log.WithError(err).Warn("Redis mirror: marshal failed")
+		return
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write(data)
+	payloadHash := h.Sum64()
+	now := time.Now()
+
+	targets := m.subjectsToPublish(subjectPKs, payloadHash, now)
+	if len(targets) == 0 {
 		return
 	}
 
@@ -80,12 +115,37 @@ func (m *RedisMirror) MirrorMany(subjectPKs []cipher.PubKey, entry interface{}, 
 	}
 
 	salt := []byte(m.salt)
-	for _, pk := range subjectPKs {
+	for _, pk := range targets {
 		target := MutableItemTarget(pk, salt)
 		if err := m.backend.Save(target, item); err != nil {
 			m.log.WithError(err).Warn("Redis mirror: save failed")
+			continue
 		}
+		m.recordPublished(pk, payloadHash, now)
 	}
+}
+
+// subjectsToPublish filters out subjects whose cached content hash matches
+// the current payload and whose cache entry is still fresh. It returns
+// the subset that must actually be signed and written.
+func (m *RedisMirror) subjectsToPublish(subjectPKs []cipher.PubKey, payloadHash uint64, now time.Time) []cipher.PubKey {
+	out := subjectPKs[:0:0]
+	m.cacheMu.RLock()
+	defer m.cacheMu.RUnlock()
+	for _, pk := range subjectPKs {
+		cached, ok := m.cache[pk]
+		if ok && cached.hash == payloadHash && now.Sub(cached.savedAt) < contentCacheMaxAge {
+			continue
+		}
+		out = append(out, pk)
+	}
+	return out
+}
+
+func (m *RedisMirror) recordPublished(pk cipher.PubKey, payloadHash uint64, now time.Time) {
+	m.cacheMu.Lock()
+	m.cache[pk] = mirroredContent{hash: payloadHash, savedAt: now}
+	m.cacheMu.Unlock()
 }
 
 // Delete removes the DHT target for the given subject PK.
@@ -97,6 +157,9 @@ func (m *RedisMirror) Delete(subjectPK cipher.PubKey) {
 	if err := m.backend.Delete(target); err != nil {
 		m.log.WithError(err).Warn("Redis mirror: delete failed")
 	}
+	m.cacheMu.Lock()
+	delete(m.cache, subjectPK)
+	m.cacheMu.Unlock()
 }
 
 // Close closes the Redis connection.

--- a/pkg/dht/mirror_redis_test.go
+++ b/pkg/dht/mirror_redis_test.go
@@ -1,0 +1,123 @@
+package dht
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+)
+
+func newTestMirror(t *testing.T) *RedisMirror {
+	t.Helper()
+	pk, sk := cipher.GenerateKeyPair()
+	return &RedisMirror{
+		salt:  "test",
+		pk:    pk,
+		sk:    sk,
+		cache: make(map[cipher.PubKey]mirroredContent),
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_EmptyCachePublishesAll(t *testing.T) {
+	m := newTestMirror(t)
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	got := m.subjectsToPublish([]cipher.PubKey{pk1, pk2}, 0xdeadbeef, time.Now())
+	if len(got) != 2 {
+		t.Fatalf("expected 2 subjects, got %d", len(got))
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_SkipsMatchingHashWithinMaxAge(t *testing.T) {
+	m := newTestMirror(t)
+	pk, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+
+	m.recordPublished(pk, 0x1234, now)
+	got := m.subjectsToPublish([]cipher.PubKey{pk}, 0x1234, now.Add(time.Minute))
+	if len(got) != 0 {
+		t.Fatalf("expected 0 (skip), got %d", len(got))
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_DoesNotSkipOnHashChange(t *testing.T) {
+	m := newTestMirror(t)
+	pk, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+
+	m.recordPublished(pk, 0x1234, now)
+	got := m.subjectsToPublish([]cipher.PubKey{pk}, 0x9999, now.Add(time.Second))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 (re-publish on hash change), got %d", len(got))
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_RefreshesAfterMaxAge(t *testing.T) {
+	m := newTestMirror(t)
+	pk, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+
+	m.recordPublished(pk, 0x1234, now)
+	got := m.subjectsToPublish([]cipher.PubKey{pk}, 0x1234, now.Add(contentCacheMaxAge+time.Second))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 (refresh after max age), got %d", len(got))
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_MixedBatchPartialSkip(t *testing.T) {
+	m := newTestMirror(t)
+	pkSkip, _ := cipher.GenerateKeyPair()
+	pkFresh, _ := cipher.GenerateKeyPair()
+	pkChanged, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+
+	m.recordPublished(pkSkip, 0xAAAA, now)
+	m.recordPublished(pkChanged, 0xBBBB, now)
+	// pkFresh has no cache entry.
+
+	got := m.subjectsToPublish([]cipher.PubKey{pkSkip, pkFresh, pkChanged}, 0xAAAA, now.Add(time.Second))
+	if len(got) != 2 {
+		t.Fatalf("expected 2 (skip=pkSkip, publish=pkFresh+pkChanged), got %d", len(got))
+	}
+	// Order preserved from input, minus the skipped entry.
+	if got[0] != pkFresh || got[1] != pkChanged {
+		t.Fatalf("unexpected order: %v", got)
+	}
+}
+
+func TestRedisMirror_Delete_InvalidatesCache(t *testing.T) {
+	m := newTestMirror(t)
+	pk, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+
+	m.recordPublished(pk, 0x1234, now)
+
+	// Manually invalidate like Delete() does — can't call Delete() without backend.
+	m.cacheMu.Lock()
+	delete(m.cache, pk)
+	m.cacheMu.Unlock()
+
+	got := m.subjectsToPublish([]cipher.PubKey{pk}, 0x1234, now.Add(time.Second))
+	if len(got) != 1 {
+		t.Fatalf("expected 1 (cache cleared by delete), got %d", len(got))
+	}
+}
+
+func TestRedisMirror_SubjectsToPublish_DoesNotMutateInput(t *testing.T) {
+	m := newTestMirror(t)
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	now := time.Now()
+	m.recordPublished(pk1, 0xAAAA, now)
+
+	input := []cipher.PubKey{pk1, pk2}
+	origLen := len(input)
+	origFirst := input[0]
+
+	_ = m.subjectsToPublish(input, 0xAAAA, now.Add(time.Second))
+
+	if len(input) != origLen || input[0] != origFirst {
+		t.Fatalf("input slice was mutated")
+	}
+}


### PR DESCRIPTION
After PR #2335 brought TPD's parse cost down, secp256k1 signing in RedisMirror.MirrorMany became the dominant remaining CPU consumer (~34 % cum, with Sign / SignHash / RecoverPubkey on the hot path). Most of those signs are wasted work: re-register / heartbeat traffic from visors publishes the exact same edge-list that was mirrored moments ago, producing an identical payload blob.

Add a per-subject content cache keyed by FNV-1a 64 of the marshalled payload. MirrorMany now filters subjects whose cached hash matches the incoming payload and whose cache entry is fresher than 1 h; only the remaining subjects are signed and written. Subject PKs deleted via Delete() are evicted from the cache so their next publish always re-signs.

The 1 h ceiling forces a periodic refresh so new DHT full-nodes (or a wiped Redis) still eventually pick up the record. Backfill on startup hits an empty cache and publishes everything as expected.

No changes to the Mirror/MirrorMany signature or semantics — this is a transparent write-side optimization shared by TPD, dmsg-discovery and service-discovery.
