### PR TITLE
perf(ar): replace GetAll SCAN with SMEMBERS on a per-netType index set

### DIFF
--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -213,11 +213,11 @@ func (s *redisStore) getAllFromIndex(ctx context.Context, netType types.Type) ([
 		// Fire-and-forget: stale members will get cleaned on the next
 		// read regardless, but doing it now keeps the index from
 		// growing unbounded under churn. context.Background is
-		// intentional — the request ctx may be cancelled by the time
+		// intentional — the request ctx may be canceled by the time
 		// this runs, and the cleanup is bounded (single SREM with a
 		// small stale slice).
-		go func() {
-			s.client.SRem(context.Background(), idx, stale...) //nolint:errcheck,gosec
+		go func() { //nolint:gosec // intentional bg ctx, see comment above
+			s.client.SRem(context.Background(), idx, stale...) //nolint:errcheck
 		}()
 	}
 

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -212,9 +212,12 @@ func (s *redisStore) getAllFromIndex(ctx context.Context, netType types.Type) ([
 	if len(stale) > 0 {
 		// Fire-and-forget: stale members will get cleaned on the next
 		// read regardless, but doing it now keeps the index from
-		// growing unbounded under churn.
+		// growing unbounded under churn. context.Background is
+		// intentional — the request ctx may be cancelled by the time
+		// this runs, and the cleanup is bounded (single SREM with a
+		// small stale slice).
 		go func() {
-			s.client.SRem(context.Background(), idx, stale...) //nolint:errcheck
+			s.client.SRem(context.Background(), idx, stale...) //nolint:errcheck,gosec
 		}()
 	}
 

--- a/pkg/address-resolver/store/redis_store.go
+++ b/pkg/address-resolver/store/redis_store.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -68,8 +67,7 @@ func newRedisStore(ctx context.Context, addr, password string, poolSize int, ttl
 func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
 	switch netType {
 	case types.STCPR, types.SUDPH:
-		key := getKey(string(netType), pk)
-		return s.bind(ctx, key, visorData)
+		return s.bindWithIndex(ctx, netType, pk, visorData)
 	default:
 		return ErrUnknownTransportType
 	}
@@ -78,8 +76,7 @@ func (s *redisStore) Bind(ctx context.Context, netType types.Type, pk cipher.Pub
 func (s *redisStore) DelBind(ctx context.Context, netType types.Type, pk cipher.PubKey) error {
 	switch netType {
 	case types.STCPR, types.SUDPH:
-		key := getKey(string(netType), pk)
-		return s.delBind(ctx, key)
+		return s.delBindWithIndex(ctx, netType, pk)
 	default:
 		return ErrUnknownTransportType
 	}
@@ -101,7 +98,7 @@ func (s *redisStore) GetAll(ctx context.Context, netType types.Type) ([]string, 
 		if pks, ok := s.getAllCache.Get(netType); ok {
 			return pks, nil
 		}
-		pks, err := s.getAll(ctx, getScanKey(string(netType)))
+		pks, err := s.getAllFromIndex(ctx, netType)
 		if err != nil {
 			return pks, err
 		}
@@ -110,35 +107,6 @@ func (s *redisStore) GetAll(ctx context.Context, netType types.Type) ([]string, 
 	default:
 		return nil, ErrUnknownTransportType
 	}
-}
-
-func (s *redisStore) bind(ctx context.Context, key string, visorData addrresolver.VisorData) error {
-	raw, err := json.Marshal(visorData)
-	if err != nil {
-		return err
-	}
-
-	// Always apply TTL so stale bindings expire when clients stop
-	// re-registering. The prior behavior skipped TTL on first-time
-	// bindings "for backward compatibility with old visors", which
-	// let crashed / offline clients leave infinite-lifetime entries
-	// in Redis — same anti-pattern as the dmsg-discovery bug fixed
-	// in #2305. Clients refresh their STCPR/SUDPH binding every
-	// 90s (see sudphReRegisterInterval in addrresolver/client.go),
-	// so a TTL >= ~2× refresh (configured via --entry-timeout,
-	// default 5m) gives safe margin for dropped or slow refreshes.
-	if _, err := s.client.Set(ctx, key, string(raw), s.ttl).Result(); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *redisStore) delBind(ctx context.Context, key string) error {
-	if _, err := s.client.Del(ctx, key).Result(); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (s *redisStore) resolve(ctx context.Context, key string) (addrresolver.VisorData, error) {
@@ -159,29 +127,104 @@ func (s *redisStore) resolve(ctx context.Context, key string) (addrresolver.Viso
 	return data, nil
 }
 
-func (s *redisStore) getAll(ctx context.Context, key string) ([]string, error) {
-	var pks []string
-	var cursor uint64
-	// todo(erichkaestner): return to reasonable batch size
-	// after the old keys are cleaned out by network-monitor
-	iter := s.client.Scan(ctx, cursor, key, 30000).Iterator()
+// bindWithIndex pipelines the per-PK Set with an SAdd to the per-netType
+// index set. The SAdd is idempotent on re-bind (90 s refresh cadence), so
+// the index converges to the live set without explicit dedup.
+func (s *redisStore) bindWithIndex(ctx context.Context, netType types.Type, pk cipher.PubKey, visorData addrresolver.VisorData) error {
+	raw, err := json.Marshal(visorData)
+	if err != nil {
+		return err
+	}
+	pipe := s.client.Pipeline()
+	pipe.Set(ctx, getKey(string(netType), pk), string(raw), s.ttl)
+	pipe.SAdd(ctx, indexKey(string(netType)), pk.String())
+	_, err = pipe.Exec(ctx)
+	return err
+}
 
-	for iter.Next(ctx) {
-		key := strings.Split(iter.Val(), ":")
-		pks = append(pks, key[2])
+// delBindWithIndex pipelines the per-PK Del with an SRem from the
+// per-netType index set so the index doesn't keep stale members after
+// an explicit deregister.
+func (s *redisStore) delBindWithIndex(ctx context.Context, netType types.Type, pk cipher.PubKey) error {
+	pipe := s.client.Pipeline()
+	pipe.Del(ctx, getKey(string(netType), pk))
+	pipe.SRem(ctx, indexKey(string(netType)), pk.String())
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+// getAllFromIndex reads the per-netType index set, then verifies each
+// member's primary key still exists (TTL-evicted bindings can leave
+// stale members behind when a visor crashes without DelBind). Stale
+// members are SREM'd asynchronously so the next read is clean —
+// mirrors the lazy-SREM pattern in pkg/service-discovery's ServicesByPK
+// and the SD index lookup added in #2339.
+//
+// Replaces the old SCAN COUNT=30000 over address-resolver:<type>:* —
+// at ~150K total redis keys, the SCAN was the largest source of redis
+// CPU on AR's host even after the cache from #2343 collapsed bursts.
+func (s *redisStore) getAllFromIndex(ctx context.Context, netType types.Type) ([]string, error) {
+	idx := indexKey(string(netType))
+	members, err := s.client.SMembers(ctx, idx).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(members) == 0 {
+		return nil, nil
 	}
 
-	if err := iter.Err(); err != nil {
-		return pks, err
+	keys := make([]string, len(members))
+	for i, m := range members {
+		keys[i] = fmt.Sprintf("%s:%s:%s", serviceName, netType, m)
 	}
 
-	return pks, nil
+	const existsBatch = 256
+	live := make([]string, 0, len(members))
+	var stale []interface{}
+	for i := 0; i < len(keys); i += existsBatch {
+		end := i + existsBatch
+		if end > len(keys) {
+			end = len(keys)
+		}
+		batchKeys := keys[i:end]
+		batchPKs := members[i:end]
+		// Issue one EXISTS per key in a pipeline so we can tell which
+		// individual keys are missing (multi-key EXISTS only returns a
+		// count). EXISTS is O(1) per key; the pipeline batches them
+		// into a single round-trip.
+		pipe := s.client.Pipeline()
+		cmds := make([]*redis.IntCmd, len(batchKeys))
+		for j, k := range batchKeys {
+			cmds[j] = pipe.Exists(ctx, k)
+		}
+		if _, err := pipe.Exec(ctx); err != nil {
+			return live, err
+		}
+		for j, c := range cmds {
+			if c.Val() == 1 {
+				live = append(live, batchPKs[j])
+			} else {
+				stale = append(stale, batchPKs[j])
+			}
+		}
+	}
+
+	if len(stale) > 0 {
+		// Fire-and-forget: stale members will get cleaned on the next
+		// read regardless, but doing it now keeps the index from
+		// growing unbounded under churn.
+		go func() {
+			s.client.SRem(context.Background(), idx, stale...) //nolint:errcheck
+		}()
+	}
+
+	return live, nil
 }
 
 func getKey(kind string, pk cipher.PubKey) string {
 	return fmt.Sprintf("%s:%s:%s", serviceName, kind, pk.String())
 }
 
-func getScanKey(kind string) string {
-	return fmt.Sprintf("%s:%s*", serviceName, kind)
+func indexKey(kind string) string {
+	return fmt.Sprintf("%s:%s:_index", serviceName, kind)
 }


### PR DESCRIPTION
## Summary

\`GetAll\` walked the \`address-resolver:<type>:*\` keyspace via SCAN \`COUNT=30000\` to enumerate registered visors for the \`/transports\` endpoint. PR #2343 added a 5s cache to absorb \`/transports\` request bursts, but each cache miss still paid the full SCAN over ~150K redis keys.

## Fix

Maintain a per-netType index SET: \`address-resolver:<type>:_index\`.

- \`Bind\` pipelines the SET with an SADD on the index.
- \`DelBind\` pipelines the DEL with an SREM on the index.
- \`GetAll\` now reads SMEMBERS of the index, then verifies each member's primary key still exists in a pipelined batch — TTL-evicted bindings without DelBind leave stale members, cleaned lazily via fire-and-forget SREM. Mirrors SD's #2339 lazy-cleanup pattern.

Trade SCAN \`COUNT=30000\` (one full keyspace walk per call) for SMEMBERS + N batched EXISTS — O(live PKs) instead of O(total keyspace).

## Layering

The cache from #2343 stays as a layer on top — hot reads hit the cache; misses hit the index set. Both correctness and perf improve, no regression.

## Test plan

- [x] \`go build ./pkg/address-resolver/...\` clean
- [x] \`go vet ./pkg/address-resolver/...\` clean
- [x] Existing \`getAllCache\` tests pass
- [ ] Pre-existing \`TestRedis\` integration test fails locally because the prod redis on this host requires auth — unchanged from upstream/develop.
- [ ] Deploy and re-capture \`INFO commandstats\`. Expect the \`address-resolver:<type>:*\` SCAN contribution to drop to zero. Existing AR keys without an index entry will be picked up on the next \`Bind\` from each visor (90s TTL refresh cycle); a one-shot backfill script could prepopulate the index from the existing keys, but isn't required for correctness — the index converges naturally.