### PR TITLE
fix(dmsgweb): don't read WebPorts[0] in resolver — bridge is gone

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -276,7 +276,7 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 
 // Context keys used by the SOCKS5 resolver ↔ Dial callback handshake.
 type (
-	dmsgResolverPortKey_t struct{} // set when .dmsg matched → value is the bridge port string
+	dmsgResolverPortKey_t struct{} // set when .dmsg matched → presence is the signal; value unused
 	dmsgOrigHostKey_t     struct{} // always set → original hostname before resolution
 )
 
@@ -304,7 +304,9 @@ func (r *dmsgResolver) Resolve(ctx context.Context, name string) (context.Contex
 	pattern := `\` + r.cfg.DomainSuffix + `(:[0-9]+)?$`
 	match, _ := regexp.MatchString(pattern, name) //nolint:errcheck
 	if match {
-		ctx = context.WithValue(ctx, dmsgResolverPortKey, fmt.Sprintf("%d", r.cfg.WebPorts[0]))
+		// The Dial callback only checks presence of this key to know
+		// "this is a .dmsg hostname" — the value is irrelevant.
+		ctx = context.WithValue(ctx, dmsgResolverPortKey, "match")
 	}
 	// Always return 127.0.0.1 — prevents the library from doing a
 	// DNS lookup that would fail for .dmsg / .skynet / any custom TLD.


### PR DESCRIPTION
## Summary

Regression from #2358 (dmsgweb HTTP bridge removal). The resolver indexed \`cfg.WebPorts[0]\` to set a sentinel context key marking \".dmsg matched\". After the bridge cleanup, embedded dmsgweb stopped populating \`WebPorts\` — so the slice is now empty and indexing it panicked on every \`.dmsg\` SOCKS5 request:

\`\`\`
panic: runtime error: index out of range [0] with length 0
  pkg/dmsgweb/runtime.go:307 (*dmsgResolver).Resolve
  vendor/github.com/confiant-inc/go-socks5/request.go:125 (*Server).handleRequest
\`\`\`

The Dial callback only checks for *presence* of the key, never reads the value (\`pkg/dmsgweb/runtime.go:228\`), so a constant string sentinel does the job.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go test ./pkg/visor/\` passes
- [x] Manual: SOCKS5 request to \`http://<pk>.dmsg/\` no longer crashes the visor; the dial proceeds and returns a normal error if no listener exists