### PR TITLE
refactor(dmsgweb): drop HTTP bridge entirely — TCP only on both sides

### DIFF
--- a/cmd/dmsg/dmsgweb/commands/dmsgweb.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgweb.go
@@ -27,7 +27,6 @@ func init() {
 	proxyPort = cmdutil.SkyenvUint("${PROXYPORT:-4445}", dwcfg)
 	addProxy = cmdutil.SkyenvString("${ADDPROXY}", dwcfg)
 	resolveDmsgAddr = cmdutil.SkyenvStringSlice("${RESOLVEPK[@]}", dwcfg)
-	rawTCP = cmdutil.SkyenvBoolSlice("${RAWTCP[@]:-false}", dwcfg)
 	if os.Getenv("DMSGWEBSK") != "" {
 		sk.Set(os.Getenv("DMSGWEBSK")) //nolint
 	}
@@ -41,9 +40,8 @@ func init() {
 	RootCmd.Flags().UintVarP(&proxyPort, "socks", "q", proxyPort, "port to serve the socks5 proxy\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&addProxy, "addproxy", "r", addProxy, "configure additional socks5 proxy for dmsgweb (i.e. 127.0.0.1:1080)\033[0m\n\r")
 	RootCmd.Flags().UintSliceVarP(&webPort, "port", "p", webPort, "port(s) to serve the web application\033[0m\n\r")
-	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port & disable proxy\033[0m\n\r")
+	RootCmd.Flags().StringSliceVarP(&resolveDmsgAddr, "resolve", "t", resolveDmsgAddr, "resolve the specified dmsg address:port on the local port as a raw TCP tunnel & disable proxy\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", "", "connect to DMSG via proxy (i.e. '127.0.0.1:1080')\033[0m\n\r")
-	RootCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy to local port as raw TCP, comma separated\033[0m\n\r")
 	RootCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	RootCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\n\r")
 	RootCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file\033[0m\n\r")
@@ -120,13 +118,6 @@ dmsgweb conf file detected: ` + dwcfg
 			seenWebPort[item] = true
 		}
 
-		if len(rawTCP) < len(resolveDmsgAddr) {
-			for len(rawTCP) < len(resolveDmsgAddr) {
-				rawTCP = append(rawTCP, false)
-			}
-		} else if len(rawTCP) > len(resolveDmsgAddr) {
-			rawTCP = rawTCP[:len(resolveDmsgAddr)]
-		}
 		if len(webPort) == 0 {
 			dlog.Fatal("webPort is empty. Ensure at least one port is specified.")
 		}
@@ -186,7 +177,6 @@ dmsgweb conf file detected: ` + dwcfg
 			ProxyPort:     proxyPort,
 			ResolveAddr:   targets,
 			UpstreamSOCKS: addProxy,
-			RawTCP:        rawTCP,
 		}
 		if err := dmsgweb.Run(ctx, dlog, dmsgC, cfg); err != nil && err != context.Canceled {
 			dlog.WithError(err).Error("dmsgweb runtime stopped")

--- a/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
+++ b/cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go
@@ -7,19 +7,16 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 	"sync"
-	"time"
 
-	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/proxy"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cmdutil"
 	dmsgcmdutil "github.com/skycoin/skywire/pkg/dmsg/cmdutil"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
 	"github.com/skycoin/skywire/pkg/logging"
 )
@@ -32,7 +29,6 @@ func init() {
 	dmsgPort = cmdutil.SkyenvUintSlice("${DMSGPORT[@]:-80}", dwscfg)
 	wl = cmdutil.SkyenvStringSlice("${WHITELISTPKS[@]}", dwscfg)
 	localPort = cmdutil.SkyenvUintSlice("${LOCALPORT[@]:-8086}", dwscfg)
-	rawTCP = cmdutil.SkyenvBoolSlice("${RAWTCP[@]:-false}", dwscfg)
 	if os.Getenv("DMSGWEBSRVSK") != "" {
 		sk.Set(os.Getenv("DMSGWEBSRVSK")) //nolint
 	}
@@ -52,12 +48,6 @@ func init() {
 		return ""
 	}())
 	srvCmd.Flags().StringVarP(&proxyAddr, "proxy", "x", proxyAddr, "connect to DMSG via proxy (e.g., '127.0.0.1:1080')")
-	srvCmd.Flags().BoolSliceVarP(&rawTCP, "rt", "c", rawTCP, "proxy local port as raw TCP, comma separated"+func() string {
-		if len(rawTCP) > 0 {
-			return "\033[0m\n\r"
-		}
-		return ""
-	}())
 	srvCmd.Flags().StringVarP(&logLvl, "loglvl", "l", "debug", "[ debug | warn | error | fatal | panic | trace | info ]\033[0m\n\r")
 	srvCmd.Flags().BoolVarP(&isEnvs, "envs", "E", false, "show example .conf file")
 	srvCmd.Flags().VarP(&sk, "sk", "s", "a random key is generated if unspecified\033[0m\n\r")
@@ -68,8 +58,10 @@ func init() {
 
 var srvCmd = &cobra.Command{
 	Use:   "srv",
-	Short: "Serve HTTP or raw TCP from local port over DMSG",
-	Long: `DMSG web server - serve HTTP or raw TCP interface from local port over DMSG` + func() string {
+	Short: "Serve a local TCP port over DMSG",
+	Long: `DMSG web server - tunnel a local TCP port over DMSG. Bytes flow
+transparently, so HTTP, WebSockets, and any other TCP-based protocol
+the local service speaks all work unchanged.` + func() string {
 		if _, err := os.Stat(dwscfg); err == nil {
 			return "\n\t.dmsenv file detected: " + dwscfg
 		}
@@ -91,8 +83,8 @@ var srvCmd = &cobra.Command{
 			dlog.WithError(err).Fatal("Failed to read specified dmsghttp-config")
 		}
 
-		if len(localPort) != len(dmsgPort) || len(localPort) != len(rawTCP) {
-			dlog.Fatal("The number of local ports, DMSG ports, and raw TCP bools must be the same")
+		if len(localPort) != len(dmsgPort) {
+			dlog.Fatal("The number of local ports and DMSG ports must be the same")
 		}
 		pk, err = sk.PubKey()
 		if err != nil {
@@ -152,68 +144,28 @@ func server() {
 			dlog.Fatalf("Error listening on DMSG port %d: %v", dmsgPort[i], err)
 		}
 		wg.Add(1)
-		go func(ctx context.Context, localPort uint, rawTCP bool, listener net.Listener) {
+		go func(ctx context.Context, localPort uint, listener net.Listener) {
 			defer wg.Done()
 			defer listener.Close() //nolint
-
-			if rawTCP {
-				proxyTCPConnections(ctx, localPort, listener)
-			} else {
-				proxyHTTPConnections(ctx, localPort, listener)
-			}
-		}(ctx, localPort[i], rawTCP[i], lis)
+			proxyTCPConnections(ctx, localPort, listener)
+		}(ctx, localPort[i], lis)
 	}
 	wg.Wait()
 }
 
-func proxyHTTPConnections(ctx context.Context, localPort uint, listener net.Listener) {
-	router := gin.New()
-	router.Use(gin.Recovery())
-	router.Use(loggingMiddleware())
-
-	authRoute := router.Group("/")
-	if len(wlkeys) > 0 {
-		authRoute.Use(whitelistAuth(wlkeys))
-	}
-	authRoute.Any("/*path", func(c *gin.Context) {
-		targetURL := fmt.Sprintf("http://127.0.0.1:%d%s?%s", localPort, c.Request.URL.Path, c.Request.URL.RawQuery)
-		parsed, err := url.Parse(targetURL)
-		if err != nil {
-			dlog.Errorf("failed to parse target URL %q: %v", targetURL, err)
-			c.String(http.StatusInternalServerError, "Bad target URL")
-			return
-		}
-		proxy := httputil.ReverseProxy{Director: func(req *http.Request) {
-			req.URL = parsed
-			req.Host = req.URL.Host
-		}}
-		proxy.ServeHTTP(c.Writer, c.Request)
-	})
-
-	server := &http.Server{
-		Handler:           router,
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       10 * time.Second,
-		WriteTimeout:      10 * time.Second,
-		IdleTimeout:       60 * time.Second,
-		MaxHeaderBytes:    1 << 20,
-	}
-
-	// Graceful shutdown on context cancellation
-	go func() { //nolint:gosec
-		<-ctx.Done()
-		if err := server.Shutdown(context.Background()); err != nil {
-			dlog.Errorf("HTTP server shutdown error: %v", err)
-		}
-	}()
-
-	if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
-		dlog.Fatalf("HTTP server error: %v", err)
-	}
-}
-
 // maxTCPConns is the maximum number of concurrent TCP proxy connections.
 const maxTCPConns = 256
+
+// peerPK extracts the remote dmsg public key from an accepted listener
+// connection so the whitelist check can run before any local TCP dial.
+// Returns the zero PubKey if the connection isn't a dmsg.Stream — the
+// caller treats that as "not whitelisted" when wlkeys is non-empty.
+func peerPK(c net.Conn) cipher.PubKey {
+	if s, ok := c.(*dmsg.Stream); ok {
+		return s.RawRemoteAddr().PK
+	}
+	return cipher.PubKey{}
+}
 
 func proxyTCPConnections(ctx context.Context, localPort uint, listener net.Listener) {
 	// To track active connections for cleanup
@@ -290,6 +242,26 @@ func proxyTCPConnections(ctx context.Context, localPort uint, listener net.Liste
 						dlog.WithError(err).Debug("Error closing dmsg connection")
 					}
 				}()
+
+				// PK whitelist enforcement. Non-dmsg conns and unknown
+				// PKs are rejected when a whitelist is configured.
+				if len(wlkeys) > 0 {
+					remotePK := peerPK(dmsgConn)
+					allowed := false
+					for _, pk := range wlkeys {
+						if pk == remotePK {
+							allowed = true
+							break
+						}
+					}
+					if !allowed {
+						dlog.WithField("remote_pk", remotePK.String()).Debug("Rejecting connection from non-whitelisted PK")
+						connMutex.Lock()
+						delete(activeConns, dmsgConn)
+						connMutex.Unlock()
+						return
+					}
+				}
 
 				localConn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", localPort))
 				if err != nil {

--- a/cmd/dmsg/dmsgweb/commands/root.go
+++ b/cmd/dmsg/dmsgweb/commands/root.go
@@ -3,15 +3,12 @@ package commands
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"runtime"
 	"strings"
-	"time"
 
 	"github.com/bitfield/script"
-	"github.com/gin-gonic/gin"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
@@ -45,7 +42,6 @@ var (
 	wlkeys             []cipher.PubKey
 	localPort          []uint
 	err                error
-	rawTCP             []bool
 	pprofMode          string
 	pprofAddr          string
 )
@@ -69,123 +65,3 @@ func printEnvs(envfile string) {
 	fmt.Println(envfile)
 	os.Exit(0)
 }
-
-func whitelistAuth(whitelistedPKs []cipher.PubKey) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		remotePK, _, err := net.SplitHostPort(c.Request.RemoteAddr)
-		if err != nil {
-			c.Writer.WriteHeader(http.StatusInternalServerError)
-			c.Writer.Write([]byte("500 Internal Server Error")) //nolint
-			c.AbortWithStatus(http.StatusInternalServerError)
-			return
-		}
-		whitelisted := false
-		if len(whitelistedPKs) == 0 {
-			whitelisted = true
-		} else {
-			for _, whitelistedPK := range whitelistedPKs {
-				if remotePK == whitelistedPK.String() {
-					whitelisted = true
-					break
-				}
-			}
-		}
-		if whitelisted {
-			c.Next()
-		} else {
-			c.Writer.WriteHeader(http.StatusUnauthorized)
-			c.Writer.Write([]byte("401 Unauthorized")) //nolint
-			c.AbortWithStatus(http.StatusUnauthorized)
-			return
-		}
-	}
-}
-
-type ginHandler struct { //nolint unused
-	Router *gin.Engine
-}
-
-func (h *ginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) { //nolint unused
-	h.Router.ServeHTTP(w, r)
-}
-
-func loggingMiddleware() gin.HandlerFunc {
-	return func(c *gin.Context) {
-		start := time.Now()
-		c.Next()
-		latency := time.Since(start)
-		if latency > time.Minute {
-			latency = latency.Truncate(time.Second)
-		}
-		statusCode := c.Writer.Status()
-		method := c.Request.Method
-		path := c.Request.URL.Path
-		// Get the background color based on the status code
-		statusCodeBackgroundColor := getBackgroundColor(statusCode)
-		// Get the method color
-		methodColor := getMethodColor(method)
-		// Print the logging in a custom format which includes the publickeyfrom c.Request.RemoteAddr ex.:
-		// [DMSGHTTP] 2023/05/18 - 19:43:15 | 200 |    10.80885ms |                 | 02b5ee5333aa6b7f5fc623b7d5f35f505cb7f974e98a70751cf41962f84c8c4637:49153 | GET      /node-info.json
-		fmt.Printf("[DMSGWEB] %s |%s %3d %s| %13v | %15s | %72s |%s %-7s %s %s\n",
-			time.Now().Format("2006/01/02 - 15:04:05"),
-			statusCodeBackgroundColor,
-			statusCode,
-			resetColor(),
-			latency,
-			c.ClientIP(),
-			c.Request.RemoteAddr,
-			methodColor,
-			method,
-			resetColor(),
-			path,
-		)
-	}
-}
-func getBackgroundColor(statusCode int) string {
-	switch {
-	case statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices:
-		return green
-	case statusCode >= http.StatusMultipleChoices && statusCode < http.StatusBadRequest:
-		return white
-	case statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError:
-		return yellow
-	default:
-		return red
-	}
-}
-
-func getMethodColor(method string) string {
-	switch method {
-	case http.MethodGet:
-		return blue
-	case http.MethodPost:
-		return cyan
-	case http.MethodPut:
-		return yellow
-	case http.MethodDelete:
-		return red
-	case http.MethodPatch:
-		return green
-	case http.MethodHead:
-		return magenta
-	case http.MethodOptions:
-		return white
-	default:
-		return reset
-	}
-}
-
-func resetColor() string {
-	return reset
-}
-
-const (
-	green   = "\033[97;42m"
-	white   = "\033[90;47m"
-	yellow  = "\033[90;43m"
-	red     = "\033[97;41m"
-	blue    = "\033[97;44m"
-	magenta = "\033[97;45m"
-	cyan    = "\033[97;46m"
-	reset   = "\033[0m"
-)

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -2,22 +2,20 @@
 // `.dmsg` (and other configurable) domain suffixes. It exposes:
 //
 //   - a SOCKS5 proxy that intercepts hosts ending in the configured
-//     DomainSuffix and routes them to an internal HTTP bridge
-//   - the internal HTTP bridge, which translates HTTP requests into
-//     DMSG HTTP client requests
-//   - an optional raw TCP bridge, for tunneling non-HTTP protocols
-//     to a fixed DMSG address:port
+//     DomainSuffix and tunnels them directly as DMSG streams
+//   - a raw TCP bridge for fixed (pk, dmsgPort) → localhost mappings
+//
+// HTTP bridging was removed; raw TCP forwards bytes transparently and
+// works for HTTP, WebSockets, server-sent events, chunked transfers,
+// and any other protocol the dmsg target speaks. The previous HTTP
+// bridge added URL rewriting and per-target connection pooling but no
+// functional behavior that raw TCP doesn't already provide.
 //
 // The package accepts an externally-created *dmsg.Client so the
 // runtime can be embedded into either the standalone `skywire dmsg
 // web` command or a visor-hosted application (e.g. a resolver inside
 // skysocks-client). Neither mode owns the client; lifecycle belongs
 // to the caller.
-//
-// This is step 1 of moving .dmsg / .skynet browser support from a
-// standalone utility into the visor process: the CLI is reduced to a
-// config adapter over Run(), and a future visor app can call Run()
-// directly without spawning a separate process.
 package dmsgweb
 
 import (
@@ -26,21 +24,17 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/chen3feng/safecast"
 	"github.com/confiant-inc/go-socks5"
-	"github.com/gin-gonic/gin"
 	"golang.org/x/net/proxy"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/dmsg/ioutil"
 	"github.com/skycoin/skywire/pkg/logging"
 )
@@ -53,22 +47,23 @@ const DefaultDomainSuffix = ".dmsg"
 // Config configures a dmsgweb runtime. Two operating modes:
 //
 //  1. ResolveAddr empty → SOCKS5 resolver mode. Any hostname ending
-//     in DomainSuffix is treated as <pk>.dmsg:<port> and bridged via
-//     a single HTTP proxy on WebPorts[0]. The SOCKS5 proxy on
-//     ProxyPort rewrites the dial target to localhost so curl /
-//     browsers can reach .dmsg sites transparently.
+//     in DomainSuffix is treated as <pk>.dmsg:<port> and tunneled
+//     directly as a DMSG stream. The SOCKS5 proxy on ProxyPort
+//     rewrites the dial target to localhost so curl/browsers reach
+//     .dmsg sites transparently.
 //
 //  2. ResolveAddr non-empty → fixed mapping mode. Each entry maps to
-//     WebPorts[i] and is served either as HTTP (default) or raw TCP
-//     (RawTCP[i] == true). The SOCKS5 proxy is disabled — callers
-//     point their client directly at 127.0.0.1:WebPorts[i].
+//     WebPorts[i] and is served as a raw TCP tunnel to (pk, dmsgPort).
+//     The SOCKS5 proxy is disabled — callers point their client
+//     directly at 127.0.0.1:WebPorts[i]. Raw TCP transparently carries
+//     HTTP, WebSockets, and any other protocol.
 type Config struct {
 	// DomainSuffix is the domain extension that the SOCKS5 resolver
 	// treats as DMSG (e.g. ".dmsg"). Defaults to DefaultDomainSuffix.
 	DomainSuffix string
 
-	// WebPorts are the HTTP listener ports. In mode 1 only WebPorts[0]
-	// is used; in mode 2 there is one listener per ResolveAddr entry.
+	// WebPorts are the localhost TCP listener ports. Used only in mode 2
+	// (fixed-mapping); ignored in SOCKS5 mode. One entry per ResolveAddr.
 	WebPorts []uint
 
 	// ProxyPort is the SOCKS5 proxy listener port. Zero disables the
@@ -85,13 +80,9 @@ type Config struct {
 	// Matches the existing `--addproxy` CLI flag.
 	UpstreamSOCKS string
 
-	// RawTCP controls per-ResolveAddr tunneling mode: false = HTTP,
-	// true = raw TCP. Length is normalised to match ResolveAddr.
-	RawTCP []bool
-
-	// Stats, when non-nil, is updated for every HTTP-bridge request.
-	// The visor layer allocates one per resolver lifetime so counters
-	// persist across Start/Stop cycles.
+	// Stats, when non-nil, is updated for every SOCKS5 dial. The visor
+	// layer allocates one per resolver lifetime so counters persist
+	// across Start/Stop cycles.
 	Stats *Stats
 }
 
@@ -154,20 +145,16 @@ func Run(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, cfg Confi
 	}
 
 	// --- Fixed-mapping mode (--resolve) ---
+	// Each --resolve entry is exposed as a raw TCP listener that pipes
+	// bytes to the dmsg target. HTTP traffic works unchanged because
+	// the bytes are forwarded transparently; no URL rewriting needed.
 	if len(cfg.ResolveAddr) > 0 {
-		httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC)}
 		for i := range cfg.ResolveAddr {
 			wg.Add(1)
 			i := i
 			go func() {
 				defer wg.Done()
-				if cfg.RawTCP[i] {
-					if err := serveTCP(ctx, log, dmsgC, cfg, i); err != nil && !errors.Is(err, net.ErrClosed) {
-						errCh <- err
-					}
-					return
-				}
-				if err := serveHTTP(ctx, log, &httpC, cfg, i); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				if err := serveTCP(ctx, log, dmsgC, cfg, i); err != nil && !errors.Is(err, net.ErrClosed) {
 					errCh <- err
 				}
 			}()
@@ -210,13 +197,6 @@ func (c *tcpAddrConn) LocalAddr() net.Addr {
 func normalize(cfg Config) Config {
 	if cfg.DomainSuffix == "" {
 		cfg.DomainSuffix = DefaultDomainSuffix
-	}
-	// Normalise RawTCP to match ResolveAddr length so callers of
-	// RawTCP[i] are always safe.
-	if n := len(cfg.ResolveAddr); len(cfg.RawTCP) < n {
-		cfg.RawTCP = append(cfg.RawTCP, make([]bool, n-len(cfg.RawTCP))...)
-	} else if len(cfg.RawTCP) > n {
-		cfg.RawTCP = cfg.RawTCP[:n]
 	}
 	return cfg
 }
@@ -329,118 +309,6 @@ func (r *dmsgResolver) Resolve(ctx context.Context, name string) (context.Contex
 	// Always return 127.0.0.1 — prevents the library from doing a
 	// DNS lookup that would fail for .dmsg / .skynet / any custom TLD.
 	return ctx, net.ParseIP("127.0.0.1"), nil
-}
-
-// --- HTTP bridge ---
-
-func serveHTTP(ctx context.Context, log *logging.Logger, httpC *http.Client, cfg Config, idx int) error {
-	gin.SetMode(gin.ReleaseMode)
-	r := gin.New()
-	r.Use(gin.Recovery())
-
-	r.Any("/*path", func(c *gin.Context) {
-		// Bound request body so a hostile client cannot balloon
-		// memory.
-		const maxBodySize = 10 << 20
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBodySize)
-
-		// Stats bookkeeping is no-op when cfg.Stats is nil.
-		var reqErr error
-		done := cfg.Stats.RecordRequest()
-		defer func() { done(reqErr) }()
-
-		urlStr := buildProxyURL(c, cfg, idx)
-		log.WithField("method", c.Request.Method).WithField("url", urlStr).Debug("HTTP bridge")
-		req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, urlStr, c.Request.Body)
-		if err != nil {
-			reqErr = err
-			c.String(http.StatusInternalServerError, "failed to build request")
-			return
-		}
-		for h, vs := range c.Request.Header {
-			for _, v := range vs {
-				req.Header.Add(h, v)
-			}
-		}
-		resp, err := httpC.Do(req)
-		if err != nil {
-			reqErr = err
-			c.String(http.StatusInternalServerError, "failed to reach dmsg target")
-			log.WithError(err).Debug("dmsg HTTP error")
-			return
-		}
-		defer ioutil.CloseQuietly(resp.Body, log)
-		for h, vs := range resp.Header {
-			for _, v := range vs {
-				c.Writer.Header().Add(h, v)
-			}
-		}
-		c.Status(resp.StatusCode)
-		if _, err := io.Copy(c.Writer, resp.Body); err != nil {
-			log.WithError(err).Debug("response copy failed")
-			// Copy errors after headers are written are common
-			// (client disconnect mid-stream) and don't warrant
-			// flagging the whole request as failed — leave reqErr nil.
-		}
-		// 5xx from the remote counts as a failure for the UI even
-		// though locally the bridge "succeeded". Stays below 4xx so
-		// simple 404s from the remote don't pollute the error rate.
-		if resp.StatusCode >= 500 {
-			reqErr = fmt.Errorf("remote status %d", resp.StatusCode)
-		}
-	})
-
-	port := cfg.WebPorts[0]
-	if idx >= 0 {
-		port = cfg.WebPorts[idx]
-	}
-	srv := &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
-		Handler:           r,
-		ReadHeaderTimeout: 5 * time.Second,
-	}
-	log.WithField("port", port).Debug("Serving HTTP bridge")
-
-	// Context-driven shutdown; ListenAndServe returns ErrServerClosed
-	// once Shutdown is called, which Run() treats as a clean exit.
-	// We deliberately derive shutdownCtx from context.Background
-	// (not ctx) because ctx is already canceled when we get here —
-	// the whole point of a shutdown timeout is giving in-flight
-	// requests a brief grace period after cancellation.
-	go func() { //nolint:gosec // G118: intentional — shutdown must outlive parent ctx
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(shutdownCtx); err != nil {
-			log.WithError(err).Debug("HTTP shutdown error")
-		}
-	}()
-	return srv.ListenAndServe()
-}
-
-func buildProxyURL(c *gin.Context, cfg Config, idx int) string {
-	if idx >= 0 {
-		// Fixed-mapping mode — target is known.
-		t := cfg.ResolveAddr[idx]
-		q := ""
-		if c.Request.URL.RawQuery != "" {
-			q = "?" + c.Request.URL.RawQuery
-		}
-		return fmt.Sprintf("dmsg://%s:%d%s%s", t.PK.Hex(), t.Port, c.Param("path"), q)
-	}
-	// Resolver mode — derive target from Host header. The suffix is
-	// stripped so "somekey.dmsg:80" becomes "somekey".
-	hostParts := strings.Split(c.Request.Host, ":")
-	dmsgPort := "80"
-	if len(hostParts) > 1 {
-		dmsgPort = hostParts[1]
-	}
-	pkHost := strings.TrimSuffix(hostParts[0], cfg.DomainSuffix)
-	q := ""
-	if c.Request.URL.RawQuery != "" {
-		q = "?" + c.Request.URL.RawQuery
-	}
-	return fmt.Sprintf("dmsg://%s:%s%s%s", pkHost, dmsgPort, c.Param("path"), q)
 }
 
 // --- TCP bridge ---

--- a/pkg/visor/api_proxies.go
+++ b/pkg/visor/api_proxies.go
@@ -163,7 +163,6 @@ func dmsgProxyInfo(cfg *visorconfig.DmsgWebConfig, runtime *EmbeddedDmsgWeb) *Em
 		Enabled:       cfg.Enable,
 		DomainSuffix:  stringOrDefault(cfg.DomainSuffix, dmsgweb.DefaultDomainSuffix),
 		SocksAddr:     localSocksAddr(true, uintOrDefault(cfg.ProxyPort, defaultDmsgWebProxyPort)),
-		WebAddr:       localWebAddr(true, uintOrDefault(cfg.WebPort, defaultDmsgWebPort)),
 		UpstreamSOCKS: cfg.UpstreamSOCKS,
 	}
 	if runtime != nil {
@@ -218,22 +217,15 @@ func (v *Visor) autoStartSkynetWeb() {
 	}
 }
 
-// localSocksAddr / localWebAddr return the fully-qualified localhost
-// listener or empty when disabled. The render layer uses empty as a
-// signal to display "—".
+// localSocksAddr returns the fully-qualified localhost listener or
+// empty when disabled. The render layer uses empty as a signal to
+// display "—".
 //
 // Why condition on `enabled` even when ports are set: a user who
 // disabled a resolver via RPC but left the config untouched shouldn't
 // see its port advertised. Enabled reflects the current config, not
 // the live Running state, so it's the right signal here.
 func localSocksAddr(enabled bool, port uint) string {
-	if !enabled || port == 0 {
-		return ""
-	}
-	return fmt.Sprintf("127.0.0.1:%d", port)
-}
-
-func localWebAddr(enabled bool, port uint) string {
 	if !enabled || port == 0 {
 		return ""
 	}

--- a/pkg/visor/embedded_dmsgweb.go
+++ b/pkg/visor/embedded_dmsgweb.go
@@ -29,12 +29,9 @@ import (
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
-// Default listener ports — match `skywire dmsg web` defaults so the
-// two surfaces behave the same from a browser's perspective.
-const (
-	defaultDmsgWebProxyPort = 4445
-	defaultDmsgWebPort      = 8080
-)
+// Default SOCKS5 listener port — matches `skywire dmsg web` so the two
+// surfaces behave identically from a browser's perspective.
+const defaultDmsgWebProxyPort = 4445
 
 // EmbeddedDmsgWeb holds the runtime state for the visor-hosted
 // dmsgweb resolver. Safe for concurrent Start/Stop calls.
@@ -150,13 +147,11 @@ func (e *EmbeddedDmsgWeb) Upstream() string {
 func (e *EmbeddedDmsgWeb) serve(ctx context.Context) {
 	cfg := dmsgweb.Config{
 		DomainSuffix:  stringOrDefault(e.cfg.DomainSuffix, dmsgweb.DefaultDomainSuffix),
-		WebPorts:      []uint{uintOrDefault(e.cfg.WebPort, defaultDmsgWebPort)},
 		ProxyPort:     uintOrDefault(e.cfg.ProxyPort, defaultDmsgWebProxyPort),
 		UpstreamSOCKS: e.cfg.UpstreamSOCKS,
 		Stats:         e.stats,
 	}
 	e.log.WithField("socks_port", cfg.ProxyPort).
-		WithField("web_port", cfg.WebPorts[0]).
 		WithField("domain", cfg.DomainSuffix).
 		Info("Serving dmsgweb resolver")
 	if err := dmsgweb.Run(ctx, e.log, e.dmsgC, cfg); err != nil && err != context.Canceled {

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -29,12 +29,9 @@ import (
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
-// Defaults — chosen to not clash with DmsgWeb's defaults (4445/8080)
-// so both resolvers can run side by side.
-const (
-	defaultSkynetWebProxyPort = 4446
-	defaultSkynetWebPort      = 8081
-)
+// Default SOCKS5 listener port — chosen so it doesn't clash with
+// dmsgweb's default (4445) and both resolvers can run side by side.
+const defaultSkynetWebProxyPort = 4446
 
 // EmbeddedSkynetWeb holds the runtime state for the visor-hosted
 // skynetweb resolver.


### PR DESCRIPTION
## Summary

**Both** the client (\`--resolve\`) and server (\`srv\`) sides of \`dmsg web\` had an HTTP bridge mode in addition to raw TCP. Raw TCP forwards bytes transparently, so HTTP, WebSockets, server-sent events, chunked transfers, and HTTP/1.1 upgrades all just work. The HTTP bridge added URL rewriting and an http.Client / gin reverse-proxy stack that provided no functional capability raw TCP doesn't already have.

The one thing the server-side HTTP mode did that raw TCP didn't was **PK whitelist auth** via gin middleware. That auth is now done at the dmsg accept loop level using the \`dmsg.Stream\`'s \`RawRemoteAddr().PK\` — same enforcement, no protocol parsing required.

## CLI changes

\`\`\`
skywire dmsg web --resolve <pk>:<port>   # always raw TCP (was HTTP-by-default + --raw-tcp opt-in)
skywire dmsg web srv --lport <p>          # always raw TCP (was HTTP-by-default + --rt opt-in)
\`\`\`

\`--raw-tcp\` / \`-c\` (client) and \`--rt\` (server) flags **removed** — both modes are gone.

## Code changes

| File | Change |
|---|---|
| \`pkg/dmsgweb/runtime.go\` | Drop \`serveHTTP\`, \`buildProxyURL\`, \`RawTCP[]\` field |
| \`cmd/dmsg/dmsgweb/commands/dmsgwebsrv.go\` | Drop \`proxyHTTPConnections\`; move whitelist enforcement into \`proxyTCPConnections\` via new \`peerPK()\` helper |
| \`cmd/dmsg/dmsgweb/commands/root.go\` | Drop \`whitelistAuth\`, \`ginHandler\`, \`loggingMiddleware\`, ANSI color constants, gin/net/time imports |
| \`pkg/visor/embedded_dmsgweb.go\` | Stop populating \`WebPorts\` (SOCKS5 mode never read them); drop \`defaultDmsgWebPort=8080\` |
| \`pkg/visor/embedded_skynetweb.go\` | Drop \`defaultSkynetWebPort=8081\` |
| \`pkg/visor/api_proxies.go\` | Drop \`WebAddr\` from \`EmbeddedProxyInfo\` rendering (was always misleading — showed 8080/8081 but nothing was bound there in SOCKS5 mode) |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/dmsgweb/... ./cmd/dmsg/dmsgweb/... ./pkg/visor/\` passes
- [x] \`golangci-lint\` 0 issues
- [x] \`make format\` clean