### PR TITLE
perf(tpd): per-edge entry cache eliminates repeat fetches in mirrorEdges

### DIFF
--- a/pkg/transport-discovery/store/edge_entries_cache.go
+++ b/pkg/transport-discovery/store/edge_entries_cache.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// edgeEntriesCache memoizes parsed *transport.Entry slices keyed by edge
+// pubkey. Cache hits skip the SMEMBERS+MGET+JSON-unmarshal+pubkey-parse
+// round-trip in GetTransportsByEdge.
+//
+// mirrorEdges fires GetTransportsByEdge once per touched edge after every
+// register / deregister. Hub edges (edges that participate in many
+// transports) are re-fetched every time another mutation touches them,
+// even though the list often hasn't changed since the previous call.
+// pprof on prod TPD showed mirrorEdges → GetTransportsByEdge dominating
+// CPU at ~35 % cumulative even after PRs #2334–#2336.
+//
+// Mutations (RegisterTransport, RegisterTransportsBatch,
+// DeregisterTransport) MUST call Invalidate for every touched edge so
+// the next GetTransportsByEdge picks up the post-mutation list. The
+// short TTL is a safety backstop only — correctness comes from explicit
+// invalidation.
+type edgeEntriesCache struct {
+	mu    sync.RWMutex
+	cap   int
+	ttl   time.Duration
+	items map[cipher.PubKey]edgeCacheEntry
+}
+
+type edgeCacheEntry struct {
+	entries []*transport.Entry
+	expiry  time.Time
+}
+
+const (
+	defaultEdgeEntriesCacheCap = 4096
+	defaultEdgeEntriesCacheTTL = 5 * time.Second
+)
+
+func newEdgeEntriesCache(cap int, ttl time.Duration) *edgeEntriesCache {
+	if cap <= 0 {
+		cap = defaultEdgeEntriesCacheCap
+	}
+	if ttl <= 0 {
+		ttl = defaultEdgeEntriesCacheTTL
+	}
+	return &edgeEntriesCache{
+		cap:   cap,
+		ttl:   ttl,
+		items: make(map[cipher.PubKey]edgeCacheEntry, cap),
+	}
+}
+
+// Get returns the cached entries for an edge if the cache holds an
+// unexpired entry for it. The returned slice is the cache's own backing
+// slice — callers must not modify it.
+func (c *edgeEntriesCache) Get(pk cipher.PubKey) ([]*transport.Entry, bool) {
+	c.mu.RLock()
+	e, ok := c.items[pk]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(e.expiry) {
+		return nil, false
+	}
+	return e.entries, true
+}
+
+// Put stores entries for an edge with the cache's configured TTL.
+// Random eviction at capacity — the cache is a perf aid, not
+// correctness-critical (TTL bounds staleness; explicit Invalidate
+// handles correctness across mutations).
+func (c *edgeEntriesCache) Put(pk cipher.PubKey, entries []*transport.Entry) {
+	c.mu.Lock()
+	if len(c.items) >= c.cap {
+		for k := range c.items {
+			delete(c.items, k)
+			break
+		}
+	}
+	c.items[pk] = edgeCacheEntry{
+		entries: entries,
+		expiry:  time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+}
+
+// Invalidate drops any cached entry for the given edges. Mutators call
+// this for every touched edge before mirrorEdges runs so the next
+// GetTransportsByEdge sees the post-mutation state.
+func (c *edgeEntriesCache) Invalidate(pks ...cipher.PubKey) {
+	if len(pks) == 0 {
+		return
+	}
+	c.mu.Lock()
+	for _, pk := range pks {
+		delete(c.items, pk)
+	}
+	c.mu.Unlock()
+}

--- a/pkg/transport-discovery/store/edge_entries_cache_test.go
+++ b/pkg/transport-discovery/store/edge_entries_cache_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+func TestEdgeEntriesCache_HitMissExpiry(t *testing.T) {
+	c := newEdgeEntriesCache(8, 50*time.Millisecond)
+
+	pk, _ := cipher.GenerateKeyPair()
+	entries := []*transport.Entry{{}}
+
+	if _, ok := c.Get(pk); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	c.Put(pk, entries)
+	got, ok := c.Get(pk)
+	if !ok {
+		t.Fatal("expected hit immediately after Put")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if _, ok := c.Get(pk); ok {
+		t.Fatal("expected miss after TTL expiry")
+	}
+}
+
+func TestEdgeEntriesCache_Invalidate(t *testing.T) {
+	c := newEdgeEntriesCache(8, time.Hour)
+
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	entries := []*transport.Entry{{}}
+
+	c.Put(pk1, entries)
+	c.Put(pk2, entries)
+
+	c.Invalidate(pk1)
+	if _, ok := c.Get(pk1); ok {
+		t.Fatal("expected miss after Invalidate")
+	}
+	if _, ok := c.Get(pk2); !ok {
+		t.Fatal("Invalidate of pk1 should not affect pk2")
+	}
+
+	// variadic form invalidates all listed
+	c.Invalidate(pk1, pk2)
+	if _, ok := c.Get(pk2); ok {
+		t.Fatal("expected miss after variadic Invalidate")
+	}
+}
+
+func TestEdgeEntriesCache_CapEviction(t *testing.T) {
+	c := newEdgeEntriesCache(2, time.Hour)
+
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	pk3, _ := cipher.GenerateKeyPair()
+	entries := []*transport.Entry{{}}
+
+	c.Put(pk1, entries)
+	c.Put(pk2, entries)
+	c.Put(pk3, entries) // forces random eviction of one of pk1/pk2
+
+	if len(c.items) > 2 {
+		t.Fatalf("cache exceeded capacity: %d", len(c.items))
+	}
+}

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -40,10 +40,11 @@ type TransportData struct {
 }
 
 type redisStore struct {
-	client  *redis.Client
-	ttl     time.Duration
-	log     *logging.Logger
-	pkCache *pubKeyCache
+	client    *redis.Client
+	ttl       time.Duration
+	log       *logging.Logger
+	pkCache   *pubKeyCache
+	edgeCache *edgeEntriesCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -78,10 +79,11 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 	}
 
 	return &redisStore{
-		client:  redisCl,
-		ttl:     ttl,
-		log:     logger,
-		pkCache: newPubKeyCache(defaultPubKeyCacheCap),
+		client:    redisCl,
+		ttl:       ttl,
+		log:       logger,
+		pkCache:   newPubKeyCache(defaultPubKeyCacheCap),
+		edgeCache: newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
 	}, nil
 }
 
@@ -161,6 +163,10 @@ func (s *redisStore) RegisterTransport(ctx context.Context, sEntry *transport.Si
 		return err
 	}
 
+	// Invalidate the per-edge entry cache so mirrorEdges (called by the
+	// API layer right after this returns) re-fetches the post-write list.
+	s.edgeCache.Invalidate(entry.Edges[0], entry.Edges[1])
+
 	return nil
 }
 
@@ -228,8 +234,19 @@ func (s *redisStore) RegisterTransportsBatch(ctx context.Context, entries []*tra
 
 	pipe.Expire(ctx, s.visorAllKey(), 400*24*time.Hour)
 
-	_, err := pipe.Exec(ctx)
-	return err
+	if _, err := pipe.Exec(ctx); err != nil {
+		return err
+	}
+
+	// Invalidate every touched edge so mirrorEdges sees the post-batch
+	// state on the next GetTransportsByEdge call.
+	for _, sEntry := range entries {
+		if sEntry == nil || sEntry.Entry == nil {
+			continue
+		}
+		s.edgeCache.Invalidate(sEntry.Entry.Edges[0], sEntry.Entry.Edges[1])
+	}
+	return nil
 }
 
 func (s *redisStore) DeregisterTransport(ctx context.Context, id uuid.UUID) error {
@@ -257,6 +274,7 @@ func (s *redisStore) DeregisterTransport(ctx context.Context, id uuid.UUID) erro
 		return err
 	}
 
+	s.edgeCache.Invalidate(entry.Edges[0], entry.Edges[1])
 	return nil
 }
 
@@ -280,6 +298,10 @@ func (s *redisStore) GetTransportByID(ctx context.Context, id uuid.UUID) (*trans
 }
 
 func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) ([]*transport.Entry, error) {
+	if entries, ok := s.edgeCache.Get(pk); ok {
+		return entries, nil
+	}
+
 	edgeKey := s.edgeKey(pk)
 
 	ids, err := s.client.SMembers(ctx, edgeKey).Result()
@@ -350,6 +372,7 @@ func (s *redisStore) GetTransportsByEdge(ctx context.Context, pk cipher.PubKey) 
 		return nil, ErrTransportNotFound
 	}
 
+	s.edgeCache.Put(pk, entries)
 	return entries, nil
 }
 


### PR DESCRIPTION
## Summary

After PRs #2333–#2336 the remaining TPD CPU was dominated by \`mirrorEdges → GetTransportsByEdge\` at ~35 % cumulative. Every register / deregister calls \`mirrorEdges\` for each touched edge, and \`mirrorEdges\` re-fetches the full per-edge list (SMEMBERS + MGET + JSON-unmarshal + edge-pubkey-parse) even when the list hasn't changed since the previous call.

For hub edges (edges that participate in many transports), this means duplicated work on every neighbouring mutation.

## Fix

Add \`edgeEntriesCache\`: a bounded TTL cache of parsed \`*transport.Entry\` slices keyed by edge pubkey.

- **Read path:** \`GetTransportsByEdge\` consults the cache first. Hit ⇒ skip Redis round-trips entirely. Miss ⇒ existing path, then \`Put\` the result.
- **Write path:** \`RegisterTransport\`, \`RegisterTransportsBatch\`, and \`DeregisterTransport\` \`Invalidate\` the touched edges *after* the redis pipeline commits. The next \`GetTransportsByEdge\` re-fetches and re-populates.
- **Backstop:** 5-second TTL — purely a safety net. Correctness comes from explicit invalidation, the TTL just bounds staleness if a future code path forgets to invalidate.
- **Capacity:** 4096 entries (same scale as the \`pubKeyCache\` from #2335). Random eviction at capacity.

Cache hit cost: one map lookup + one mutex acquire. Cache miss cost: unchanged from today.

## Test plan

- [x] \`go build ./pkg/transport-discovery/...\` clean
- [x] \`go vet ./pkg/transport-discovery/...\` clean
- [x] \`go test ./pkg/transport-discovery/store/...\` — all existing tests pass
- [x] Three new unit tests for \`edgeEntriesCache\` (hit/miss/expiry, Invalidate, capacity eviction)
- [ ] Deploy and re-capture 30 s pprof on TPD; expect \`mirrorEdges\` cumulative CPU to drop from ~35 % to single-digit % under steady-state register churn
- [ ] Confirm DHT mirror correctness via existing v3 tests / spot-checks