### PR TITLE
setup-node: add porter watchdog to bound ephemeral port leaks

### DIFF
--- a/pkg/router/setupnode.go
+++ b/pkg/router/setupnode.go
@@ -157,6 +157,38 @@ func (sn *Node) Serve(ctx context.Context, m setupmetrics.Metrics) error {
 		}
 	}()
 
+	// Porter watchdog: periodically sweep stale ephemeral port reservations
+	// and log usage. The embedded RSN (pkg/visor/embedded_route_setup.go) runs
+	// the same loop; without it here, the standalone setup-node container
+	// leaks reservations until the 16K ephemeral range saturates and every
+	// new dial fails with "ephemeral port space exhausted" (observed: ~13
+	// ports/min in prod, full exhaustion in ~20h). Sweep age matches the
+	// pool TTL — anything older than that should have been freed already.
+	const porterMaxAge = 5 * time.Minute
+	go func() {
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+		var lastCount int
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				swept := sn.dmsgC.SweepStalePorterEntries(porterMaxAge)
+				diag := sn.dmsgC.PorterDiag()
+				delta := diag.Ephemeral - lastCount
+				if diag.Ephemeral > 100 || delta > 0 || swept > 0 {
+					log.WithField("ephemeral", diag.Ephemeral).
+						WithField("delta_60s", delta).
+						WithField("swept", swept).
+						WithField("pool_size", sn.pool.Size()).
+						Warn("Setup-node porter watchdog")
+				}
+				lastCount = diag.Ephemeral
+			}
+		}
+	}()
+
 	// handlerTimeout is the hard deadline for an entire RPC handler goroutine.
 	// This covers the full lifecycle: dial to remote visors, reserve IDs,
 	// broadcast rules, and return response. It must be longer than the


### PR DESCRIPTION
Standalone Node.Serve was missing the SweepStalePorterEntries loop that the embedded RSN already runs (pkg/visor/embedded_route_setup.go), so any leaked stream reservation accumulated until the 49152-65535 ephemeral range saturated. Observed in prod: ~13 ports/min leak rate, full exhaustion (ports_reserved=16387) after ~20h container uptime, every new DialStream then failing with "ephemeral port space exhausted" while holding ~1 GB of yamux.Stream objects parented by the porter map.

Adds the same 60s ticker that sweeps entries older than 5 minutes and logs ephemeral / delta / swept / pool_size, matching the embedded RSN format so both paths show up identically in dashboards.
