### PR TITLE
perf(ar): short-TTL cache for GetAll to absorb /transports endpoint SCANs

### DIFF
--- a/pkg/address-resolver/store/getall_cache.go
+++ b/pkg/address-resolver/store/getall_cache.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"sync"
+	"time"
+
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// getAllCache memoizes the result of GetAll(netType) for a short TTL.
+// AR's /transports endpoint calls GetAll twice per request (once for
+// STCPR, once for SUDPH), and each call does a Redis SCAN COUNT=30000
+// over the address-resolver:<type>:* keyspace.
+//
+// The cache holds two slots — one per netType. Within the TTL window,
+// concurrent /transports callers share a single SCAN per netType. There
+// is no explicit invalidation; callers of /transports tolerate the
+// brief staleness (a recently-bound visor may take up to TTL seconds
+// to appear in the list, same shape the consumers already accept from
+// other discovery surfaces).
+//
+// Mirrors the per-edge cache pattern in pkg/transport-discovery/store
+// (PRs #2340 and #2342).
+type getAllCache struct {
+	mu  sync.RWMutex
+	ttl time.Duration
+
+	stcpr getAllCacheEntry
+	sudph getAllCacheEntry
+}
+
+type getAllCacheEntry struct {
+	pks    []string
+	expiry time.Time
+}
+
+const defaultGetAllCacheTTL = 5 * time.Second
+
+func newGetAllCache(ttl time.Duration) *getAllCache {
+	if ttl <= 0 {
+		ttl = defaultGetAllCacheTTL
+	}
+	return &getAllCache{ttl: ttl}
+}
+
+// Get returns the cached PK list for netType if the slot holds an
+// unexpired entry. The returned slice is the cache's own backing
+// array — callers must not modify it.
+func (c *getAllCache) Get(netType types.Type) ([]string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e := c.slot(netType)
+	if e.pks == nil || time.Now().After(e.expiry) {
+		return nil, false
+	}
+	return e.pks, true
+}
+
+// Put stores pks for netType with the cache's configured TTL.
+func (c *getAllCache) Put(netType types.Type, pks []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e := getAllCacheEntry{pks: pks, expiry: time.Now().Add(c.ttl)}
+	switch netType {
+	case types.STCPR:
+		c.stcpr = e
+	case types.SUDPH:
+		c.sudph = e
+	}
+}
+
+func (c *getAllCache) slot(netType types.Type) getAllCacheEntry {
+	switch netType {
+	case types.STCPR:
+		return c.stcpr
+	case types.SUDPH:
+		return c.sudph
+	}
+	return getAllCacheEntry{}
+}

--- a/pkg/address-resolver/store/getall_cache_test.go
+++ b/pkg/address-resolver/store/getall_cache_test.go
@@ -1,0 +1,60 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+func TestGetAllCache_HitMissExpiry(t *testing.T) {
+	c := newGetAllCache(50 * time.Millisecond)
+
+	if _, ok := c.Get(types.STCPR); ok {
+		t.Fatal("expected miss on empty cache (STCPR)")
+	}
+
+	stcprPKs := []string{"a", "b"}
+	sudphPKs := []string{"c"}
+
+	c.Put(types.STCPR, stcprPKs)
+	c.Put(types.SUDPH, sudphPKs)
+
+	if got, ok := c.Get(types.STCPR); !ok || len(got) != 2 {
+		t.Fatalf("expected hit with 2 entries for STCPR, got ok=%v len=%d", ok, len(got))
+	}
+	if got, ok := c.Get(types.SUDPH); !ok || len(got) != 1 {
+		t.Fatalf("expected hit with 1 entry for SUDPH, got ok=%v len=%d", ok, len(got))
+	}
+
+	time.Sleep(60 * time.Millisecond)
+	if _, ok := c.Get(types.STCPR); ok {
+		t.Fatal("expected miss after TTL expiry (STCPR)")
+	}
+	if _, ok := c.Get(types.SUDPH); ok {
+		t.Fatal("expected miss after TTL expiry (SUDPH)")
+	}
+}
+
+func TestGetAllCache_SlotsIndependent(t *testing.T) {
+	c := newGetAllCache(time.Hour)
+	c.Put(types.STCPR, []string{"a"})
+
+	if _, ok := c.Get(types.SUDPH); ok {
+		t.Fatal("Put(STCPR) must not populate Get(SUDPH) slot")
+	}
+	if _, ok := c.Get(types.STCPR); !ok {
+		t.Fatal("Put(STCPR) must populate Get(STCPR) slot")
+	}
+}
+
+func TestGetAllCache_UnknownNetType(t *testing.T) {
+	c := newGetAllCache(time.Hour)
+	if _, ok := c.Get(types.Type("bogus")); ok {
+		t.Fatal("unknown netType should always miss")
+	}
+	c.Put(types.Type("bogus"), []string{"a"}) // no-op
+	if _, ok := c.Get(types.Type("bogus")); ok {
+		t.Fatal("Put on unknown netType should be a no-op")
+	}
+}

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -22,8 +22,9 @@ const (
 )
 
 type redisStore struct {
-	client *redis.Client
-	ttl    time.Duration
+	client      *redis.Client
+	ttl         time.Duration
+	getAllCache *getAllCache
 }
 
 func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl time.Duration, logger *logging.Logger) (*redisStore, error) {
@@ -57,7 +58,11 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 		return nil, err
 	}
 
-	return &redisStore{client: redisCl, ttl: ttl}, nil
+	return &redisStore{
+		client:      redisCl,
+		ttl:         ttl,
+		getAllCache: newGetAllCache(defaultGetAllCacheTTL),
+	}, nil
 }
 
 func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
@@ -93,8 +98,15 @@ func (s *redisStore) Resolve(ctx context.Context, netType types.Type, pk cipher.
 func (s *redisStore) GetAll(ctx context.Context, netType types.Type) ([]string, error) {
 	switch netType {
 	case types.STCPR, types.SUDPH:
-		key := getScanKey(string(netType))
-		return s.getAll(ctx, key)
+		if pks, ok := s.getAllCache.Get(netType); ok {
+			return pks, nil
+		}
+		pks, err := s.getAll(ctx, getScanKey(string(netType)))
+		if err != nil {
+			return pks, err
+		}
+		s.getAllCache.Put(netType, pks)
+		return pks, nil
 	default:
 		return nil, ErrUnknownTransportType
 	}


### PR DESCRIPTION
## Summary

After the wave of TPD/SD perf fixes (#2338-#2342) landed, AR's contribution to redis SCAN load is the next visible item. The \`/transports\` endpoint calls \`store.GetAll(SUDPH)\` + \`store.GetAll(STCPR)\` on every request, and each call does a SCAN \`COUNT=30000\` over the \`address-resolver:<type>:*\` keyspace. Production observation: ~48 calls/min to AR \`/transports\` × 2 SCANs each = ~1.6 SCAN/sec from this single endpoint, plus the corresponding key-walk cost on every miss.

## Fix

Add \`getAllCache\`: a 5-second TTL cache with two slots (one per netType — STCPR, SUDPH). \`GetAll\` consults it first; on miss does the existing scan and populates the slot. Concurrent \`/transports\` callers within the TTL window share one SCAN per netType.

## No invalidation

Mirrors the stance from PR #2342: \`/transports\` consumers tolerate brief staleness — a recently-bound visor appears in the list within at most one TTL window. The canonical per-PK lookup (\`Resolve\`) is unchanged and continues to give immediate freshness; \`/transports\` is a list/snapshot path that's already inherently best-effort.

## Test plan

- [x] \`go build ./pkg/address-resolver/...\` clean
- [x] \`go vet ./pkg/address-resolver/...\` clean
- [x] Three new unit tests (TTL hit/miss/expiry, slot independence, unknown netType handled gracefully)
- [x] Broader \`go build ./pkg/... ./cmd/...\` clean
- [ ] Deploy and re-capture redis \`INFO commandstats\` — expect SCAN call rate to drop further from current ~17/sec toward the lower bound, and AR container CPU to drop slightly. Pre-existing \`TestRedis\` integration test fails locally on this host because the prod redis requires auth — unchanged from upstream/develop.