### PR TITLE
log: include PK on untrusted-setup-node reject; quiet expected dmsg-tracker miss

### DIFF
--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -143,7 +143,10 @@ func (r *router) serveSetup() {
 
 		remotePK := conn.RawRemoteAddr().PK
 		if !r.SetupIsTrusted(remotePK) {
-			r.logger.Warnf("closing conn from untrusted setup node: %v", conn.Close())
+			closeErr := conn.Close()
+			r.logger.WithField("remote_pk", remotePK).
+				WithField("close_err", closeErr).
+				Warn("Closing conn from untrusted setup node")
 			continue
 		}
 

--- a/pkg/visor/dmsgtracker/dmsg_tracker.go
+++ b/pkg/visor/dmsgtracker/dmsg_tracker.go
@@ -3,17 +3,43 @@ package dmsgtracker
 
 import (
 	"context"
+	"errors"
 	"io"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsgctrl"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
+
+// isExpectedTrackerLookupErr classifies failures that happen during
+// normal operation: a peer that disappeared from discovery, or the
+// per-attempt deadline firing because we were already shutting down or
+// the network was slow. Loudly logging these spams the warn channel
+// without giving operators anything actionable.
+func isExpectedTrackerLookupErr(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, disc.ErrKeyNotFound) {
+		return true
+	}
+	// Fallback: dmsg discovery returns the error wrapped with a string
+	// path through net/http, so errors.Is won't catch every case.
+	msg := err.Error()
+	if strings.Contains(msg, "context canceled") ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "entry is not found") {
+		return true
+	}
+	return false
+}
 
 // Default values for DmsgTrackerManager
 const (
@@ -244,7 +270,15 @@ func (dtm *Manager) establishTracker(ctx context.Context, pk cipher.PubKey) {
 
 	dt, err := newDmsgTracker(dCtx, dtm.dc, pk)
 	if err != nil {
-		log.WithError(err).WithField("client_pk", pk).Warn("Failed to re-create dmsgtracker client.")
+		// "entry not found" + cancel/deadline are expected when a peer
+		// is offline or the tracker shuts down mid-lookup; downgrade to
+		// debug so the warn channel stays useful for real failures.
+		entry := log.WithError(err).WithField("client_pk", pk)
+		if isExpectedTrackerLookupErr(err) {
+			entry.Debug("Skipped dmsgtracker client (peer not in discovery or lookup canceled).")
+		} else {
+			entry.Warn("Failed to re-create dmsgtracker client.")
+		}
 		return
 	}
 	if dt != nil {


### PR DESCRIPTION
## Summary

Two operator-flagged log quality fixes on a hypervisor that prints a lot:

### 1. Router's untrusted-setup-node reject logs the wrong field

Before:

\`\`\`
WARN [router]: closing conn from untrusted setup node: <nil>
\`\`\`

The format string interpolated \`conn.Close()\`'s return value (almost always \`nil\`) and never the offending PK. Operators couldn't tell which setup node the visor was distrusting — important for diagnosing \`route_setup_nodes\` config drift. Switch to structured fields:

\`\`\`
WARN [router] Closing conn from untrusted setup node  remote_pk=<pk>  close_err=<err>
\`\`\`

(\`pkg/router/router_serve.go:144\`)

### 2. dmsgtracker WARNs on every offline peer + every shutdown race

\`establishTracker\` logged \`Failed to re-create dmsgtracker client\` at WARN whenever:
- A tracked peer was offline (\`dmsg error 100 - entry is not found in discovery\`)
- The per-attempt deadline fired (\`context canceled\` / \`context deadline exceeded\`)

Both are normal during operation: peers come and go, the tracker periodically races its own shutdown deadline. Result: the warn channel filled with noise during peer churn and operators learned to ignore it.

Add \`isExpectedTrackerLookupErr\` that recognizes \`context.Canceled\`, \`context.DeadlineExceeded\`, and \`disc.ErrKeyNotFound\` (plus string fallbacks because the dmsg-discovery HTTP path wraps errors in a way \`errors.Is\` doesn't see through). Route those to DEBUG; everything else still WARNs.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go vet ./...\` clean
- [ ] Manual: trigger an untrusted-setup-node connection (or just observe the next event) and confirm the PK is now in the log
- [ ] Manual: confirm \`Failed to re-create dmsgtracker client\` no longer appears at WARN for offline peers