### PR TITLE
perf(sd): replace SCAN-for-existence with per-visor index lookup

### DIFF
--- a/pkg/service-discovery/store/redis_store.go
+++ b/pkg/service-discovery/store/redis_store.go
@@ -506,13 +506,35 @@ func (s *redisStore) GetAllVisorSummaries(ctx context.Context, v2 bool, timeline
 
 // isServiceOnline checks whether any live service entry exists for the given PK hex.
 // A service entry exists when the visor has recently called UpdateService (within TTL).
+//
+// The previous implementation walked the entire keyspace via SCAN cursor=0
+// pattern="service:*:<pk>" COUNT=10. With ~150K keys in production, an
+// offline visor's check meant ~15K SCAN round-trips per call — and this is
+// invoked once per visor seen today inside refreshUptimesCache, which fires
+// every 5 minutes for both v1 and v2 caches. Production redis was spending
+// ~33% of its CPU on SCAN alone (~3316 calls/sec).
+//
+// Now: consult the per-visor service-type index that UpdateService /
+// UpdateServiceAndHeartbeat / DeleteService already maintain (see
+// visorServicesKey + ServicesByPK). Build the actual service keys and
+// resolve in a single multi-key EXISTS. The index can lag primary-key
+// TTLs; an existing index member with no live primary just returns false
+// here, and ServicesByPK's lazy SREM cleans it up on the next read.
+// O(1) Redis round-trips per call regardless of keyspace size.
 func (s *redisStore) isServiceOnline(ctx context.Context, pkHex string) bool {
-	pattern := fmt.Sprintf("%s*:%s", serviceKeyPrefix, pkHex)
-	iter := s.client.Scan(ctx, 0, pattern, 10).Iterator()
-	for iter.Next(ctx) {
-		return true
+	types, err := s.client.SMembers(ctx, s.visorServicesKey(pkHex)).Result()
+	if err != nil || len(types) == 0 {
+		return false
 	}
-	return false
+	keys := make([]string, len(types))
+	for i, t := range types {
+		keys[i] = fmt.Sprintf("%s%s:%s", serviceKeyPrefix, t, pkHex)
+	}
+	n, err := s.client.Exists(ctx, keys...).Result()
+	if err != nil {
+		return false
+	}
+	return n > 0
 }
 
 // getDailyUptime returns the last 7 days of uptime percentages for a visor.


### PR DESCRIPTION
## Summary

`isServiceOnline` walked the entire Redis keyspace via `SCAN cursor=0 pattern=\"service:*:<pk>\" COUNT=10` to test whether any live service entry existed for a visor. With ~150K keys in production, an offline visor's check meant ~15K SCAN round-trips per call — and \`refreshUptimesCache\` fires \`GetAllVisorSummaries\` twice every 5 minutes, calling \`isServiceOnline\` once per visor seen today (~200). Net result: redis spent **~33% of its CPU on SCAN alone (~3316 calls/sec)** sustained.

## Production observation

\`INFO commandstats\` (redis uptime 23 min, fresh restart):

| Command | calls | total CPU | per-call | rate |
|---|---:|---:|---:|---:|
| **SCAN** | **4 542 040** | **452 s** | 99 µs | **3316/s** |
| MGET | 321 208 | 33 s | 102 µs | 234/s |
| SMEMBERS | 320 654 | 7 s | 22 µs | 234/s |

Redis container CPU sat at 33–48 % on this host; SCAN alone was the #1 contributor.

## Fix

Switch to the per-visor service-type index set (\`sd:visor-svc:<pkHex>\`) that \`UpdateService\`, \`UpdateServiceAndHeartbeat\`, and \`DeleteService\` already maintain. \`ServicesByPK\` already reads from it. \`isServiceOnline\` now does:

1. SMEMBERS the index to get registered types.
2. Multi-key EXISTS to confirm at least one primary key is still live.

Constant Redis round-trips per call regardless of keyspace size.

## Index staleness

If a primary key TTL-expires without a clean \`DeleteService\` call, the index can keep a stale entry pointing to a missing key. The new \`isServiceOnline\` correctly returns \`false\` for that case (EXISTS sees nothing live), and \`ServicesByPK\`'s existing lazy \`SREM\` cleans the index on the next read. No new staleness risk introduced.

## Test plan

- [x] \`go build ./pkg/service-discovery/...\` clean
- [x] \`go test ./pkg/service-discovery/store/...\` (no test files in package)
- [ ] Deploy to prod redis, capture \`redis-cli INFO commandstats\` over a 30-min window
- [ ] Confirm SCAN call rate drops from ~3316/s to near-zero
- [ ] Confirm redis container CPU drops noticeably (expected: 33–48 % → ~10–15 %)