### PR TITLE
fix: DHT seq monotonicity + self-probe /ping → /health

### DIFF
--- a/pkg/dht/tpd_adapter.go
+++ b/pkg/dht/tpd_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -65,13 +66,12 @@ func (d *TPDAdapter) putEntries(ctx context.Context, entries []*transport.Signed
 	if len(data) > MaxValueSize {
 		return fmt.Errorf("dht tpd: transport list too large (%d bytes, max %d)", len(data), MaxValueSize)
 	}
-	// Use a rolling sequence number based on the entry count to ensure monotonic increase.
-	seq := uint64(len(entries))
-	for _, e := range entries {
-		if e.Entry != nil {
-			seq += e.Entry.Bandwidth // use cumulative bandwidth as a proxy for freshness
-		}
-	}
+	// Wall-clock nanoseconds as monotonic seq generator. Survives restarts
+	// (in-memory entry counts and bandwidth totals do not) and is virtually
+	// guaranteed to climb past whatever peers cached for our PK previously.
+	// On clock skew the DHT layer's per-peer rejection still keeps things
+	// safe — we'll catch up next tick.
+	seq := uint64(time.Now().UnixNano())
 	return d.node.Put(ctx, data, seq, tpSalt)
 }
 

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -172,12 +172,20 @@ func dhtPublishLoop(ctx context.Context, v *Visor, node *dht.Node, log *logging.
 	case <-time.After(15 * time.Second):
 	}
 
-	// Start seq from the existing entry's seq + 1 so we always
-	// overtake what's in the DHT (even after restart).
-	seq := uint64(1)
-	target := dht.MutableItemTarget(v.conf.PK, []byte("dmsg"))
-	if existing := node.Store().Get(target); existing != nil {
-		seq = existing.Seq + 1
+	// Use wall-clock nanoseconds as a monotonic seq generator. This
+	// survives restarts (in-memory store reset) and is essentially
+	// guaranteed to overtake whatever the DHT has cached for our PK
+	// from a previous incarnation. We also cross-check against the
+	// network: if any peer reports a higher seq for our PK, climb
+	// above it (handles backwards clock skew + a peer that was last
+	// to receive our previous publish).
+	seq := uint64(time.Now().UnixNano())
+	for _, salt := range [][]byte{[]byte("dmsg"), []byte("tp")} {
+		queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		if got, err := node.Get(queryCtx, v.conf.PK, salt); err == nil && got != nil && got.Seq >= seq {
+			seq = got.Seq + 1
+		}
+		cancel()
 	}
 
 	ticker := time.NewTicker(60 * time.Second)

--- a/pkg/visor/init_selfprobe.go
+++ b/pkg/visor/init_selfprobe.go
@@ -160,10 +160,10 @@ func runSelfProbes(ctx context.Context, _ *Visor, dmsgC *dmsg.Client, log *loggi
 	// closes for untrusted — but the dial success confirms reachability.
 	results[skyenv.DmsgAwaitSetupPort] = probeRawDial(ctx, dmsgC, myPK, skyenv.DmsgAwaitSetupPort)
 
-	// Probe port 80 (dmsghttp log server) — HTTP GET /ping over dmsg.
+	// Probe port 80 (dmsghttp log server) — HTTP GET /health over dmsg.
 	// Uses the visor's own dmsg client to make an HTTP request through
-	// the server bridge back to itself. The /ping endpoint returns 200
-	// with no body — minimal overhead.
+	// the server bridge back to itself. /health is the lightest open
+	// endpoint on the log server (open to everyone, no auth required).
 	results[visorconfig.DmsgHTTPPort] = probeDmsgHTTP(ctx, dmsgC, myPK, log)
 
 	return results
@@ -176,7 +176,7 @@ func probeRawDial(ctx context.Context, dmsgC *dmsg.Client, pk cipher.PubKey, por
 	return dmsgC.Probe(probeCtx, pk, port)
 }
 
-// probeDmsgHTTP does an HTTP GET /ping over dmsg to the visor's own log server.
+// probeDmsgHTTP does an HTTP GET /health over dmsg to the visor's own log server.
 func probeDmsgHTTP(ctx context.Context, dmsgC *dmsg.Client, myPK cipher.PubKey, log *logging.Logger) bool {
 	probeCtx, cancel := context.WithTimeout(ctx, selfProbeTimeout)
 	defer cancel()
@@ -184,7 +184,7 @@ func probeDmsgHTTP(ctx context.Context, dmsgC *dmsg.Client, myPK cipher.PubKey, 
 	tr := dmsghttp.MakeHTTPTransport(probeCtx, dmsgC)
 	client := &http.Client{Transport: tr, Timeout: selfProbeTimeout}
 
-	url := fmt.Sprintf("dmsg://%s:%d/ping", myPK.Hex(), visorconfig.DmsgHTTPPort)
+	url := fmt.Sprintf("dmsg://%s:%d/health", myPK.Hex(), visorconfig.DmsgHTTPPort)
 	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, url, nil)
 	if err != nil {
 		log.WithError(err).Debug("Self-probe HTTP: failed to create request")


### PR DESCRIPTION
## Summary

Two unrelated but small fixes:

### DHT seq monotonicity (root cause of repeated \`PutValue failed: sequence number must increase\` debug logs)

Two places generated non-monotonic seq values:

- **\`pkg/visor/init_dht.go:dhtPublishLoop\`** seeded seq from the local in-memory store, which resets to empty on every visor restart. Result: seq starts at 1, peers still hold the high seq from the previous incarnation, every put rejected until seq climbs past it.
- **\`pkg/dht/tpd_adapter.go:putEntries\`** computed \`seq = entry_count + sum(entry.Bandwidth)\`. Bandwidth is in-memory (resets on restart), and removing a busy transport drops the sum.

Replace both with \`time.Now().UnixNano()\`. Aligns with the convention TPD (\`mirrorEdges\`, \`BackfillDHTMirror\`) and SD already use. On startup, \`dhtPublishLoop\` also queries the DHT for any higher seq under our PK and climbs above it (handles backwards clock skew + stale peer cache).

### Self-probe \`/ping\` → \`/health\`

The \`/ping\` endpoint was removed from the dmsghttp log server in #2317 (\"remove unused /ping endpoint from port 80 logserver\") but the self-probe in \`init_selfprobe.go:probeDmsgHTTP\` still hit it, getting 404s and reporting persistent \`dmsg listener unreachable\` false-positives despite the listener being healthy. Switch the probe to \`/health\` which is registered and open to everyone.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/dht/... ./pkg/visor\` pass
- [x] \`golangci-lint\` 0 issues
- [ ] On a long-running visor: confirm \`Self-probe FAILED: dmsg listener unreachable\` no longer fires
- [ ] On visor restart: confirm \`PutValue failed: ... sequence number must increase\` rate drops to ~0