### PR TITLE
geoip: visor uses embedded MMDB instead of querying ip.skycoin.com

### DIFF
--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -25,7 +27,6 @@ import (
 	services "github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cmdutil"
-	"github.com/skycoin/skywire/pkg/visor"
 )
 
 func init() {
@@ -123,7 +124,12 @@ var startCmd = &cobra.Command{
 					if state.Status == appserver.AppStatusRunning {
 						startProcess = false
 						internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintln("\nRunning!"))
-						ip, err := visor.GetIP(geoipURL)
+						// Query the configured geoip URL through the VPN to confirm
+						// the exit IP changed. The visor itself uses an embedded
+						// MaxMind database now; this is one of the few remaining
+						// HTTP queries to the geoip service — appropriate here
+						// because we specifically want to test the VPN exit path.
+						ip, err := fetchGeoIPAddr(geoipURL)
 						out := output{
 							CurrentIP: ip,
 						}
@@ -568,4 +574,26 @@ var listCmd = &cobra.Command{
 
 		script.Echo(joinedJSON).JQ(jqFilter).Replace(`"`, "").Stdout() //nolint:errcheck,gosec
 	},
+}
+
+// fetchGeoIPAddr does an HTTP GET to the geoip URL and returns the reported
+// public IP. Used by `vpn start` to confirm the VPN actually rerouted traffic.
+func fetchGeoIPAddr(url string) (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var r struct {
+		IP string `json:"ip_address"`
+	}
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", err
+	}
+	return r.IP, nil
 }

--- a/cmd/svc/geoip/commands/root.go
+++ b/cmd/svc/geoip/commands/root.go
@@ -3,7 +3,6 @@ package commands
 
 import (
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -22,17 +21,16 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tidwall/pretty"
 
+	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/metricsutil"
 )
 
-//go:embed GeoLite2-City.mmdb
-var embeddedGeoIP []byte
-
 // EmbeddedGeoIP returns the embedded GeoLite2-City database bytes.
+// Kept for backwards-compat: callers should prefer pkg/geoip.EmbeddedDB.
 func EmbeddedGeoIP() []byte {
-	return embeddedGeoIP
+	return geoip.EmbeddedDB()
 }
 
 // LookupResult holds a GeoIP lookup result.
@@ -159,7 +157,7 @@ Usage Examples:
 		} else {
 			// Use embedded database
 			logger.Info("Using embedded GeoIP database")
-			db, err = geoip2.OpenBytes(embeddedGeoIP)
+			db, err = geoip.OpenEmbedded()
 			if err != nil {
 				logger.Fatalf("failed to load embedded GeoIP database: %v", err)
 			}

--- a/pkg/geoip/geoip.go
+++ b/pkg/geoip/geoip.go
@@ -1,0 +1,87 @@
+// Package geoip embeds the MaxMind GeoLite2-City database and exposes
+// a lookup function. Used by the visor (for service-discovery
+// geolocation tagging without an HTTP round-trip to the geoip service)
+// and by `cmd/svc/geoip` (the standalone HTTP geoip service).
+package geoip
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"net/netip"
+
+	"github.com/oschwald/geoip2-golang/v2"
+)
+
+//go:embed GeoLite2-City.mmdb
+var embedded []byte
+
+// EmbeddedDB returns the raw bytes of the embedded GeoLite2-City database.
+// The standalone geoip service uses this when no external `--db` path is
+// configured; the visor uses this for in-process lookups.
+func EmbeddedDB() []byte {
+	return embedded
+}
+
+// Result is the schema returned by both the in-process Lookup and the
+// HTTP geoip service. The JSON tags match what `cmd/svc/geoip` returns
+// over HTTP so callers can swap between the two without conversion.
+type Result struct {
+	IP            string   `json:"ip_address"`
+	Latitude      *float64 `json:"latitude"`
+	Longitude     *float64 `json:"longitude"`
+	PostalCode    string   `json:"postal_code"`
+	ContinentCode string   `json:"continent_code"`
+	ContinentName string   `json:"continent_name"`
+	CountryCode   string   `json:"country_code"`
+	CountryName   string   `json:"country_name"`
+	RegionCode    string   `json:"region_code"`
+	RegionName    string   `json:"region_name"`
+	CityName      string   `json:"city_name"`
+	Timezone      string   `json:"timezone"`
+}
+
+// Lookup looks up an IP in the given database reader and returns a Result.
+func Lookup(db *geoip2.Reader, ipStr string) (*Result, error) {
+	if db == nil {
+		return nil, errors.New("geoip: database not initialized")
+	}
+	if ipStr == "" {
+		return nil, errors.New("geoip: empty IP")
+	}
+	addr, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		return nil, fmt.Errorf("geoip: invalid IP %q: %w", ipStr, err)
+	}
+
+	record, err := db.City(addr)
+	if err != nil {
+		return nil, fmt.Errorf("geoip: lookup: %w", err)
+	}
+
+	res := &Result{
+		IP:            ipStr,
+		PostalCode:    record.Postal.Code,
+		ContinentCode: record.Continent.Code,
+		ContinentName: record.Continent.Names.English,
+		CountryCode:   record.Country.ISOCode,
+		CountryName:   record.Country.Names.English,
+		CityName:      record.City.Names.English,
+		Timezone:      record.Location.TimeZone,
+	}
+	if record.Location.Latitude != nil && record.Location.Longitude != nil {
+		res.Latitude = record.Location.Latitude
+		res.Longitude = record.Location.Longitude
+	}
+	if len(record.Subdivisions) > 0 {
+		res.RegionCode = record.Subdivisions[0].ISOCode
+		res.RegionName = record.Subdivisions[0].Names.English
+	}
+	return res, nil
+}
+
+// OpenEmbedded returns a *geoip2.Reader backed by the embedded database.
+// Reuse the reader — it's safe for concurrent use.
+func OpenEmbedded() (*geoip2.Reader, error) {
+	return geoip2.OpenBytes(embedded)
+}

--- a/pkg/visor/api_visor.go
+++ b/pkg/visor/api_visor.go
@@ -47,18 +47,9 @@ func (v *Visor) Overview() (*Overview, error) {
 			isSymmetricNAT = false
 		case stun.NATSymmetric, stun.NATSymmetricUDPFirewall:
 			isSymmetricNAT = true
-			// Try to get IP from GeoIP service when STUN doesn't provide it
-			if ip, err := GetIP(v.conf.GeoIP); err == nil && ip != "" {
-				publicIP = ip
-			}
 		case stun.NATError, stun.NATUnknown, stun.NATBlocked:
 			isSymmetricNAT = false
-			// STUN failed, try GeoIP service as fallback
-			if ip, err := GetIP(v.conf.GeoIP); err == nil && ip != "" {
-				publicIP = ip
-			} else {
-				publicIP = v.stun.client.NATType.String()
-			}
+			publicIP = v.stun.client.NATType.String()
 		}
 	}
 

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
+	"github.com/skycoin/skywire/pkg/geoip"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/skywire-utilities/pkg/cipher"
@@ -156,23 +157,15 @@ func getPublicIP(v *Visor, service string) (string, error) {
 		return pIP, fmt.Errorf("provided URL is invalid: %w", err)
 	}
 
-	pIP, err = GetIP(v.conf.GeoIP)
-	if err != nil {
-		<-v.stun.ready
-		if v.stun.client.PublicIP != nil {
-			pIP = v.stun.client.PublicIP.IP()
-			return pIP, nil
-		}
-		err = fmt.Errorf("cannot fetch public ip")
+	<-v.stun.ready
+	if v.stun.client.PublicIP != nil {
+		pIP = v.stun.client.PublicIP.IP()
+		return pIP, nil
 	}
-	if err != nil {
-		return pIP, err
-	}
-
-	return pIP, nil
+	return pIP, fmt.Errorf("cannot fetch public ip")
 }
 
-// GeoData holds geolocation information from the geoIP service.
+// GeoData holds geolocation information for the visor.
 type GeoData struct {
 	CountryCode string  `json:"country_code,omitempty"`
 	CountryName string  `json:"country_name,omitempty"`
@@ -183,61 +176,37 @@ type GeoData struct {
 	Longitude   float64 `json:"longitude,omitempty"`
 }
 
-type geoIPResponse struct {
-	IP          string   `json:"ip_address"`
-	CountryCode string   `json:"country_code"`
-	CountryName string   `json:"country_name"`
-	RegionCode  string   `json:"region_code"`
-	RegionName  string   `json:"region_name"`
-	CityName    string   `json:"city_name"`
-	Latitude    *float64 `json:"latitude"`
-	Longitude   *float64 `json:"longitude"`
-}
-
-// GetIP used for getting current IP of visor
-func GetIP(geoipURL string) (string, error) {
-	ip, _ := GetIPWithGeo(geoipURL)
-	return ip, nil
-}
-
-// GetIPWithGeo fetches public IP and geolocation data from the geoIP service.
-func GetIPWithGeo(geoipURL string) (string, *GeoData) {
-	client := &http.Client{
-		Timeout: 10 * time.Second,
+// LookupGeo returns geolocation data for the given IP using the embedded
+// MaxMind GeoLite2-City database. Returns nil if ip is empty or lookup
+// fails. No network round-trip — replaces the previous HTTP call to the
+// configured ip.skycoin.com geoip service.
+func LookupGeo(ip string) *GeoData {
+	if ip == "" {
+		return nil
 	}
-
-	resp, err := client.Get(geoipURL)
+	db, err := geoip.OpenEmbedded()
 	if err != nil {
-		return "", nil
+		return nil
 	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	body, err := io.ReadAll(resp.Body)
+	defer db.Close() //nolint:errcheck
+	res, err := geoip.Lookup(db, ip)
 	if err != nil {
-		return "", nil
+		return nil
 	}
-
-	var geoResp geoIPResponse
-	err = json.Unmarshal(body, &geoResp)
-	if err != nil {
-		return "", nil
+	g := &GeoData{
+		CountryCode: res.CountryCode,
+		CountryName: res.CountryName,
+		RegionCode:  res.RegionCode,
+		RegionName:  res.RegionName,
+		CityName:    res.CityName,
 	}
-
-	geo := &GeoData{
-		CountryCode: geoResp.CountryCode,
-		CountryName: geoResp.CountryName,
-		RegionCode:  geoResp.RegionCode,
-		RegionName:  geoResp.RegionName,
-		CityName:    geoResp.CityName,
+	if res.Latitude != nil {
+		g.Latitude = *res.Latitude
 	}
-	if geoResp.Latitude != nil {
-		geo.Latitude = *geoResp.Latitude
+	if res.Longitude != nil {
+		g.Longitude = *res.Longitude
 	}
-	if geoResp.Longitude != nil {
-		geo.Longitude = *geoResp.Longitude
-	}
-
-	return geoResp.IP, geo
+	return g
 }
 
 func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) error {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -59,53 +59,30 @@ func initAddressResolver(ctx context.Context, v *Visor, log *logging.Logger) err
 		return err
 	}
 
-	// Get public IP for address resolver binding (needed for NAT setups)
-	// Try multiple methods with fallback chain:
-	// 1. dmsg server (may fail if local dmsg server returns private IP)
-	// 2. GeoIP service
-	// 3. STUN servers
+	// Get public IP for address resolver binding (needed for NAT setups).
+	// Try dmsg first; fall back to STUN. Geolocation comes from the embedded
+	// MaxMind database — no HTTP round-trip to the geoip service.
 	var pIP string
-	var geoData *GeoData
 
-	// Try dmsg LookupIP first (with timeout to avoid blocking init if dmsg isn't ready)
 	lookupCtx, lookupCancel := context.WithTimeout(ctx, 10*time.Second)
 	ipAddr, err := v.dmsgC.LookupIP(lookupCtx, nil)
 	lookupCancel()
 	if err != nil {
-		log.WithError(err).Debug("Failed to get public IP from dmsg server, trying GeoIP")
-
-		// Fall back to GeoIP - also get geolocation data
-		pIP, geoData = GetIPWithGeo(v.conf.GeoIP)
-		if pIP == "" {
-			log.Debug("Failed to get public IP from GeoIP, trying STUN")
-
-			// Fall back to STUN
-			<-v.stun.ready
-			if v.stun.client.PublicIP != nil {
-				pIP = v.stun.client.PublicIP.IP()
-				log.WithField("public_ip", pIP).Debug("Got public IP from STUN")
-			} else {
-				log.Warn("Failed to determine public IP from dmsg, GeoIP, and STUN")
-				pIP = ""
-			}
+		log.WithError(err).Debug("Failed to get public IP from dmsg server, trying STUN")
+		<-v.stun.ready
+		if v.stun.client.PublicIP != nil {
+			pIP = v.stun.client.PublicIP.IP()
+			log.WithField("public_ip", pIP).Debug("Got public IP from STUN")
 		} else {
-			log.WithField("public_ip", pIP).Debug("Got public IP from GeoIP")
-			if geoData != nil {
-				log.WithField("country", geoData.CountryCode).Debug("Got geolocation from GeoIP")
-			}
+			log.Warn("Failed to determine public IP from dmsg and STUN")
 		}
 	} else {
 		pIP = ipAddr.String()
 		log.WithField("public_ip", pIP).Debug("Got public IP from dmsg server")
-		// When we get IP from dmsg, still try to get geo data separately
-		_, geoData = GetIPWithGeo(v.conf.GeoIP)
-		if geoData != nil {
-			log.WithField("country", geoData.CountryCode).Debug("Got geolocation from GeoIP")
-		}
 	}
 
-	// Store geolocation data if we got it
-	if geoData != nil {
+	if geoData := LookupGeo(pIP); geoData != nil {
+		log.WithField("country", geoData.CountryCode).Debug("Got geolocation from embedded GeoIP database")
 		v.geo.mu.Lock()
 		v.geo.data = geoData
 		v.geo.mu.Unlock()
@@ -160,30 +137,21 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 		factory.HeartbeatInterval = time.Duration(conf.HeartbeatInterval)
 		factory.Client = httpC
 
-		// Get public IP for service discovery (needed for NAT setups)
-		// Use same fallback chain as address resolver: dmsg -> GeoIP -> STUN
+		// Get public IP for service discovery (needed for NAT setups).
+		// Try dmsg first; fall back to STUN. No HTTP geoip query.
 		logger := factory.Log
 		var pIP string
 		lookupCtx, lookupCancel := context.WithTimeout(ctx, 10*time.Second)
 		ipAddr, err := v.dmsgC.LookupIP(lookupCtx, nil)
 		lookupCancel()
 		if err != nil {
-			logger.WithError(err).Debug("Failed to get public IP from dmsg server, trying GeoIP")
-
-			pIP, err = GetIP(v.conf.GeoIP)
-			if err != nil {
-				logger.WithError(err).Debug("Failed to get public IP from GeoIP, trying STUN")
-
-				<-v.stun.ready
-				if v.stun.client.PublicIP != nil {
-					pIP = v.stun.client.PublicIP.IP()
-					logger.WithField("public_ip", pIP).Debug("Got public IP from STUN for service discovery")
-				} else {
-					logger.Warn("Failed to determine public IP for service discovery from dmsg, GeoIP, and STUN")
-					pIP = ""
-				}
+			logger.WithError(err).Debug("Failed to get public IP from dmsg server, trying STUN")
+			<-v.stun.ready
+			if v.stun.client.PublicIP != nil {
+				pIP = v.stun.client.PublicIP.IP()
+				logger.WithField("public_ip", pIP).Debug("Got public IP from STUN for service discovery")
 			} else {
-				logger.WithField("public_ip", pIP).Debug("Got public IP from GeoIP for service discovery")
+				logger.Warn("Failed to determine public IP for service discovery from dmsg and STUN")
 			}
 		} else {
 			pIP = ipAddr.String()


### PR DESCRIPTION
## Summary

The MaxMind GeoLite2-City database has been embedded in the skywire binary since #2313 (\`cmd/svc/geoip\` subcommand). Visors were still making HTTP round-trips to the configured \`ip.skycoin.com\` geoip URL on startup to populate their service-discovery geolocation tags — unnecessary now that the data is local.

### Changes

- **New \`pkg/geoip\`** package with the embedded \`GeoLite2-City.mmdb\` (moved from \`cmd/svc/geoip/commands/\`) and \`Lookup\`/\`OpenEmbedded\`/\`EmbeddedDB\` helpers.
- **\`cmd/svc/geoip/commands/root.go\`** imports the new package; existing \`EmbeddedGeoIP()\` and \`LookupIP()\` exports stay as backwards-compat shims for the \`cmd/skywire-cli/rewards\` consumers.
- **Visor** replaces \`GetIP\`/\`GetIPWithGeo\` HTTP fetchers with \`LookupGeo(ip)\` against the embedded DB. Public IP comes from dmsg \`LookupIP\` first, STUN as fallback; geolocation comes from looking that IP up in the embedded MMDB.
- **\`skywire cli vpn start\`** still queries the configured geoip URL through the VPN to confirm the exit IP changed (legitimate use); replaced \`visor.GetIP\` call with a private \`fetchGeoIPAddr\` helper local to the vpn command.
- **Visor config keeps the \`GeoIP\` field** — it's still used by config refresh, proxy-test config defaults, and the \`cli vpn start --geoip\` flag.

### Why

- No more dependency on \`ip.skycoin.com\` for visors to start advertising correct geolocation.
- Eliminates one network round-trip per visor startup.
- Visors behind firewalls / in regions where the geoip service is blocked still get correct geolocation tags.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/visor/... ./pkg/geoip/...\` passes
- [x] \`golangci-lint\` 0 issues
- [x] \`skywire svc ip 8.8.8.8\` still works (embedded path verified)
- [ ] Run a visor on a fresh machine and confirm \`country_code\` populates in service-discovery without any HTTP geoip query in tcpdump