### PR TITLE
fix(dht): publish a real signed DMSG entry; one writer for tp salt

### DIFF
--- a/pkg/dht/disc_hybrid.go
+++ b/pkg/dht/disc_hybrid.go
@@ -27,13 +27,42 @@ func NewHybridDiscClient(dhtAdapter *DiscAdapter, httpClient disc.APIClient, log
 }
 
 // Entry tries DHT first, falls back to HTTP.
+//
+// DHT-stored entries are validated before being returned: any entry
+// whose Static field doesn't match the requested PK, or whose
+// Signature is empty, is treated as a DHT miss and the HTTP path is
+// used instead. This stops corrupt DHT entries (a stale or
+// mis-published value under our key) from being handed to callers
+// like the dmsg client's updateClientEntry path, which would
+// otherwise mutate-and-republish the corruption every cycle.
 func (h *HybridDiscClient) Entry(ctx context.Context, pk cipher.PubKey) (*disc.Entry, error) {
 	entry, err := h.dht.Entry(ctx, pk)
-	if err == nil {
+	if err == nil && validEntry(entry, pk) {
 		return entry, nil
 	}
-	h.log.WithField("pk", pk.String()[:8]).Debug("DHT miss, falling back to HTTP discovery")
+	if err == nil {
+		h.log.WithField("pk", pk.String()).
+			Debug("DHT entry failed validation, falling back to HTTP discovery")
+	} else {
+		h.log.WithField("pk", pk.String()).Debug("DHT miss, falling back to HTTP discovery")
+	}
 	return h.http.Entry(ctx, pk)
+}
+
+// validEntry returns true if the entry's identity fields match the
+// PK we asked for and the entry has been signed. Lets the hybrid
+// client distinguish a usable DHT entry from a malformed one.
+func validEntry(entry *disc.Entry, pk cipher.PubKey) bool {
+	if entry == nil {
+		return false
+	}
+	if entry.Static != pk {
+		return false
+	}
+	if entry.Signature == "" {
+		return false
+	}
+	return true
 }
 
 // AvailableServers tries DHT cache first, falls back to HTTP.
@@ -54,21 +83,48 @@ func (h *HybridDiscClient) AllServers(ctx context.Context) ([]*disc.Entry, error
 	return h.http.AllServers(ctx)
 }
 
-// PostEntry writes to both DHT and HTTP.
+// PostEntry writes to both DHT and HTTP. The DHT write is gated on
+// the entry being fully populated and signed — partial entries (e.g.
+// internal seed-cache placeholders) shouldn't end up authoritative
+// state visible to other visors.
 func (h *HybridDiscClient) PostEntry(ctx context.Context, entry *disc.Entry) error {
-	// Write to DHT (best-effort).
-	if err := h.dht.PostEntry(ctx, entry); err != nil {
-		h.log.WithError(err).Debug("DHT PostEntry failed (continuing with HTTP)")
+	if shouldMirrorToDHT(entry) {
+		if err := h.dht.PostEntry(ctx, entry); err != nil {
+			h.log.WithError(err).Debug("DHT PostEntry failed (continuing with HTTP)")
+		}
 	}
 	return h.http.PostEntry(ctx, entry)
 }
 
-// PutEntry writes to both DHT and HTTP.
+// PutEntry writes to both DHT and HTTP. HTTP writes always go
+// through; the DHT mirror is skipped for unsigned/partial entries
+// (see shouldMirrorToDHT).
 func (h *HybridDiscClient) PutEntry(ctx context.Context, sk cipher.SecKey, entry *disc.Entry) error {
-	if err := h.dht.PutEntry(ctx, sk, entry); err != nil {
-		h.log.WithError(err).Debug("DHT PutEntry failed (continuing with HTTP)")
+	if shouldMirrorToDHT(entry) {
+		if err := h.dht.PutEntry(ctx, sk, entry); err != nil {
+			h.log.WithError(err).Debug("DHT PutEntry failed (continuing with HTTP)")
+		}
 	}
 	return h.http.PutEntry(ctx, sk, entry)
+}
+
+// shouldMirrorToDHT returns true when an entry is safe to mirror to
+// the DHT. The DHT can't validate inner entry signatures the way the
+// HTTP discovery does, so anything we mirror needs to already be
+// fully populated and signed by the publisher — otherwise the DHT
+// ends up holding garbage that other visors will read back via
+// HybridDiscClient.Entry.
+func shouldMirrorToDHT(entry *disc.Entry) bool {
+	if entry == nil {
+		return false
+	}
+	if entry.Static.Null() {
+		return false
+	}
+	if entry.Signature == "" {
+		return false
+	}
+	return true
 }
 
 // DelEntry deletes from both DHT and HTTP.

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -11,7 +11,6 @@ import (
 	"github.com/skycoin/skywire/pkg/dht"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/logging"
-	"github.com/skycoin/skywire/pkg/transport"
 )
 
 func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
@@ -180,13 +179,11 @@ func dhtPublishLoop(ctx context.Context, v *Visor, node *dht.Node, log *logging.
 	// above it (handles backwards clock skew + a peer that was last
 	// to receive our previous publish).
 	seq := uint64(time.Now().UnixNano())
-	for _, salt := range [][]byte{[]byte("dmsg"), []byte("tp")} {
-		queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		if got, err := node.Get(queryCtx, v.conf.PK, salt); err == nil && got != nil && got.Seq >= seq {
-			seq = got.Seq + 1
-		}
-		cancel()
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	if got, err := node.Get(queryCtx, v.conf.PK, []byte("dmsg")); err == nil && got != nil && got.Seq >= seq {
+		seq = got.Seq + 1
 	}
+	cancel()
 
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
@@ -203,53 +200,41 @@ func dhtPublishLoop(ctx context.Context, v *Visor, node *dht.Node, log *logging.
 	}
 }
 
+// dhtPublish writes the visor's DMSG discovery entry to the DHT under
+// salt "dmsg".
+//
+// Transports are NOT published here — the TPDAdapter (wired into the
+// transport manager via NewHybridTPDClient) is the sole writer of salt
+// "tp". Two writers with different formats would race; the manager-
+// driven path already publishes on every register/heartbeat in the
+// canonical SignedEntry shape that GetTransportsByEdge reads back.
 func dhtPublish(ctx context.Context, v *Visor, node *dht.Node, log *logging.Logger, seq uint64) {
-	// Publish DMSG discovery entry.
-	if v.dClient != nil {
-		entry, err := v.dClient.Entry(ctx, v.conf.PK)
-		if err == nil && entry != nil {
-			data, err := json.Marshal(entry)
-			if err == nil && len(data) <= dht.MaxValueSize {
-				if err := node.Put(ctx, data, seq, []byte("dmsg")); err != nil {
-					log.WithError(err).Trace("DHT: publish DMSG entry failed")
-				}
-			}
-		}
+	// Use the dmsg client's own discovery view (via DiscEntry → HTTP
+	// discovery) rather than v.dClient. v.dClient is a direct.Client
+	// returning synthetic placeholder entries with no Signature — those
+	// are useful inside the visor for in-memory dialing but unsafe to
+	// hand to the rest of the network as authoritative state.
+	if v.dmsgC == nil {
+		return
 	}
-
-	// Publish transport list.
-	if v.tpM != nil {
-		tps := v.tpM.GetTransportsByLabels(transport.LabelSkycoin, transport.LabelAutomatic)
-		if len(tps) > 0 {
-			type tpEntry struct {
-				Remote  cipher.PubKey `json:"r"`
-				Type    string        `json:"t"`
-				Latency float64       `json:"l,omitempty"`
-				// Bw is the live cumulative bandwidth (sent + recv
-				// bytes) for this transport. Live snapshot only; the
-				// historical daily series lives on the visor's CXO
-				// telemetry feed and HTTP /stats/* endpoints.
-				Bw uint64 `json:"b,omitempty"`
-			}
-			entries := make([]tpEntry, 0, len(tps))
-			for _, tp := range tps {
-				if tp.IsClosed() {
-					continue
-				}
-				bw := tp.GetBandwidth()
-				entries = append(entries, tpEntry{
-					Remote:  tp.Remote(),
-					Type:    string(tp.Type()),
-					Latency: tp.GetLatency(),
-					Bw:      bw.SentBytes + bw.RecvBytes,
-				})
-			}
-			data, err := json.Marshal(entries)
-			if err == nil && len(data) <= dht.MaxValueSize {
-				if err := node.Put(ctx, data, seq, []byte("tp")); err != nil {
-					log.WithError(err).Trace("DHT: publish transports failed")
-				}
-			}
-		}
+	entry, err := v.dmsgC.DiscEntry(ctx, v.conf.PK)
+	if err != nil || entry == nil {
+		return
+	}
+	// Defense-in-depth: only publish a fully-formed signed entry. Even
+	// if a future caller wires in a different discovery source, the DHT
+	// can't reject malformed inner JSON on its own, so we filter here.
+	if entry.Static != v.conf.PK || entry.Signature == "" {
+		log.WithField("static_match", entry.Static == v.conf.PK).
+			WithField("has_signature", entry.Signature != "").
+			Debug("DHT: skipping publish of malformed self DMSG entry")
+		return
+	}
+	data, err := json.Marshal(entry)
+	if err != nil || len(data) > dht.MaxValueSize {
+		return
+	}
+	if err := node.Put(ctx, data, seq, []byte("dmsg")); err != nil {
+		log.WithError(err).Trace("DHT: publish DMSG entry failed")
 	}
 }


### PR DESCRIPTION
## Summary

Three related bugs in what the visor publishes about itself to the DHT:

### 1. \`dmsg\` salt entry was a synthetic placeholder, not the canonical signed entry

\`dhtPublish\` was calling \`v.dClient.Entry(ctx, v.conf.PK)\` to obtain the entry to put on the DHT. \`v.dClient\` is a \`direct.Client\` which returns synthetic entries from \`GetClientEntry\` (\`pkg/dmsg/direct/entries.go:17-23\`) — only \`Static\` + \`Client.DelegatedServers\` populated, no \`Signature\`, no \`ClientType\`, no \`Protocol\`, \`Sequence=0\`, \`Timestamp=0\`. Mirrored to DHT, this produced an entry other visors couldn't \`VerifySignature\` on.

Worse: under \`dClient\`'s in-memory store there was an even older corruption where \`Static\` was the **transport_discovery service's PK** (\`02b307aee5c8...\`) instead of the local visor's PK, because that synthetic seed entry leaked under the wrong key during initialization at some prior point. Once stored, the bad entry self-perpetuated through the dmsg client's \`updateClientEntry\` path.

**Fix**: switch \`dhtPublish\` to \`v.dmsgC.DiscEntry\` which routes through the dmsg client's network HTTP discovery — the actual canonical signed entry. Add a defensive guard at the publish site: refuse to publish when \`Static != self\` or \`Signature == ""\`.

### 2. \`HybridDiscClient\` propagated DHT corruption

The hybrid client returned DHT entries unconditionally on hit, so once a malformed entry was stored under our key, every reader (including the dmsg client itself) saw it and republished it. Validate the DHT result against the requested PK and drop entries with empty \`Signature\`; fall through to HTTP on failure. Also gate \`PostEntry\`/\`PutEntry\` on the same check so partial entries can't leak in via writes.

### 3. Two writers raced on the \`tp\` salt

\`dhtPublish\` wrote a compact \`[]{r, t, l, b}\` format that no reader ever consumed. The canonical reader \`TPDAdapter.GetTransportsByEdge\` expects the verbose \`[]*SignedEntry\` format that \`TPDAdapter.RegisterTransports\` writes via the transport manager's \`DiscoveryClient\` on every register/heartbeat. Drop the compact branch — TPDAdapter is the sole writer now.

## Verification

\`\`\`
$ ./skywire cli visor dht get <self> dmsg | jq 'fromjson | {static_is_self: (.static == "<self>"), sequence, has_sig: (.signature != null and .signature != ""), client_type, protocol, num_servers: (.client.delegated_servers | length)}'
{
  "static_is_self": true,
  "sequence": 2,
  "has_sig": true,
  "client_type": "visor",
  "protocol": "yamux",
  "num_servers": 6
}
\`\`\`

vs the pre-fix output:

\`\`\`
{
  "static_is_self": false,           ← was 02b307aee5c8... (TPD PK)
  "sequence": 0,
  "has_sig": false,
  "client_type": null,
  "protocol": null,
  "num_servers": 1
}
\`\`\`

\`fullnode\` and \`tp\` salts unchanged and continue to look correct.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/dht/ ./pkg/visor/\` pass
- [x] Manual: DHT \`dmsg\` entry now matches HTTP discovery shape and signature