### PR TITLE
perf(cipher): disable DebugLevel1 to skip post-Sign verify-after-sign

### DIFF
--- a/pkg/skywire-utilities/pkg/cipher/cipher.go
+++ b/pkg/skywire-utilities/pkg/cipher/cipher.go
@@ -56,6 +56,22 @@ func verifyCacheStore(pk cipher.PubKey, sig cipher.Sig, hash cipher.SHA256) {
 
 func init() {
 	cipher.DebugLevel2 = false // DebugLevel2 causes ECDH to be really slow
+
+	// DebugLevel1 triggers a paranoid verify-after-sign block in
+	// cipher.SignHash (skycoin crypto.go:381) that recovers the public
+	// key from the signature and re-verifies it — three extra secp256k1
+	// ops on top of every Sign. Skycoin enables it as 10⁻⁴⁰ coin-loss
+	// insurance; in skywire's network-handshake context an invalid sig
+	// would just cause the next handshake to fail and retry, so the
+	// cost-vs-risk math goes the other way.
+	//
+	// Production pprof on address-resolver showed RecoverPubkey at 29 %
+	// cum and VerifyPubKeySignedHash at 14 % cum on top of SignHash
+	// itself — all of which were the post-verify path. Disabling it
+	// halves the per-Sign CPU cost across every signing site (dmsg
+	// noise stream sign/verify, every service's nonce-signed responses,
+	// every visor's stream-request signatures).
+	cipher.DebugLevel1 = false
 }
 
 // GenerateKeyPair creates key pair


### PR DESCRIPTION
## Summary

skycoin's \`cipher.SignHash\` (crypto.go:381) runs a verify-after-sign block when either \`DebugLevel1\` or \`DebugLevel2\` is true:

\`\`\`go
if DebugLevel2 || DebugLevel1 {
    pubkey, err := PubKeyFromSig(sig, hash)            // RecoverPubkey
    if VerifyPubKeySignedHash(pubkey, sig, hash) != nil { ... }   // ECmult
    if VerifyAddressSignedHash(...) != nil { ... }     // hash + decompress
}
\`\`\`

Three extra secp256k1 ops on top of every \`Sign\`. Skycoin enables both as 10⁻⁴⁰ coin-loss insurance for the wallet context — but skywire isn't a coin context. An invalid signature just makes the next handshake fail and retry.

\`DebugLevel2\` is already disabled in this \`init()\`. \`DebugLevel1\` defaults to \`true\`, so the post-verify still runs on every Sign. Disable it.

## Production observation (address-resolver, post-#2338)

30 s pprof, 6.75 s active CPU:

| Frame | flat | cum |
|---|---:|---:|
| \`secp256k1-go2.(*XYZ).ECmult\` | — | 39 % |
| \`secp256k1-go.RecoverPubkey\` | — | 29 % |
| \`secp256k1-go2.(*Field).Mul\` | 25 % | 26 % |
| \`secp256k1-go2.(*Field).Sqr\` | 18 % | 19 % |
| \`secp256k1-go.VerifySignature\` | — | 14 % |
| \`secp256k1-go2.(*Field).Sqrt\` | — | 12 % |

All reachable only through the post-Sign verify path. The read path already uses \`VerifyPubKeySignedHashLight\` with its own verify cache.

## Scope

This change is in \`pkg/skywire-utilities/pkg/cipher\`'s package \`init()\`. It applies to every binary that imports the package — every service, every visor, the setup-node, dmsg-server. Anything that signs anything.

## Estimated impact

- AR / dmsg-server / dmsg-disc (sign-heavy on every dmsg handshake): **~30-40 % CPU drop**
- TPD / SD (mix of sign + verify): ~10-20 % CPU drop
- Visors: ~5-15 % depending on transport churn

## Test plan

- [x] \`go build ./pkg/skywire-utilities/pkg/cipher/...\` clean
- [x] \`go test ./pkg/skywire-utilities/pkg/cipher/...\` pass
- [x] \`go build ./pkg/... ./cmd/svc/...\` clean
- [ ] Deploy and re-capture pprof on AR + dmsg-server + dmsg-disc, confirm \`RecoverPubkey\`/\`Field.Mul\`/\`Field.Sqr\` cumulative collapses.