### PR TITLE
config: add --dmsgweb / --skynetweb gen flags for proxy auto-start

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -266,6 +266,17 @@ func init() {
 	genConfigCmd.Flags().BoolVar(&isProxyServerEnable, "serveproxy", scriptExecBool("${PROXYSERVER:-true}"), "autostart proxy server (default: true)")
 	genConfigCmd.Flags().StringVar(&proxyServerWhitelist, "proxywl", scriptExecArray("${PROXYSERVERWL[@]}"), "comma-separated list of public keys allowed to connect to proxy server (empty = allow all)")
 
+	// Embedded resolving-proxy flags. Browsers point a single SOCKS5
+	// at the dmsgweb listener and `.dmsg` / `.skynet` URLs resolve.
+	// When both are enabled, the runtime auto-chains dmsgweb's
+	// upstream → skynetweb so one entry covers both TLDs.
+	genConfigCmd.Flags().BoolVar(&enableDmsgWeb, "dmsgweb", scriptExecBool("${DMSGWEB:-false}"), "enable embedded .dmsg resolving SOCKS5 proxy on 127.0.0.1:4445")
+	genConfigCmd.Flags().BoolVar(&enableSkynetWeb, "skynetweb", scriptExecBool("${SKYNETWEB:-false}"), "enable embedded .skynet resolving SOCKS5 proxy on 127.0.0.1:4446")
+	genConfigCmd.Flags().StringVar(&dmsgWebUpstreamSOCKS, "dmsgweb-upstream", scriptExecString("${DMSGWEBUPSTREAM}"), "upstream SOCKS5 for non-.dmsg traffic (e.g. 127.0.0.1:1080); empty + skynetweb on = auto-chain to skynetweb")
+	gHiddenFlags = append(gHiddenFlags, "dmsgweb-upstream")
+	genConfigCmd.Flags().StringVar(&skynetWebUpstreamSOCKS, "skynetweb-upstream", scriptExecString("${SKYNETWEBUPSTREAM}"), "upstream SOCKS5 for non-.skynet traffic (e.g. 127.0.0.1:1080)")
+	gHiddenFlags = append(gHiddenFlags, "skynetweb-upstream")
+
 	// Skychat flags
 	genConfigCmd.Flags().BoolVar(&isSkychatEnable, "servechat", scriptExecBool("${SKYCHAT:-true}"), "autostart skychat (default: true)")
 	genConfigCmd.Flags().StringVar(&skychatAddr, "chataddr", scriptExecString("${SKYCHATADDR:-"+skyenv.SkychatAddr+"}"), "skychat local address")
@@ -562,6 +573,8 @@ var genConfigCmd = &cobra.Command{
 		configureHypervisor(log)
 
 		configureApps(log)
+
+		configureResolvingProxies()
 
 		applyOverrides()
 
@@ -1394,6 +1407,26 @@ func configureApps(log *logging.Logger) {
 	if (selectedOS == "win") || (selectedOS == "mac") {
 		if isHypervisor {
 			conf.Hypervisor.EnableAuth = true
+		}
+	}
+}
+
+// configureResolvingProxies populates the dmsg_web / skynet_web
+// blocks when --dmsgweb / --skynetweb is set. The visor auto-starts
+// each block at boot when Enable=true and (when both are enabled)
+// auto-chains dmsgweb → skynetweb so a browser pointed at port 4445
+// covers both .dmsg and .skynet traffic.
+func configureResolvingProxies() {
+	if enableDmsgWeb {
+		conf.DmsgWeb = &visorconfig.DmsgWebConfig{
+			Enable:        true,
+			UpstreamSOCKS: dmsgWebUpstreamSOCKS,
+		}
+	}
+	if enableSkynetWeb {
+		conf.SkynetWeb = &visorconfig.SkynetWebConfig{
+			Enable:        true,
+			UpstreamSOCKS: skynetWebUpstreamSOCKS,
 		}
 	}
 }

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -94,6 +94,10 @@ var (
 	enableProxyClientAutostart bool
 	isProxyServerEnable        bool
 	proxyServerWhitelist       string
+	enableDmsgWeb              bool
+	enableSkynetWeb            bool
+	dmsgWebUpstreamSOCKS       string
+	skynetWebUpstreamSOCKS     string
 	configServicePath          string
 	dmsgHTTPPath               string
 	snConfig                   bool


### PR DESCRIPTION
## Summary

The visor's embedded \`.dmsg\` / \`.skynet\` resolving SOCKS5 proxies already auto-start at boot when their config blocks have \`Enable=true\` (\`pkg/visor/api_proxies.go\`, \`pkg/visor/embedded_*.go\`) and auto-chain dmsgweb → skynetweb at runtime when both are present.

But there was no way to populate those blocks at config-gen time short of editing JSON by hand. Runtime toggles via \`cli visor proxies set <kind> on\` don't persist across restarts. So most users either ran the toggles every boot or never used the resolvers.

Add four \`config gen\` flags (two visible, two hidden under \`--all\`):

\`\`\`
--dmsgweb              enable .dmsg resolver block (4445)
--skynetweb            enable .skynet resolver block (4446)
--dmsgweb-upstream     optional upstream SOCKS5
--skynetweb-upstream   optional upstream SOCKS5
\`\`\`

\`\`\`shell
skywire cli config gen --dmsgweb --skynetweb -o skywire-config.json
\`\`\`

writes:

\`\`\`json
\"dmsg_web\":   { \"enable\": true }
\"skynet_web\": { \"enable\": true }
\`\`\`

When both are enabled, the runtime auto-chain (dmsgweb upstream → skynetweb) kicks in by default, so a browser pointed at \`127.0.0.1:4445\` covers \`.dmsg\` and \`.skynet\` without further config. Either upstream can be set explicitly to layer skysocks-client (\`127.0.0.1:1080\`) at the end of the chain:

\`\`\`shell
skywire cli config gen --dmsgweb --skynetweb --skynetweb-upstream 127.0.0.1:1080
\`\`\`

The existing runtime RPC controls (\`visor proxies set\`/\`upstream\`) still work for session-scoped overrides on top of whatever the config sets at boot.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] Manual: \`config gen --dmsgweb --skynetweb\` produces both blocks with \`enable: true\`
- [x] Manual: \`config gen --skynetweb-upstream 127.0.0.1:1080\` propagates through to \`upstream_socks\`
- [ ] Manual: visor started against generated config has both proxies running and chained out of the box