### PR TITLE
fix: move DefaultCXOPort off 46 to stop colliding with DmsgHypervisorPort

### DIFF
--- a/pkg/cxo/node/transport/dmsg.go
+++ b/pkg/cxo/node/transport/dmsg.go
@@ -12,10 +12,19 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 // DefaultCXOPort is the default DMSG port for CXO connections.
-const DefaultCXOPort = uint16(46)
+// Sourced from skyenv so the port allocation is visible in the same
+// table as DmsgHypervisorPort (46), DmsgTransportSetupPort (47), etc.
+//
+// Was previously the literal 46, which clashed with DmsgHypervisorPort:
+// whichever module called dmsgC.Listen first won, and on a hypervisor-
+// enabled visor the CXO publisher's Listen typically fired before the
+// hypervisor's, so hypervisor-RPC-over-DMSG silently failed with
+// "port already occupied" and remote visors stopped showing up.
+const DefaultCXOPort = skyenv.DmsgCXOPort
 
 // DMSGFactory creates and manages CXO connections over DMSG.
 // It implements the same interface as TCPFactory but uses DMSG

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -39,6 +39,12 @@ const (
 	// DmsgGRPCPort is the DMSG port for gRPC services (remote gotop, stats, etc.)
 	DmsgGRPCPort uint16 = 49
 
+	// DmsgCXOPort is the DMSG port the visor's CXO TreeStore publisher
+	// listens on (and the TPD aggregator + other visors dial). Picked
+	// outside the 46–49 dmsg-RPC cluster so the CXO listener can't
+	// collide with DmsgHypervisorPort.
+	DmsgCXOPort uint16 = 50
+
 	// DmsgDHTPort Listening port for the Kademlia DHT protocol.
 	DmsgDHTPort uint16 = 100
 


### PR DESCRIPTION
## Summary

#2359 (self-tracking telemetry) wired the visor's CXO TreeStore publisher to dmsg port \`46\` via \`pkg/cxo/node/transport/dmsg.go\`'s \`DefaultCXOPort\`. That's the same number as \`DmsgHypervisorPort\` in \`pkg/skyenv\` (also 46) — so on any hypervisor-enabled visor, whichever module called \`dmsgC.Listen\` first won the port and the loser silently failed.

In practice \`initStats\` runs early enough that the CXO publisher's \`Listen\` typically fires first, so the hypervisor RPC-over-DMSG listener gets \`dmsg error 400 - port already occupied\` and never serves. **Symptom**: \`skywire cli visor hv ls\` shows only the local visor; remote visors that normally connect to this hypervisor disappear from the list because they can't dial the hypervisor RPC.

\`\`\`
[hypervisor]: Serving hypervisor RPC over DMSG addr=\"<pk>:46\"
[hypervisor]: Hypervisor DMSG RPC stopped error=\"dmsg error 400 - port already occupied\"
\`\`\`

## Fix

- Add \`DmsgCXOPort = 50\` to \`pkg/skyenv/skyenv.go\` (next free slot after the 46–49 dmsg-RPC cluster, before \`DmsgHTTPPort = 80\`) so port allocation stays visible in one table.
- Point \`DefaultCXOPort\` at the skyenv constant. Both the visor publisher (\`pkg/cxo/treestore\`) and the TPD aggregator (\`pkg/transport-discovery/cxoaggregator\`) reference \`DefaultCXOPort\`, so the move is single-source and they stay in sync.

## Verified

After rebuild + restart, \`hv ls\` shows the full set of remote visors (only the local one before the fix).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go test ./pkg/cxo/... ./pkg/visor/ ./pkg/transport-discovery/...\` pass
- [x] Manual: \`hv ls\` populated; hypervisor RPC log line no longer reports port-already-occupied