### PR TITLE
fix(visor): port-80 reverse proxy honors --local-port when --proxy-addr empty

### DIFF
--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -52,17 +52,33 @@ func (v *Visor) refreshWebsiteHandler(log *logging.Logger) {
 		return
 	}
 
-	// Reverse-proxy mode: a forwarded port for 80 with proxy_addr.
-	if fp := v.forwardedPorts.Get(int(visorconfig.DmsgHTTPPort)); fp != nil && fp.ProxyAddr != "" {
-		target, err := url.Parse("http://" + fp.ProxyAddr)
-		if err != nil {
-			log.WithError(err).Warn("Invalid forwarded port proxy_addr; clearing website handler")
-			lsAPI.SetWebsiteHandler(nil)
+	// Reverse-proxy mode: a forwarded port for 80 with proxy_addr (or
+	// local_port as a fallback). Port 80 is owned by the dmsghttp
+	// logserver — raw-TCP forwarding can't bind it, so the only way
+	// to expose a local service on the visor's port-80 face is the
+	// reverse proxy. If a user registers port 80 with --local-port
+	// instead of --proxy-addr, treat that as their intent and
+	// derive the proxy target from local_port; otherwise the entry
+	// would silently do nothing and the visor landing page would
+	// keep showing.
+	if fp := v.forwardedPorts.Get(int(visorconfig.DmsgHTTPPort)); fp != nil {
+		addr := fp.ProxyAddr
+		if addr == "" && fp.LocalPort > 0 {
+			addr = fmt.Sprintf("127.0.0.1:%d", fp.LocalPort)
+			log.WithField("local_port", fp.LocalPort).
+				Info("Port 80 has --local-port but no --proxy-addr; using localhost:LocalPort as reverse-proxy target")
+		}
+		if addr != "" {
+			target, err := url.Parse("http://" + addr)
+			if err != nil {
+				log.WithError(err).Warn("Invalid forwarded port target; clearing website handler")
+				lsAPI.SetWebsiteHandler(nil)
+				return
+			}
+			log.WithField("addr", addr).Info("Reverse-proxying custom website (port 80)")
+			lsAPI.SetWebsiteHandler(httputil.NewSingleHostReverseProxy(target))
 			return
 		}
-		log.WithField("addr", fp.ProxyAddr).Info("Reverse-proxying custom website (port 80)")
-		lsAPI.SetWebsiteHandler(httputil.NewSingleHostReverseProxy(target))
-		return
 	}
 
 	// Default: clear the handler so the built-in landing page shows.


### PR DESCRIPTION
## Summary

Footgun: registering a forwarded port for 80 with \`--local-port 9883\` instead of \`--proxy-addr 127.0.0.1:9883\` silently kept the visor's default landing page. The website-handler refresh checked only \`ProxyAddr\` — \`LocalPort\` was ignored. The entry shows up in \`port ls\` with \`LOCAL ADDR: localhost:9883\` (because \`EffectiveLocalPort\` falls back to \`LocalPort\`), so it looks correct, but the visor's port-80 face keeps serving \`/health\`, \`/node-info\`, etc., not the user's site.

For port 80 the two flags aren't really alternatives — port 80 is owned by the dmsghttp logserver, raw-TCP forwarding can't bind it, and the only way to expose a local service through the visor's port-80 face is the reverse proxy. So if a user's intent is \"expose this local port as my visor's port 80,\" \`--local-port\` reads naturally even though the implementation cares about \`ProxyAddr\`.

## Fix

In \`refreshWebsiteHandler\`, when \`ProxyAddr\` is empty for the port-80 entry, fall back to \`\"127.0.0.1:<LocalPort>\"\`. Logs the substitution at INFO so the operator sees what we did and can rewrite the entry explicitly with \`--proxy-addr\` if they prefer.

## Verified

\`\`\`
$ skywire cli skynet port add 80 --local-port 9999 --label test
Port 80 forwarded (local TCP 9999) (test)

# log shows the substitution + reverse proxy mount
INFO [dmsghttp_logserver]: Port 80 has --local-port but no --proxy-addr;
     using localhost:LocalPort as reverse-proxy target  local_port=9999
INFO [dmsghttp_logserver]: Reverse-proxying custom website (port 80)
     addr=\"127.0.0.1:9999\"
\`\`\`

The websiteHandler now serves the local 9999 service for any path that doesn't collide with the visor's built-in routes (\`/health\`, \`/node-info\`, \`/visor.log\`, \`/stats/*\`, etc.).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] \`go vet ./...\` clean
- [x] Manual: \`cli skynet port add 80 --local-port N\` triggers website handler refresh on the localhost:N target; previous flow with \`--proxy-addr\` keeps working unchanged