### PR TITLE
feat(visor): user-publishable CXO feeds with /feeds discovery

### DIFF
--- a/cmd/skywire-cli/commands/visor/cxo_feeds.go
+++ b/cmd/skywire-cli/commands/visor/cxo_feeds.go
@@ -1,0 +1,125 @@
+// Package clivisor cmd/skywire-cli/commands/visor/cxo_feeds.go
+//
+// `skywire cli visor cxo` — surface for the user-publishable CXO
+// TreeStore feeds. Each feed is its own DMSG listener under the
+// visor's PK; subscribers connect to (visor PK, feed.dmsg_port) and
+// receive the published path tree.
+//
+// Discovery happens out-of-band via the dmsghttp logserver's /feeds
+// endpoint (and via this CLI which calls the same data source over
+// RPC).
+package clivisor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+)
+
+var (
+	cxoJSON            bool
+	cxoFeedDescription string
+)
+
+func init() {
+	cxoFeedsCmd.Flags().BoolVar(&cxoJSON, "json", false, "emit raw JSON")
+	cxoFeedAddCmd.Flags().StringVarP(&cxoFeedDescription, "desc", "d", "", "human-readable description")
+	cxoFeedsCmd.AddCommand(cxoFeedAddCmd)
+	cxoFeedsCmd.AddCommand(cxoFeedRmCmd)
+	cxoFeedsCmd.AddCommand(cxoFeedLsCmd)
+	cxoCmd.AddCommand(cxoFeedsCmd)
+	RootCmd.AddCommand(cxoCmd)
+}
+
+var cxoCmd = &cobra.Command{
+	Use:   "cxo",
+	Short: "CXO TreeStore controls",
+	Long:  "Inspect and manage user-published CXO feeds running on the visor.",
+}
+
+var cxoFeedsCmd = &cobra.Command{
+	Use:   "feeds",
+	Short: "List, add, and remove CXO user feeds",
+	Long: `Each visor publishes a single system feed (telemetry) by default.
+User feeds are independent CXO TreeStore publishers running on
+distinct DMSG ports under the same visor PK. Subscribers fetch
+http://<visor-pk>.dmsg/feeds for the catalog, then connect to the
+desired (PK, dmsg_port) pair over DMSG.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		// Default to ls when invoked without a subcommand.
+		_ = cmd.Help() //nolint:errcheck,gosec
+	},
+}
+
+var cxoFeedLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List published CXO feeds (system + user)",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		feeds := rpcClient.ListCXOFeeds()
+		if cxoJSON {
+			_ = json.NewEncoder(os.Stdout).Encode(feeds) //nolint:errcheck,gosec
+			return
+		}
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tDMSG PORT\tSYSTEM\tDESCRIPTION") //nolint:errcheck,gosec
+		for _, f := range feeds {
+			desc := f.Description
+			if desc == "" {
+				desc = "-"
+			}
+			fmt.Fprintf(w, "%s\t%d\t%v\t%s\n", f.Name, f.DmsgPort, f.System, desc) //nolint:errcheck,gosec
+		}
+		w.Flush() //nolint:errcheck,gosec
+	},
+}
+
+var cxoFeedAddCmd = &cobra.Command{
+	Use:   "add <name> <dmsg-port>",
+	Short: "Register a new CXO user feed",
+	Long: `Spin up a CXO TreeStore publisher under the visor's PK on the
+given DMSG port. The port must be unused by other feeds and not
+collide with reserved DMSG ports (e.g. 46 hypervisor, 47 transport
+setup, 50 system telemetry).`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		port, err := strconv.ParseUint(args[1], 10, 16)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid dmsg port %q: %w", args[1], err))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.RegisterCXOFeed(args[0], uint16(port), cxoFeedDescription); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RegisterCXOFeed failed: %w", err))
+		}
+		fmt.Printf("Feed %q registered on dmsg:%d\n", args[0], port)
+	},
+}
+
+var cxoFeedRmCmd = &cobra.Command{
+	Use:   "rm <name>",
+	Short: "Stop and remove a CXO user feed",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.UnregisterCXOFeed(args[0]); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("UnregisterCXOFeed failed: %w", err))
+		}
+		fmt.Printf("Feed %q removed\n", args[0])
+	},
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -87,6 +87,11 @@ type PubConfig struct {
 	Logger      *logging.Logger // see Config.Logger
 	InMemoryDB  bool            // forwarded to skyobject.Config
 	DataDir     string          // forwarded to skyobject.Config (ignored if InMemoryDB)
+	// DmsgPort overrides the listener port; zero falls back to
+	// cxotransport.DefaultCXOPort. Multiple publishers under the same
+	// PK can coexist as long as they use distinct ports — useful for
+	// hosting independent CXO feeds on a single visor.
+	DmsgPort uint16
 }
 
 // NewWithDMSG is a convenience wrapper around New: it constructs a
@@ -100,12 +105,24 @@ func NewWithDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, conf PubConfig) (*Publish
 	if conf.DataDir != "" {
 		cfg.Config.DataDir = conf.DataDir
 	}
+	// We're DMSG-only — disable the CXO node's default TCP/UDP/RPC
+	// listeners. They default to :8870 / :8871 / "" respectively, and
+	// hardcoded ports mean two Publishers in the same process collide
+	// on bind. None of those listeners are reachable through DMSG
+	// anyway.
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
 
 	cxoNode, err := node.NewNode(cfg)
 	if err != nil {
 		return nil, err
 	}
-	factory := cxotransport.NewDMSGFactory(dmsgC, cxotransport.DefaultCXOPort)
+	port := conf.DmsgPort
+	if port == 0 {
+		port = cxotransport.DefaultCXOPort
+	}
+	factory := cxotransport.NewDMSGFactory(dmsgC, port)
 	if err := cxoNode.EnableDMSG(factory); err != nil {
 		_ = cxoNode.Close() //nolint:errcheck
 		return nil, err

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
+	"github.com/skycoin/skywire/pkg/visor/logserver"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -188,6 +189,12 @@ type API interface {
 	DmsgConnectAll() (*DmsgConnectAllResult, error)
 	SetDmsgSessionsCount(count int) (*DmsgConnectAllResult, error)
 	DmsgSessions() (*DmsgClientSessions, error)
+
+	// CXO user feeds — visor-published TreeStore feeds beyond the
+	// always-on telemetry one. See pkg/visor/cxo_user_feeds.go.
+	RegisterCXOFeed(name string, dmsgPort uint16, description string) error
+	UnregisterCXOFeed(name string) error
+	ListCXOFeeds() []logserver.CXOFeedEntry
 
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -1,0 +1,227 @@
+// Package visor pkg/visor/cxo_user_feeds.go
+//
+// CXO user-feed registry. Each visor publishes one always-on system
+// feed (the telemetry feed wired up by initStats on
+// skyenv.DmsgCXOPort) and any number of user feeds — distinct CXO
+// TreeStore publishers running on distinct DMSG ports under the
+// visor's PK. Subscribers discover them via the dmsghttp logserver's
+// /feeds endpoint, then connect their CXO subscriber to
+// (visor PK, feed.DmsgPort) directly.
+//
+// The system feed is reserved at skyenv.DmsgCXOPort. User feeds must
+// pick a different port; collisions with system DMSG ports listed in
+// pkg/skyenv (hypervisor=46, transport-setup=47, http=80, dht=100,
+// etc.) are rejected at registration so a user feed can't shadow a
+// reserved listener.
+package visor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/visor/logserver"
+)
+
+// systemCXOFeedName is the well-known name of the visor's telemetry
+// feed (the one initStats wires up on skyenv.DmsgCXOPort). Reserved
+// so user-registered feeds can't collide with it.
+const systemCXOFeedName = "stats"
+
+// cxoUserFeed wraps a treestore.Publisher with the metadata needed for
+// /feeds discovery and clean teardown.
+type cxoUserFeed struct {
+	name        string
+	port        uint16
+	description string
+	pub         *treestore.Publisher
+}
+
+// reservedDmsgPorts enumerates DMSG ports already bound by visor
+// subsystems. Registering a CXO feed on one of these would either
+// silently fail to listen or shadow the existing service, so we reject
+// the request up front.
+//
+// Kept in code rather than discovered at runtime because the listeners
+// come up after init in a way that races RegisterCXOFeed; a static
+// table is simpler and the cost of staying in sync with skyenv is one
+// line per new system port.
+func reservedDmsgPorts() map[uint16]string {
+	return map[uint16]string{
+		skyenv.DmsgCtrlPort:                  "dmsgctrl",
+		skyenv.DmsgPingPort:                  "dmsg-ping",
+		skyenv.DmsgPtyPort:                   "dmsgpty",
+		skyenv.DmsgSetupPort:                 "setup-node",
+		skyenv.DmsgHypervisorPort:            "hypervisor-rpc",
+		skyenv.DmsgTransportSetupPort:        "transport-setup",
+		skyenv.DmsgTransportSetupServicePort: "transport-setup-service",
+		skyenv.DmsgGRPCPort:                  "grpc",
+		skyenv.DmsgCXOPort:                   "stats", // system CXO feed
+		80:                                   "dmsg-http",
+		skyenv.DmsgDHTPort:                   "dht",
+		skyenv.DmsgAwaitSetupPort:            "await-setup",
+	}
+}
+
+// RegisterCXOFeed creates and starts a user CXO feed under name on
+// dmsgPort. Idempotent on (name, port) — registering an existing feed
+// returns nil without re-creating it. Conflicts (same name with a
+// different port, or a port collision with another feed/system port)
+// return errors.
+func (v *Visor) RegisterCXOFeed(name string, dmsgPort uint16, description string) error {
+	if name == "" {
+		return errors.New("cxo feed: name required")
+	}
+	if name == systemCXOFeedName {
+		return fmt.Errorf("cxo feed: name %q reserved for the system telemetry feed", name)
+	}
+	if dmsgPort == 0 {
+		return errors.New("cxo feed: dmsg port required")
+	}
+	if used, ok := reservedDmsgPorts()[dmsgPort]; ok {
+		return fmt.Errorf("cxo feed: dmsg port %d reserved for %s", dmsgPort, used)
+	}
+	if v.dmsgC == nil {
+		return errors.New("cxo feed: dmsg client not available")
+	}
+
+	v.cxoUserFeedsMu.Lock()
+	defer v.cxoUserFeedsMu.Unlock()
+
+	if v.cxoUserFeeds == nil {
+		v.cxoUserFeeds = make(map[string]*cxoUserFeed)
+	}
+	if existing, ok := v.cxoUserFeeds[name]; ok {
+		if existing.port != dmsgPort {
+			return fmt.Errorf("cxo feed %q already registered on port %d", name, existing.port)
+		}
+		if description != "" && existing.description != description {
+			existing.description = description
+		}
+		return nil
+	}
+	for _, fd := range v.cxoUserFeeds {
+		if fd.port == dmsgPort {
+			return fmt.Errorf("cxo feed: dmsg port %d already used by feed %q", dmsgPort, fd.name)
+		}
+	}
+
+	log := v.MasterLogger().PackageLogger("cxo_user_feed:" + name)
+	dataDir := filepath.Join(v.conf.LocalPath, "cxo-user-feeds", name)
+	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
+		BatchWindow: 1 * time.Second,
+		Logger:      log,
+		DataDir:     dataDir,
+		DmsgPort:    dmsgPort,
+	})
+	if err != nil {
+		return fmt.Errorf("cxo feed %q: start publisher: %w", name, err)
+	}
+	v.cxoUserFeeds[name] = &cxoUserFeed{
+		name:        name,
+		port:        dmsgPort,
+		description: description,
+		pub:         pub,
+	}
+	log.WithField("port", dmsgPort).WithField("data_dir", dataDir).
+		Info("CXO user feed registered")
+	return nil
+}
+
+// UnregisterCXOFeed stops a previously-registered user feed.
+// Removing the system feed by name is rejected. Unknown names are a
+// no-op (idempotent).
+func (v *Visor) UnregisterCXOFeed(name string) error {
+	if name == systemCXOFeedName {
+		return fmt.Errorf("cxo feed: cannot unregister system feed %q", name)
+	}
+	v.cxoUserFeedsMu.Lock()
+	feed, ok := v.cxoUserFeeds[name]
+	if ok {
+		delete(v.cxoUserFeeds, name)
+	}
+	v.cxoUserFeedsMu.Unlock()
+	if !ok {
+		return nil
+	}
+	if err := feed.pub.Close(); err != nil {
+		return fmt.Errorf("cxo feed %q: close: %w", name, err)
+	}
+	v.log.WithField("name", name).Info("CXO user feed unregistered")
+	return nil
+}
+
+// ListCXOFeeds implements logserver.CXOFeedsLister. Returns the system
+// telemetry feed plus every user-registered feed, sorted by port for
+// stable output.
+func (v *Visor) ListCXOFeeds() []logserver.CXOFeedEntry {
+	out := []logserver.CXOFeedEntry{
+		{
+			Name:        systemCXOFeedName,
+			DmsgPort:    skyenv.DmsgCXOPort,
+			Description: "visor self-tracking telemetry (transports, uptime, services)",
+			System:      true,
+		},
+	}
+	v.cxoUserFeedsMu.Lock()
+	for _, fd := range v.cxoUserFeeds {
+		out = append(out, logserver.CXOFeedEntry{
+			Name:        fd.name,
+			DmsgPort:    fd.port,
+			Description: fd.description,
+		})
+	}
+	v.cxoUserFeedsMu.Unlock()
+	// Stable order: system feed first (it's appended first), then user
+	// feeds in port order so listing diffs are deterministic.
+	if len(out) > 2 {
+		sortFeedsByPort(out[1:])
+	}
+	return out
+}
+
+// closeAllCXOUserFeeds stops every user feed. Called from the visor
+// close stack on shutdown.
+func (v *Visor) closeAllCXOUserFeeds() error {
+	v.cxoUserFeedsMu.Lock()
+	feeds := v.cxoUserFeeds
+	v.cxoUserFeeds = nil
+	v.cxoUserFeedsMu.Unlock()
+
+	var firstErr error
+	for name, fd := range feeds {
+		if err := fd.pub.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("cxo feed %q close: %w", name, err)
+		}
+	}
+	return firstErr
+}
+
+func sortFeedsByPort(feeds []logserver.CXOFeedEntry) {
+	for i := 1; i < len(feeds); i++ {
+		for j := i; j > 0 && feeds[j-1].DmsgPort > feeds[j].DmsgPort; j-- {
+			feeds[j-1], feeds[j] = feeds[j], feeds[j-1]
+		}
+	}
+}
+
+// initCXOUserFeeds wires the user-feed registry into the visor
+// lifecycle. Runs after initStats so the logserver's CXOFeedsLister
+// hookup happens after lsAPI is available. The registry itself starts
+// empty — feeds are added at runtime via RPC.
+func initCXOUserFeeds(_ context.Context, v *Visor, log *logging.Logger) error {
+	v.initLock.RLock()
+	lsAPI := v.logServer.api
+	v.initLock.RUnlock()
+	if lsAPI != nil {
+		lsAPI.SetCXOFeedsLister(v)
+	}
+	v.pushCloseStack("cxo_user_feeds", v.closeAllCXOUserFeeds)
+	log.Debug("CXO user-feed registry ready")
+	return nil
+}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -126,7 +126,8 @@ var (
 	// Kademlia DHT node
 	dhtMod vinit.Module
 	// Visor-local telemetry store (bbolt + sampler)
-	statsMod vinit.Module
+	statsMod        vinit.Module
+	cxoUserFeedsMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -193,8 +194,11 @@ func registerModules(logger *logging.MasterLogger) {
 	// pull-style and tolerate nil at probe time, so missing-but-still-
 	// initializing deps just yield "offline" for that subsystem.
 	statsMod = maker("stats", initStats, &tr, &dmsgC, &launch)
+	// User-feed registry depends on stats (it shares the logserver
+	// hookup) and dmsgC (each user feed gets its own dmsg listener).
+	cxoUserFeedsMod = maker("cxo_user_feeds", initCXOUserFeeds, &statsMod, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &statsMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &statsMod, &cxoUserFeedsMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -62,6 +62,24 @@ type HealthStatsProvider interface {
 	GetNetworkTypes() []string
 }
 
+// CXOFeedEntry describes one CXO TreeStore feed published by the visor.
+// Subscribers connect to (visor PK, DmsgPort) over DMSG and request
+// the registered prefix, mirroring the data into their own subscriber.
+type CXOFeedEntry struct {
+	Name        string `json:"name"`
+	DmsgPort    uint16 `json:"dmsg_port"`
+	Description string `json:"description,omitempty"`
+	System      bool   `json:"system,omitempty"`
+}
+
+// CXOFeedsLister provides the list of CXO feeds the visor is publishing.
+// Returns the always-on system feed (stats/telemetry) plus any
+// user-registered feeds. Pure metadata — actual feed content is served
+// out-of-band over DMSG by treestore.Publisher.
+type CXOFeedsLister interface {
+	ListCXOFeeds() []CXOFeedEntry
+}
+
 // API register all the API endpoints.
 // It implements a net/http.Handler.
 type API struct {
@@ -72,6 +90,7 @@ type API struct {
 	healthStatsProvider HealthStatsProvider
 	serviceLister       ServiceLister
 	forwardedPortLister ForwardedPortLister
+	cxoFeedsLister      CXOFeedsLister
 	statsReader         StatsReader  // visor-local telemetry store, set via SetStatsReader
 	websiteHandler      http.Handler // optional: serves unmatched routes (custom website)
 }
@@ -133,6 +152,19 @@ func New(log *logging.Logger, tpLogPath, localPath, _ string, whitelistedPKs []c
 			return
 		}
 		c.JSON(http.StatusOK, api.serviceLister.ListPublic())
+	})
+
+	// CXO feed catalog — lists every feed (system + user-registered)
+	// that the visor publishes over DMSG. Subscribers fetch this once
+	// to discover names + ports, then connect their CXO subscriber to
+	// (this visor's PK, dmsg_port) and apply prefix filtering. Pure
+	// metadata, no auth required.
+	r.GET("/feeds", func(c *gin.Context) {
+		if api.cxoFeedsLister == nil {
+			c.JSON(http.StatusOK, []CXOFeedEntry{})
+			return
+		}
+		c.JSON(http.StatusOK, api.cxoFeedsLister.ListCXOFeeds())
 	})
 
 	// Transport log files (auth'd)
@@ -352,6 +384,12 @@ func (api *API) SetServiceLister(lister ServiceLister) {
 // SetForwardedPortLister sets the forwarded port provider for the landing page.
 func (api *API) SetForwardedPortLister(lister ForwardedPortLister) {
 	api.forwardedPortLister = lister
+}
+
+// SetCXOFeedsLister sets the CXO feed catalog provider. Called from
+// visor init after the user-feed registry is wired up.
+func (api *API) SetCXOFeedsLister(lister CXOFeedsLister) {
+	api.cxoFeedsLister = lister
 }
 
 func whitelistAuth(whitelistedPKs []cipher.PubKey) gin.HandlerFunc {

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
+	"github.com/skycoin/skywire/pkg/visor/logserver"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -1039,6 +1040,29 @@ func (rc *rpcClient) DmsgSessions() (*DmsgClientSessions, error) {
 		return nil, err
 	}
 	return &resp, nil
+}
+
+// RegisterCXOFeed implements API.
+func (rc *rpcClient) RegisterCXOFeed(name string, dmsgPort uint16, description string) error {
+	return rc.Call("RegisterCXOFeed", &RegisterCXOFeedRequest{
+		Name:        name,
+		DmsgPort:    dmsgPort,
+		Description: description,
+	}, &struct{}{})
+}
+
+// UnregisterCXOFeed implements API.
+func (rc *rpcClient) UnregisterCXOFeed(name string) error {
+	return rc.Call("UnregisterCXOFeed", &name, &struct{}{})
+}
+
+// ListCXOFeeds implements API.
+func (rc *rpcClient) ListCXOFeeds() []logserver.CXOFeedEntry {
+	var resp []logserver.CXOFeedEntry
+	if err := rc.Call("ListCXOFeeds", &struct{}{}, &resp); err != nil {
+		return nil
+	}
+	return resp
 }
 
 // TPSStatus returns the status of the embedded TPS.

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -27,6 +27,7 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/util/cipherutil"
+	"github.com/skycoin/skywire/pkg/visor/logserver"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -1071,6 +1072,15 @@ func (mc *mockRPCClient) SetDmsgSessionsCount(_ int) (*DmsgConnectAllResult, err
 func (mc *mockRPCClient) DmsgSessions() (*DmsgClientSessions, error) {
 	return &DmsgClientSessions{}, nil
 }
+
+// RegisterCXOFeed implements API.
+func (mc *mockRPCClient) RegisterCXOFeed(_ string, _ uint16, _ string) error { return nil }
+
+// UnregisterCXOFeed implements API.
+func (mc *mockRPCClient) UnregisterCXOFeed(_ string) error { return nil }
+
+// ListCXOFeeds implements API.
+func (mc *mockRPCClient) ListCXOFeeds() []logserver.CXOFeedEntry { return nil }
 
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {

--- a/pkg/visor/rpc_cxo_feeds.go
+++ b/pkg/visor/rpc_cxo_feeds.go
@@ -1,0 +1,51 @@
+// Package visor pkg/visor/rpc_cxo_feeds.go
+//
+// RPC adapter for the CXO user-feed registry. The handlers are thin
+// wrappers over Visor.RegisterCXOFeed / UnregisterCXOFeed /
+// ListCXOFeeds; per-feed lifecycle management lives in
+// cxo_user_feeds.go.
+package visor
+
+import (
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/util/rpcutil"
+	"github.com/skycoin/skywire/pkg/visor/logserver"
+)
+
+// RegisterCXOFeedRequest is the input to RPC.RegisterCXOFeed.
+type RegisterCXOFeedRequest struct {
+	Name        string `json:"name"`
+	DmsgPort    uint16 `json:"dmsg_port"`
+	Description string `json:"description,omitempty"`
+}
+
+// RegisterCXOFeed creates a new user-published CXO TreeStore feed
+// listening on dmsgPort under the visor's PK. The feed is reachable
+// from any peer that subscribes to (visor PK, dmsgPort) over DMSG.
+func (r *RPC) RegisterCXOFeed(req *RegisterCXOFeedRequest, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "RegisterCXOFeed", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.RegisterCXOFeed(req.Name, req.DmsgPort, req.Description)
+}
+
+// UnregisterCXOFeed stops the named user feed (no-op for unknown
+// names). The reserved system feed name "stats" cannot be removed.
+func (r *RPC) UnregisterCXOFeed(name *string, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "UnregisterCXOFeed", name)(nil, &err)
+	if name == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.UnregisterCXOFeed(*name)
+}
+
+// ListCXOFeeds returns the current set of feeds (system + user).
+// Mirrors what the dmsghttp logserver exposes at /feeds for
+// out-of-band discovery.
+func (r *RPC) ListCXOFeeds(_ *struct{}, out *[]logserver.CXOFeedEntry) (err error) {
+	defer rpcutil.LogCall(r.log, "ListCXOFeeds", nil)(out, &err)
+	*out = r.visor.ListCXOFeeds()
+	return nil
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -173,6 +173,13 @@ type Visor struct {
 	// publisher.
 	statsTracker *stats.Tracker
 
+	// User-registered CXO TreeStore feeds keyed by name. Each feed
+	// is its own dmsg listener on a distinct port; the system feed
+	// (telemetry) is published separately by initStats and shows up
+	// in ListCXOFeeds via systemCXOFeed below.
+	cxoUserFeeds   map[string]*cxoUserFeed
+	cxoUserFeedsMu sync.Mutex
+
 	// Embedded DMSG Web resolver (nil if dmsg_web.enable is false).
 	// Provides a localhost SOCKS5 proxy that resolves .dmsg hosts.
 	embeddedDmsgWeb *EmbeddedDmsgWeb


### PR DESCRIPTION
## Summary

The visor publishes one always-on CXO TreeStore feed (telemetry, on \`skyenv.DmsgCXOPort = 50\` after #2367). This PR adds the ability for users to publish their own feeds alongside it without touching the telemetry stream.

**Architecture: \`(PK, dmsg port)\` = independent feed.** Each user feed runs its own \`treestore.Publisher\` on a distinct dmsg port under the visor's PK. Subscribers connect to \`(visor PK, feed.dmsg_port)\` over DMSG and receive the published path tree. Different feeds don't share a root, so:

- Path conflicts are impossible — \`chat\` can put \`/posts/\` and \`stats\` can put \`/transports/\` without coordination.
- Rolling / resetting / restarting one feed doesn't touch the others.
- Each feed has its own \`BatchWindow\`, lifecycle, and persistent storage under \`local/cxo-user-feeds/<name>/\`.

## What's included

- **\`Visor.RegisterCXOFeed\` / \`UnregisterCXOFeed\` / \`ListCXOFeeds\`** in \`pkg/visor/cxo_user_feeds.go\`. Registry keyed by name. Reserved-port checks reject collisions with system DMSG ports (hypervisor 46, transport-setup 47, http 80, dht 100, etc.) and cross-feed port duplicates up front.
- **\`treestore.PubConfig.DmsgPort\`** override so multiple publishers coexist at the same PK on different ports.
- **CXO node hardcoded listener fix**: \`pkg/cxo/treestore/publisher.go\` disables the \`node.NewConfig\` defaults of \`TCP=:8870\`, \`RPC=:8871\`. Two publishers in the same process used to collide on those binds; none of them are reachable through DMSG anyway, so the listeners were just wasted.
- **\`/feeds\` endpoint** on the dmsghttp logserver returning the catalog as JSON. No auth — metadata only. Subscribers \`curl http://<pk>.dmsg/feeds\` (already routes through dmsgweb) to discover what a visor publishes.
- **RPC**: \`RegisterCXOFeed\`, \`UnregisterCXOFeed\`, \`ListCXOFeeds\`.
- **CLI**: \`skywire cli visor cxo feeds ls / add / rm\`.

## Verified end-to-end

\`\`\`
$ skywire cli visor cxo feeds ls
NAME   DMSG PORT  SYSTEM  DESCRIPTION
stats  50         true    visor self-tracking telemetry (...)

$ skywire cli visor cxo feeds add chat 51 --desc "demo chat feed"
Feed \"chat\" registered on dmsg:51

$ skywire cli visor cxo feeds add bad 46
FATAL: cxo feed: dmsg port 46 reserved for hypervisor-rpc

$ curl -sS --socks5-hostname 127.0.0.1:4445 \"http://<pk>.dmsg/feeds\" | jq
[
  {\"name\": \"stats\", \"dmsg_port\": 50, \"description\": \"...\", \"system\": true},
  {\"name\": \"chat\", \"dmsg_port\": 51, \"description\": \"demo chat feed\"}
]
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/cxo/... ./pkg/visor/...\` pass
- [x] Manual: register / list / port-collision / unregister
- [x] Manual: \`/feeds\` over DMSG returns the catalog
- [ ] Subscriber-side integration: connect a separate visor's CXO subscriber to a registered user feed and verify \`Put\`/\`Walk\` work end-to-end