### PR TITLE
perf(tpd): extend allTransportsCache to cover getAllTransportsWithQoS

### DIFF
--- a/pkg/transport-discovery/store/all_transports_cache.go
+++ b/pkg/transport-discovery/store/all_transports_cache.go
@@ -7,27 +7,28 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 )
 
-// allTransportsCache memoizes the result of GetAllTransports for a short
-// TTL. The function is hit on every register/deregister request that
-// includes ?sync=true (visors asking for a fresh full snapshot to
-// recompute local routes), and each call does a Redis SCAN over the
-// full tp:* keyspace plus an MGET of every transport key. With ~50
-// register/sec across the network, redis was spending ~390ms/sec in
-// SCAN alone after PRs #2334–#2341 — call rate was 35/s × 11ms each.
+// allTransportsCache memoizes the result of GetAllTransports and
+// getAllTransportsWithQoS for a short TTL. The plain variant is hit on
+// every register/deregister request with ?sync=true; the WithQoS
+// variant is hit on every metrics scrape (Prometheus / Victoria Metrics
+// pulling /metrics/network, /metrics/visors, etc.). Both do a Redis
+// SCAN over the full tp:* keyspace plus an MGET of every transport
+// key.
 //
-// The cache holds at most two slots — one per value of the
-// selfTransports filter. Within the TTL window, all sync=true callers
-// share the same snapshot. There is no explicit invalidation; the
-// snapshot can be up to TTL stale, which matches the consistency model
-// sync=true callers already accept (the canonical fanout is the DHT
-// mirror, which fires immediately on register; sync=true is a
-// secondary snapshot path).
+// The cache holds four slots: {selfTransports} × {withQoS}. Within the
+// TTL window, all callers of a given variant share the same snapshot.
+// There is no explicit invalidation; the snapshot can be up to TTL
+// stale, which matches the consistency model these callers already
+// accept (sync=true clients get fresh data via the DHT mirror; metrics
+// scrapers tolerate any sub-scrape-interval delay).
 type allTransportsCache struct {
 	mu  sync.RWMutex
 	ttl time.Duration
 
-	withSelf    allTransportsCacheEntry
-	withoutSelf allTransportsCacheEntry
+	withSelf       allTransportsCacheEntry
+	withoutSelf    allTransportsCacheEntry
+	withSelfQoS    allTransportsCacheEntry
+	withoutSelfQoS allTransportsCacheEntry
 }
 
 type allTransportsCacheEntry struct {
@@ -44,35 +45,45 @@ func newAllTransportsCache(ttl time.Duration) *allTransportsCache {
 	return &allTransportsCache{ttl: ttl}
 }
 
-// Get returns the cached entries for the given selfTransports filter
-// if the slot holds an unexpired snapshot. The returned slice is the
-// cache's own backing array — callers must not modify it.
-func (c *allTransportsCache) Get(selfTransports bool) ([]*transport.Entry, bool) {
+// Get returns the cached entries for the given filters if the slot
+// holds an unexpired snapshot. The returned slice is the cache's own
+// backing array — callers must not modify it.
+func (c *allTransportsCache) Get(selfTransports, withQoS bool) ([]*transport.Entry, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	e := c.slot(selfTransports)
+	e := c.slot(selfTransports, withQoS)
 	if e.entries == nil || time.Now().After(e.expiry) {
 		return nil, false
 	}
 	return e.entries, true
 }
 
-// Put stores entries for the given selfTransports filter with the
-// cache's configured TTL.
-func (c *allTransportsCache) Put(selfTransports bool, entries []*transport.Entry) {
+// Put stores entries for the given filters with the cache's configured TTL.
+func (c *allTransportsCache) Put(selfTransports, withQoS bool, entries []*transport.Entry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	e := allTransportsCacheEntry{entries: entries, expiry: time.Now().Add(c.ttl)}
-	if selfTransports {
+	switch {
+	case selfTransports && withQoS:
+		c.withSelfQoS = e
+	case !selfTransports && withQoS:
+		c.withoutSelfQoS = e
+	case selfTransports && !withQoS:
 		c.withSelf = e
-	} else {
+	default:
 		c.withoutSelf = e
 	}
 }
 
-func (c *allTransportsCache) slot(selfTransports bool) allTransportsCacheEntry {
-	if selfTransports {
+func (c *allTransportsCache) slot(selfTransports, withQoS bool) allTransportsCacheEntry {
+	switch {
+	case selfTransports && withQoS:
+		return c.withSelfQoS
+	case !selfTransports && withQoS:
+		return c.withoutSelfQoS
+	case selfTransports && !withQoS:
 		return c.withSelf
+	default:
+		return c.withoutSelf
 	}
-	return c.withoutSelf
 }

--- a/pkg/transport-discovery/store/all_transports_cache_test.go
+++ b/pkg/transport-discovery/store/all_transports_cache_test.go
@@ -10,43 +10,60 @@ import (
 func TestAllTransportsCache_HitMissExpiry(t *testing.T) {
 	c := newAllTransportsCache(50 * time.Millisecond)
 
-	if _, ok := c.Get(true); ok {
-		t.Fatal("expected miss on empty cache (selfTransports=true)")
-	}
-	if _, ok := c.Get(false); ok {
-		t.Fatal("expected miss on empty cache (selfTransports=false)")
+	for _, withQoS := range []bool{false, true} {
+		for _, selfTps := range []bool{false, true} {
+			if _, ok := c.Get(selfTps, withQoS); ok {
+				t.Fatalf("expected miss on empty cache (self=%v qos=%v)", selfTps, withQoS)
+			}
+		}
 	}
 
 	withSelf := []*transport.Entry{{}, {}}
 	withoutSelf := []*transport.Entry{{}}
+	withSelfQoS := []*transport.Entry{{}, {}, {}}
+	withoutSelfQoS := []*transport.Entry{{}, {}, {}, {}}
 
-	c.Put(true, withSelf)
-	c.Put(false, withoutSelf)
+	c.Put(true, false, withSelf)
+	c.Put(false, false, withoutSelf)
+	c.Put(true, true, withSelfQoS)
+	c.Put(false, true, withoutSelfQoS)
 
-	if got, ok := c.Get(true); !ok || len(got) != 2 {
-		t.Fatalf("expected hit with 2 entries for selfTransports=true, got ok=%v len=%d", ok, len(got))
+	cases := []struct {
+		self, qos bool
+		want      int
+	}{
+		{true, false, 2},
+		{false, false, 1},
+		{true, true, 3},
+		{false, true, 4},
 	}
-	if got, ok := c.Get(false); !ok || len(got) != 1 {
-		t.Fatalf("expected hit with 1 entry for selfTransports=false, got ok=%v len=%d", ok, len(got))
+	for _, tc := range cases {
+		got, ok := c.Get(tc.self, tc.qos)
+		if !ok || len(got) != tc.want {
+			t.Fatalf("self=%v qos=%v: expected hit with %d entries, got ok=%v len=%d",
+				tc.self, tc.qos, tc.want, ok, len(got))
+		}
 	}
 
 	time.Sleep(60 * time.Millisecond)
-	if _, ok := c.Get(true); ok {
-		t.Fatal("expected miss after TTL expiry (selfTransports=true)")
-	}
-	if _, ok := c.Get(false); ok {
-		t.Fatal("expected miss after TTL expiry (selfTransports=false)")
+	for _, tc := range cases {
+		if _, ok := c.Get(tc.self, tc.qos); ok {
+			t.Fatalf("self=%v qos=%v: expected miss after TTL expiry", tc.self, tc.qos)
+		}
 	}
 }
 
 func TestAllTransportsCache_SlotsIndependent(t *testing.T) {
 	c := newAllTransportsCache(time.Hour)
-	c.Put(true, []*transport.Entry{{}})
+	c.Put(true, false, []*transport.Entry{{}})
 
-	if _, ok := c.Get(false); ok {
-		t.Fatal("Put(true) must not populate Get(false) slot")
+	if _, ok := c.Get(false, false); ok {
+		t.Fatal("Put(true,false) must not populate Get(false,false)")
 	}
-	if _, ok := c.Get(true); !ok {
-		t.Fatal("Put(true) must populate Get(true) slot")
+	if _, ok := c.Get(true, true); ok {
+		t.Fatal("Put(true,false) must not populate Get(true,true) (different qos)")
+	}
+	if _, ok := c.Get(true, false); !ok {
+		t.Fatal("Put(true,false) must populate Get(true,false)")
 	}
 }

--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -423,21 +423,32 @@ func (s *redisStore) GetNumberOfTransports(ctx context.Context) (map[types.Type]
 }
 
 func (s *redisStore) GetAllTransports(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
-	if entries, ok := s.allTpsCache.Get(selfTransports); ok {
+	if entries, ok := s.allTpsCache.Get(selfTransports, false); ok {
 		return entries, nil
 	}
 	entries, err := s.scanAllTransports(ctx, selfTransports, false)
 	if err != nil {
 		return nil, err
 	}
-	s.allTpsCache.Put(selfTransports, entries)
+	s.allTpsCache.Put(selfTransports, false, entries)
 	return entries, nil
 }
 
 // getAllTransportsWithQoS returns all transports including QoS metrics.
 // Used internally by metrics functions that need bandwidth/latency data.
+// Cached with the same TTL+slot scheme as GetAllTransports — metrics
+// scrapers (Prometheus / Victoria Metrics) hit these endpoints on a
+// regular cadence and were paying a full SCAN+MGET each time.
 func (s *redisStore) getAllTransportsWithQoS(ctx context.Context, selfTransports bool) ([]*transport.Entry, error) {
-	return s.scanAllTransports(ctx, selfTransports, true)
+	if entries, ok := s.allTpsCache.Get(selfTransports, true); ok {
+		return entries, nil
+	}
+	entries, err := s.scanAllTransports(ctx, selfTransports, true)
+	if err != nil {
+		return nil, err
+	}
+	s.allTpsCache.Put(selfTransports, true, entries)
+	return entries, nil
 }
 
 // scanAllTransports is the shared implementation for GetAllTransports and getAllTransportsWithQoS.


### PR DESCRIPTION
## Summary

PR #2342 cached \`GetAllTransports\` to absorb \`?sync=true\` register bursts. The WithQoS variant — used by the metrics endpoints (Prometheus / Victoria Metrics scrape \`/metrics/network\`, \`/metrics/visors\`, \`/metrics/transports/*\`, \`/metrics/aggregate\`) — still hit \`scanAllTransports\` directly and is the next visible SCAN driver after #2342 deployed.

## Fix

Extend the existing cache from 2 slots to 4: \`{selfTransports} × {withQoS}\`. Same 5-second TTL, same no-invalidation stance — metrics scrapers tolerate sub-scrape-interval staleness, the canonical per-PK / per-edge lookups are unaffected.

\`getAllTransportsWithQoS\` now consults the cache first; on miss does the existing SCAN+MGET and populates.

## Test plan

- [x] \`go build ./pkg/transport-discovery/...\` clean
- [x] \`go vet ./pkg/transport-discovery/...\` clean
- [x] Existing tests pass; new test covers all four slots independently
- [ ] Deploy and re-capture redis \`INFO commandstats\` — expect SCAN call rate to drop from ~7-10 /s toward ~1-2 /s; metrics endpoint p99 should improve since cache hits are O(1).