### PR TITLE
fix(cli): ask the running visor for its config path

### DIFF
--- a/cmd/skywire-cli/commands/config/show.go
+++ b/cmd/skywire-cli/commands/config/show.go
@@ -39,20 +39,18 @@ Use --path to print just the config file path.`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if showPath {
-			// Try RPC first to get the actual path the visor is using
+			// Ask the running visor for the path it actually loaded.
+			// Falls back to the default install path only when no visor
+			// is reachable (CLI invoked without a running visor).
 			rpcClient, err := clirpc.Client(cmd.Flags())
 			if err != nil {
-				// Fallback: print the default config path
 				fmt.Println(visorconfig.SkywireConfig())
 				return
 			}
-			// GetRuntimeConfig returns the full config; we parse it for the path
-			// But we don't actually have a path RPC. Use VisorConfigFile if available.
-			configPath := visorconfig.VisorConfigFile
-			if configPath == "" || configPath == visorconfig.Stdin {
+			configPath, err := rpcClient.GetConfigPath()
+			if err != nil || configPath == "" {
 				configPath = visorconfig.SkywireConfig()
 			}
-			_ = rpcClient // used to verify visor is running
 			fmt.Println(configPath)
 			return
 		}

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -114,6 +114,7 @@ type API interface {
 	SetIsPublic(isPublic bool) error
 	GetIsPublic() bool
 	GetRuntimeConfig() ([]byte, error)
+	GetConfigPath() (string, error)
 	StartPublicAutoconnect() error
 	StopPublicAutoconnect() error
 	PublicAutoconnectStatus() (bool, error)

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -542,6 +542,13 @@ func (v *Visor) GetRuntimeConfig() ([]byte, error) {
 	return json.MarshalIndent(v.conf, "", "  ")
 }
 
+// GetConfigPath returns the filesystem path the visor loaded its config
+// from. Returns "stdin" when the config was read from stdin or supplied
+// via --config-arg; returns an empty string if the path was never set.
+func (v *Visor) GetConfigPath() (string, error) {
+	return visorconfig.VisorConfigFile, nil
+}
+
 // PublicAutoconnectStatus returns whether public autoconnect is currently running
 func (v *Visor) PublicAutoconnectStatus() (bool, error) {
 	return v.IsPublicAutoconnectRunning(), nil

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -524,6 +524,13 @@ func (rc *rpcClient) GetRuntimeConfig() ([]byte, error) {
 	return out, err
 }
 
+// GetConfigPath implements API.
+func (rc *rpcClient) GetConfigPath() (string, error) {
+	var out string
+	err := rc.Call("GetConfigPath", &struct{}{}, &out)
+	return out, err
+}
+
 // StartPublicAutoconnect implements API.
 func (rc *rpcClient) StartPublicAutoconnect() error {
 	return rc.Call("StartPublicAutoconnect", &struct{}{}, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -647,6 +647,9 @@ func (mc *mockRPCClient) GetIsPublic() bool { return false }
 // GetRuntimeConfig implements API.
 func (mc *mockRPCClient) GetRuntimeConfig() ([]byte, error) { return []byte("{}"), nil }
 
+// GetConfigPath implements API.
+func (mc *mockRPCClient) GetConfigPath() (string, error) { return "", nil }
+
 // SetPublicAutoconnect implements API.
 func (mc *mockRPCClient) SetPublicAutoconnect(_ bool) error {
 	return nil

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -151,6 +151,13 @@ func (r *RPC) GetRuntimeConfig(_ *struct{}, out *[]byte) (err error) {
 	return err
 }
 
+// GetConfigPath returns the filesystem path the visor loaded its config from.
+func (r *RPC) GetConfigPath(_ *struct{}, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "GetConfigPath", nil)(out, &err)
+	*out, err = r.visor.GetConfigPath()
+	return err
+}
+
 // RemoteVisors return connected remote visors
 func (r *RPC) RemoteVisors(_ *struct{}, out *[]string) (err error) {
 	defer rpcutil.LogCall(r.log, "RemoteVisor", nil)(out, &err)


### PR DESCRIPTION
## Summary

\`skywire cli config show --path\` always returned \`/opt/skywire/skywire.json\` regardless of what the visor actually loaded — because it was reading \`visorconfig.VisorConfigFile\` out of the CLI's own process (where that global is unset), and falling back to the default install path.

The existing comment in \`show.go\` claimed it was \"trying RPC first\" but no RPC call retrieved the path; the rpcClient was only used as a liveness check.

Fix: add a tiny \`GetConfigPath()\` RPC method that returns \`visorconfig.VisorConfigFile\` from the visor process, and have the CLI call it. Falls back to the default install path only when no visor is reachable.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go test ./pkg/visor/\` passes
- [ ] Manual: with a visor running from cwd via \`./skywire visor\`, \`skywire cli config show --path\` now prints the actual cwd \`skywire-config.json\` instead of \`/opt/skywire/skywire.json\`