### PR TITLE
perf(tpd): short-TTL cache for GetAllTransports to absorb sync=true bursts

### DIFF
--- a/pkg/transport-discovery/store/all_transports_cache.go
+++ b/pkg/transport-discovery/store/all_transports_cache.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+// allTransportsCache memoizes the result of GetAllTransports for a short
+// TTL. The function is hit on every register/deregister request that
+// includes ?sync=true (visors asking for a fresh full snapshot to
+// recompute local routes), and each call does a Redis SCAN over the
+// full tp:* keyspace plus an MGET of every transport key. With ~50
+// register/sec across the network, redis was spending ~390ms/sec in
+// SCAN alone after PRs #2334–#2341 — call rate was 35/s × 11ms each.
+//
+// The cache holds at most two slots — one per value of the
+// selfTransports filter. Within the TTL window, all sync=true callers
+// share the same snapshot. There is no explicit invalidation; the
+// snapshot can be up to TTL stale, which matches the consistency model
+// sync=true callers already accept (the canonical fanout is the DHT
+// mirror, which fires immediately on register; sync=true is a
+// secondary snapshot path).
+type allTransportsCache struct {
+	mu  sync.RWMutex
+	ttl time.Duration
+
+	withSelf    allTransportsCacheEntry
+	withoutSelf allTransportsCacheEntry
+}
+
+type allTransportsCacheEntry struct {
+	entries []*transport.Entry
+	expiry  time.Time
+}
+
+const defaultAllTransportsCacheTTL = 5 * time.Second
+
+func newAllTransportsCache(ttl time.Duration) *allTransportsCache {
+	if ttl <= 0 {
+		ttl = defaultAllTransportsCacheTTL
+	}
+	return &allTransportsCache{ttl: ttl}
+}
+
+// Get returns the cached entries for the given selfTransports filter
+// if the slot holds an unexpired snapshot. The returned slice is the
+// cache's own backing array — callers must not modify it.
+func (c *allTransportsCache) Get(selfTransports bool) ([]*transport.Entry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e := c.slot(selfTransports)
+	if e.entries == nil || time.Now().After(e.expiry) {
+		return nil, false
+	}
+	return e.entries, true
+}
+
+// Put stores entries for the given selfTransports filter with the
+// cache's configured TTL.
+func (c *allTransportsCache) Put(selfTransports bool, entries []*transport.Entry) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e := allTransportsCacheEntry{entries: entries, expiry: time.Now().Add(c.ttl)}
+	if selfTransports {
+		c.withSelf = e
+	} else {
+		c.withoutSelf = e
+	}
+}
+
+func (c *allTransportsCache) slot(selfTransports bool) allTransportsCacheEntry {
+	if selfTransports {
+		return c.withSelf
+	}
+	return c.withoutSelf
+}

--- a/pkg/transport-discovery/store/all_transports_cache_test.go
+++ b/pkg/transport-discovery/store/all_transports_cache_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/transport"
+)
+
+func TestAllTransportsCache_HitMissExpiry(t *testing.T) {
+	c := newAllTransportsCache(50 * time.Millisecond)
+
+	if _, ok := c.Get(true); ok {
+		t.Fatal("expected miss on empty cache (selfTransports=true)")
+	}
+	if _, ok := c.Get(false); ok {
+		t.Fatal("expected miss on empty cache (selfTransports=false)")
+	}
+
+	withSelf := []*transport.Entry{{}, {}}
+	withoutSelf := []*transport.Entry{{}}
+
+	c.Put(true, withSelf)
+	c.Put(false, withoutSelf)
+
+	if got, ok := c.Get(true); !ok || len(got) != 2 {
+		t.Fatalf("expected hit with 2 entries for selfTransports=true, got ok=%v len=%d", ok, len(got))
+	}
+	if got, ok := c.Get(false); !ok || len(got) != 1 {
+		t.Fatalf("expected hit with 1 entry for selfTransports=false, got ok=%v len=%d", ok, len(got))
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if _, ok := c.Get(true); ok {
+		t.Fatal("expected miss after TTL expiry (selfTransports=true)")
+	}
+	if _, ok := c.Get(false); ok {
+		t.Fatal("expected miss after TTL expiry (selfTransports=false)")
+	}
+}
+
+func TestAllTransportsCache_SlotsIndependent(t *testing.T) {
+	c := newAllTransportsCache(time.Hour)
+	c.Put(true, []*transport.Entry{{}})
+
+	if _, ok := c.Get(false); ok {
+		t.Fatal("Put(true) must not populate Get(false) slot")
+	}
+	if _, ok := c.Get(true); !ok {
+		t.Fatal("Put(true) must populate Get(true) slot")
+	}
+}

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -40,11 +40,12 @@ type TransportData struct {
 }
 
 type redisStore struct {
-	client    *redis.Client
-	ttl       time.Duration
-	log       *logging.Logger
-	pkCache   *pubKeyCache
-	edgeCache *edgeEntriesCache
+	client       *redis.Client
+	ttl          time.Duration
+	log          *logging.Logger
+	pkCache      *pubKeyCache
+	edgeCache    *edgeEntriesCache
+	allTpsCache  *allTransportsCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -79,11 +80,12 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 	}
 
 	return &redisStore{
-		client:    redisCl,
-		ttl:       ttl,
-		log:       logger,
-		pkCache:   newPubKeyCache(defaultPubKeyCacheCap),
-		edgeCache: newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
+		client:      redisCl,
+		ttl:         ttl,
+		log:         logger,
+		pkCache:     newPubKeyCache(defaultPubKeyCacheCap),
+		edgeCache:   newEdgeEntriesCache(defaultEdgeEntriesCacheCap, defaultEdgeEntriesCacheTTL),
+		allTpsCache: newAllTransportsCache(defaultAllTransportsCacheTTL),
 	}, nil
 }
 
@@ -421,7 +423,15 @@ func (s *redisStore) GetNumberOfTransports(ctx context.Context) (map[types.Type]
 }
 
 func (s *redisStore) GetAllTransports(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
-	return s.scanAllTransports(ctx, selfTransports, false)
+	if entries, ok := s.allTpsCache.Get(selfTransports); ok {
+		return entries, nil
+	}
+	entries, err := s.scanAllTransports(ctx, selfTransports, false)
+	if err != nil {
+		return nil, err
+	}
+	s.allTpsCache.Put(selfTransports, entries)
+	return entries, nil
 }
 
 // getAllTransportsWithQoS returns all transports including QoS metrics.

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -40,12 +40,12 @@ type TransportData struct {
 }
 
 type redisStore struct {
-	client       *redis.Client
-	ttl          time.Duration
-	log          *logging.Logger
-	pkCache      *pubKeyCache
-	edgeCache    *edgeEntriesCache
-	allTpsCache  *allTransportsCache
+	client      *redis.Client
+	ttl         time.Duration
+	log         *logging.Logger
+	pkCache     *pubKeyCache
+	edgeCache   *edgeEntriesCache
+	allTpsCache *allTransportsCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {


### PR DESCRIPTION
## Summary

Register endpoints accept \`?sync=true\` to ask for the full transport snapshot in the response (visors recompute local routes from it). Each call goes through \`store.GetAllTransports\` which does a Redis SCAN over the \`tp:*\` keyspace + MGET of every transport key.

After today's perf wave (#2338, #2339, #2340, #2341) eliminated the SD \`isServiceOnline\` SCAN noise, redis CPU stayed at ~68 % under steady load. Tracing the remaining hotspot in \`INFO commandstats\`:

| | Pre-merge (1370 s) | Post-merge (441 s) |
|---|---:|---:|
| SCAN call rate | 3316 /s | **35.5 /s** |
| µs / call | 99 | **11 074** |
| **SCAN CPU rate** | 330 ms / s | **393 ms / s** |
| MGET calls/s | 234 | 175 |

The big-COUNT SCANs (`COUNT=10000`) from \`scanAllTransports\` were always there but were drowned out by the SD volume. Now they're the dominant load — and they're firing 35×/sec because every \`?sync=true\` register triggers one.

## Fix

Add a 5-second TTL cache with two slots (one per \`selfTransports\` value) at the store level. \`GetAllTransports\` consults it first; on miss, does the full SCAN+MGET and populates. A burst of N concurrent registers within the TTL collapses to one SCAN+MGET instead of N.

## No invalidation

Deliberately omitted. \`?sync=true\` callers already accept that the DHT mirror is the source of truth for fresh data — \`mirrorEdges\` (the per-edge DHT publish) fires immediately on every register and gives the same visor an immediate update of its own touched edges. The sync=true response is a secondary snapshot path. A 5-second cache window is well below the visor's 90-second re-register cadence.

If future correctness considerations require it, invalidation would just be a per-edge \`Invalidate\` call after each successful register/deregister (same shape as the edge cache from #2340).

## Out of scope

Listing endpoints (\`getAllTransports\` / \`Stats\` / \`PerKeyStats\` in \`endpoints.go\`) already consult \`api.transportsCache\` and only fall through to \`GetAllTransports\` on cold start, so they don't drive the redis SCAN load. \`getAllTransportsWithQoS\` is a separate code path used by metrics functions; not cached here. The 30-second \`refreshTransportsCache\` loop will get a free hit if the sync=true path warmed the slot in the same window — bonus, not a goal.

## Test plan

- [x] \`go build ./pkg/transport-discovery/...\` clean
- [x] \`go vet ./pkg/transport-discovery/...\` clean
- [x] \`go test ./pkg/transport-discovery/store/...\` — all existing tests pass
- [x] Two new unit tests (TTL hit/miss/expiry, slot independence)
- [ ] Deploy and re-capture redis \`INFO commandstats\` — expect SCAN call rate to drop from ~35 /s to under 1 /s, redis container CPU to drop noticeably from ~68 % to roughly ~30-40 %.