### PR TITLE
fix(sudph): reconnect on AR drop, retry STUN on transient fail, 3s→5s handshake

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -512,12 +512,16 @@ func (a *API) writeJSON(w http.ResponseWriter, r *http.Request, code int, object
 }
 
 // sudphHandshakeTimeout is the per-connection deadline for completing the
-// SUDPH responder handshake. Legitimate clients complete the 3-frame
-// exchange in well under a second; the default handshake.Timeout of 10s
-// is needlessly generous for a public-facing UDP listener and lets
-// scanner / broken-client connections accumulate one goroutine and one
-// KCP session each for the full 10s.
-const sudphHandshakeTimeout = 3 * time.Second
+// SUDPH responder handshake. Legitimate clients on a healthy network
+// complete the 3-frame exchange in well under a second, but real visors
+// on slow / lossy links (high RTT + KCP retransmission) can take longer.
+// The default handshake.Timeout of 10s was needlessly generous for a
+// public-facing UDP listener and let scanner / broken-client connections
+// accumulate state for the full 10s; 3s was tight enough that legitimate
+// slow clients were timing out and never appearing in the AR. 5s is the
+// compromise: still shaves ~50% off the worst-case scanner waste vs. the
+// 10s default, while leaving enough budget for high-RTT real handshakes.
+const sudphHandshakeTimeout = 5 * time.Second
 
 // sudphMaxInFlightHandshakes caps the number of concurrent in-flight
 // SUDPH handshakes. Any new UDP connection arriving while this many

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -38,6 +38,13 @@ const (
 	defaultUDPPort          = "30178"
 	// UDPDelBindMessage is used as a deletebind packet on visor shutdown.
 	UDPDelBindMessage = "delBind"
+	// sudphReconnectInitialBackoff is the initial sleep before the first
+	// retry after a SUDPH connection to AR dies. Doubles on each failed
+	// attempt up to sudphReconnectMaxBackoff.
+	sudphReconnectInitialBackoff = 2 * time.Second
+	// sudphReconnectMaxBackoff caps the reconnect sleep so a long AR
+	// outage doesn't push the retry interval out indefinitely.
+	sudphReconnectMaxBackoff = 60 * time.Second
 )
 
 var (
@@ -333,40 +340,76 @@ func (c *httpClient) delBindSTCPR(ctx context.Context) error {
 type Handshake func(net.Conn) (net.Conn, error)
 
 func (c *httpClient) BindSUDPH(filter *pfilter.PacketFilter, hs Handshake) (<-chan RemoteVisor, error) {
-	log := c.log.WithField("func", "httpClient.BindSUDPR")
+	log := c.log.WithField("func", "httpClient.BindSUDPH")
 	if !c.isReady() {
-		log.Debug("BindSUDPR: Address resolver is not ready yet, waiting...")
+		log.Debug("BindSUDPH: Address resolver is not ready yet, waiting...")
 		<-c.ready
-		log.Debug("BindSUDPR: Address resolver became ready, binding")
+		log.Debug("BindSUDPH: Address resolver became ready, binding")
 	}
 
-	rAddr, err := net.ResolveUDPAddr("udp", c.remoteUDPAddr)
+	// First connect must succeed for the caller to consider SUDPH initialized;
+	// surface dial / handshake / register failure synchronously.
+	arConn, localAddresses, err := c.connectSUDPH(filter, hs)
 	if err != nil {
 		return nil, err
 	}
 
-	c.sudphConn = filter.NewConn(sudphPriority, packetfilter.NewAddressFilter(rAddr, c.mLog))
+	c.sudphArConn = arConn
+	c.sudphLocalAddr = localAddresses
+
+	// addrCh is the long-lived channel returned to the caller. It survives
+	// individual arConn instances; reconnects do not close it. It is closed
+	// exactly once, on shutdown, by serveSUDPHReconnect's defer.
+	addrCh := make(chan RemoteVisor, addrChSize)
+
+	// Single delBindSUDPH goroutine for the lifetime of the client. It
+	// blocks until c.closed fires, then writes the unbind packet on
+	// whichever arConn is current at that moment.
+	c.delBindSudphWg.Add(1)
+	go c.delBindSUDPHLoop()
+
+	go c.serveSUDPHReconnect(filter, hs, arConn, addrCh)
+
+	return addrCh, nil
+}
+
+// connectSUDPH establishes a fresh KCP+handshake session with the AR's UDP
+// listener and posts the initial register payload. Called once on initial
+// BindSUDPH and again on every reconnect attempt.
+//
+// The underlying packet listener (c.sudphConn) is created on the first call
+// and reused across reconnects so the local UDP port stays stable — both
+// for AR's record of our public address and for any remote visors that
+// already received our (PK, port) tuple via Resolve.
+func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (net.Conn, LocalAddresses, error) {
+	rAddr, err := net.ResolveUDPAddr("udp", c.remoteUDPAddr)
+	if err != nil {
+		return nil, LocalAddresses{}, err
+	}
+
+	if c.sudphConn == nil {
+		c.sudphConn = filter.NewConn(sudphPriority, packetfilter.NewAddressFilter(rAddr, c.mLog))
+	}
 
 	_, localPort, err := net.SplitHostPort(c.sudphConn.LocalAddr().String())
 	if err != nil {
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 
-	log.Debugf("SUDPH Local port: %v", localPort)
 	kcpConn, err := kcp.NewConn(c.remoteUDPAddr, nil, 0, 0, c.sudphConn)
 	if err != nil {
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 	arConn, err := hs(kcpConn)
 	if err != nil {
 		kcpConn.Close() //nolint:errcheck,gosec
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 
 	addresses, err := netutil.LocalAddresses()
 	if err != nil {
 		arConn.Close() //nolint:errcheck,gosec
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 
 	localAddresses := LocalAddresses{
@@ -377,39 +420,102 @@ func (c *httpClient) BindSUDPH(filter *pfilter.PacketFilter, hs Handshake) (<-ch
 	laData, err := json.Marshal(localAddresses)
 	if err != nil {
 		arConn.Close() //nolint:errcheck,gosec
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 
 	if _, err := arConn.Write(laData); err != nil {
 		arConn.Close() //nolint:errcheck,gosec
-		return nil, err
+		return nil, LocalAddresses{}, err
 	}
 
-	// Store for re-registration
-	c.sudphArConn = arConn
-	c.sudphLocalAddr = localAddresses
+	return arConn, localAddresses, nil
+}
 
-	addrCh := c.readSUDPHMessages(arConn)
+// serveSUDPHReconnect runs the per-connection loops (heartbeat / re-register /
+// read-and-forward) over arConn and reconnects with backoff when the
+// connection dies. The supplied addrCh is held across reconnects so callers
+// see a single channel that survives transient AR outages, network blips,
+// or KCP session resets. Without this loop, any of those events would
+// silently exit the per-connection goroutines, leaving the visor unreachable
+// via SUDPH until it was restarted.
+func (c *httpClient) serveSUDPHReconnect(filter *pfilter.PacketFilter, hs Handshake, arConn net.Conn, addrCh chan<- RemoteVisor) {
+	defer close(addrCh)
 
-	go func() {
-		if err := c.keepSudphHeartbeatLoop(arConn); err != nil {
-			log.WithError(err).Errorf("Failed to send UDP heartbeat packet to address-resolver")
+	backoff := sudphReconnectInitialBackoff
+	for {
+		c.serveSUDPHConn(arConn, addrCh)
+
+		if c.isClosed() {
+			return
 		}
+
+		c.log.Warn("SUDPH connection to address-resolver lost, reconnecting...")
+		var newConn net.Conn
+		var newLocalAddrs LocalAddresses
+		for {
+			select {
+			case <-c.closed:
+				return
+			case <-time.After(backoff):
+			}
+			var err error
+			newConn, newLocalAddrs, err = c.connectSUDPH(filter, hs)
+			if err == nil {
+				break
+			}
+			c.log.WithError(err).Warn("SUDPH reconnect failed, will retry")
+			backoff *= 2
+			if backoff > sudphReconnectMaxBackoff {
+				backoff = sudphReconnectMaxBackoff
+			}
+		}
+		backoff = sudphReconnectInitialBackoff
+		arConn = newConn
+		c.sudphArConn = arConn
+		c.sudphLocalAddr = newLocalAddrs
+		c.log.Info("SUDPH reconnected to address-resolver")
+	}
+}
+
+// serveSUDPHConn runs the read / heartbeat / re-register loops on arConn
+// until any of them errors (connection dead) or the client is closed.
+// Returns once all three loops have exited.
+//
+// On the connection-dead path, the first loop to exit closes arConn so the
+// other two unblock quickly (read by EOF, write by broken-pipe). On the
+// clean-shutdown path (c.closed) we leave arConn open so delBindSUDPHLoop
+// can still write the unbind packet; Close() tears down the underlying
+// packet listener afterwards, which makes the read loop exit.
+func (c *httpClient) serveSUDPHConn(arConn net.Conn, addrCh chan<- RemoteVisor) {
+	var (
+		wg           sync.WaitGroup
+		closeOnce    sync.Once
+		closeOnError = func() {
+			if c.isClosed() {
+				return
+			}
+			closeOnce.Do(func() { _ = arConn.Close() }) //nolint:errcheck
+		}
+	)
+
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		c.readSUDPHIntoChan(arConn, addrCh)
+		closeOnError()
+	}()
+	go func() {
+		defer wg.Done()
+		_ = c.keepSudphHeartbeatLoop(arConn) //nolint:errcheck
+		closeOnError()
+	}()
+	go func() {
+		defer wg.Done()
+		_ = c.sudphReRegisterLoop(arConn) //nolint:errcheck
+		closeOnError()
 	}()
 
-	go func() {
-		if err := c.sudphReRegisterLoop(arConn); err != nil {
-			log.WithError(err).Errorf("Failed to re-register SUDPH with address-resolver")
-		}
-	}()
-
-	go func() {
-		if err := c.delBindSUDPH(arConn); err != nil {
-			log.WithError(err).Errorf("Failed to send UDP unbind packet to address-resolver")
-		}
-	}()
-
-	return addrCh, nil
+	wg.Wait()
 }
 
 func (c *httpClient) Resolve(ctx context.Context, tType string, pk cipher.PubKey) (VisorData, error) {
@@ -597,45 +703,52 @@ type RemoteVisor struct {
 	Addr string
 }
 
-func (c *httpClient) readSUDPHMessages(reader io.Reader) <-chan RemoteVisor {
-	addrCh := make(chan RemoteVisor, addrChSize)
+// readSUDPHIntoChan reads framed messages from arConn and forwards parsed
+// RemoteVisor entries onto out. Unlike the previous readSUDPHMessages it
+// does NOT close out — that channel is owned by serveSUDPHReconnect and
+// outlives individual arConn instances across reconnects.
+//
+// On c.closed, a watcher goroutine forces the blocked Read to return via
+// SetReadDeadline (a closed deadline is the only reliable way to interrupt
+// a blocked KCP/yamux Read mid-call without closing the underlying conn).
+func (c *httpClient) readSUDPHIntoChan(arConn net.Conn, out chan<- RemoteVisor) {
+	done := make(chan struct{})
+	defer close(done)
 
-	go func(addrCh chan<- RemoteVisor) {
-		defer func() {
-			close(addrCh)
-		}()
-
-		buf := make([]byte, 4096)
-
-		for {
-			select {
-			case <-c.closed:
-				return
-			default:
-				n, err := reader.Read(buf)
-				if err != nil {
-					if c.isClosed() {
-						c.log.Debugf("SUDPH conn closed on shutdown message: %v", err)
-						return
-					}
-					c.log.Errorf("Failed to read SUDPH message: %v", err)
-					return
-				}
-
-				c.log.Debugf("New SUDPH message: %v", string(buf[:n]))
-
-				var remote RemoteVisor
-				if err := json.Unmarshal(buf[:n], &remote); err != nil {
-					c.log.Errorf("Failed to read unmarshal message: %v", err)
-					continue
-				}
-
-				addrCh <- remote
-			}
+	go func() {
+		select {
+		case <-c.closed:
+			_ = arConn.SetReadDeadline(time.Unix(1, 0)) //nolint:errcheck
+		case <-done:
 		}
-	}(addrCh)
+	}()
 
-	return addrCh
+	buf := make([]byte, 4096)
+	for {
+		n, err := arConn.Read(buf)
+		if err != nil {
+			if c.isClosed() {
+				c.log.Debugf("SUDPH conn closed on shutdown: %v", err)
+			} else {
+				c.log.Debugf("SUDPH read error (will reconnect): %v", err)
+			}
+			return
+		}
+
+		c.log.Debugf("New SUDPH message: %v", string(buf[:n]))
+
+		var remote RemoteVisor
+		if err := json.Unmarshal(buf[:n], &remote); err != nil {
+			c.log.Errorf("Failed to unmarshal SUDPH message: %v", err)
+			continue
+		}
+
+		select {
+		case <-c.closed:
+			return
+		case out <- remote:
+		}
+	}
 }
 
 func (c *httpClient) Close() error {
@@ -649,10 +762,14 @@ func (c *httpClient) Close() error {
 		c.sudphConn = nil
 	}()
 
+	// Signal shutdown. delBindSUDPHLoop (if BindSUDPH was called) and the
+	// per-conn read/heartbeat/re-register loops watch this. delBindSudphWg
+	// has counter 1 if BindSUDPH ran, 0 otherwise — Wait returns
+	// immediately in the latter case.
+	close(c.closed)
+	c.delBindSudphWg.Wait()
+
 	if c.sudphConn != nil {
-		c.delBindSudphWg.Add(1)
-		close(c.closed)
-		c.delBindSudphWg.Wait()
 		if err := c.sudphConn.Close(); err != nil {
 			c.log.WithError(err).Errorf("Failed to close SUDPH")
 		}
@@ -671,17 +788,22 @@ func (c *httpClient) Close() error {
 	return nil
 }
 
-// Keep NAT mapping alive.
+// Keep NAT mapping alive. Returns on c.closed (clean shutdown) or the
+// first Write error (connection dead → caller will reconnect).
 func (c *httpClient) keepSudphHeartbeatLoop(w io.Writer) error {
 	for {
 		select {
 		case <-c.closed:
 			return nil
 		default:
-			if _, err := w.Write([]byte(UDPKeepHeartbeatMessage)); err != nil {
-				return err
-			}
-			time.Sleep(udpKeepHeartbeatInterval)
+		}
+		if _, err := w.Write([]byte(UDPKeepHeartbeatMessage)); err != nil {
+			return err
+		}
+		select {
+		case <-c.closed:
+			return nil
+		case <-time.After(udpKeepHeartbeatInterval):
 		}
 	}
 }
@@ -711,17 +833,25 @@ func (c *httpClient) sudphReRegisterLoop(w io.Writer) error {
 	}
 }
 
-// delBindSUDPH unbinds SUDPH entry in address resolver.
-func (c *httpClient) delBindSUDPH(w io.Writer) error {
-	// send unbind packet on shutdown
-	<-c.closed
+// delBindSUDPHLoop is the lifetime-of-client goroutine that sends the
+// unbind packet on shutdown. It blocks until c.closed fires, then writes
+// to whichever arConn is current at that moment (which may have been
+// rotated zero or more times by the reconnect loop). A write failure here
+// is non-fatal — if the conn is dead the entry will simply expire via
+// AR's TTL instead of being deleted explicitly.
+func (c *httpClient) delBindSUDPHLoop() {
 	defer c.delBindSudphWg.Done()
-	if _, err := w.Write([]byte(UDPDelBindMessage)); err != nil {
-		return err
-	}
-	c.log.WithField("func", "httpClient.delBindSUDPH").Debugf("Deleted bind pk: %v from Address resolver successfully", c.pk.String())
+	<-c.closed
 
-	return nil
+	arConn := c.sudphArConn
+	if arConn == nil {
+		return
+	}
+	if _, err := arConn.Write([]byte(UDPDelBindMessage)); err != nil {
+		c.log.WithError(err).Debugf("Failed to send UDP unbind packet (entry will TTL out): pk=%v", c.pk.String())
+		return
+	}
+	c.log.WithField("func", "httpClient.delBindSUDPHLoop").Debugf("Deleted bind pk: %v from Address resolver successfully", c.pk.String())
 }
 
 func (c *httpClient) isClosed() bool {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -166,6 +166,27 @@ func initDiscovery(ctx context.Context, v *Visor, _ *logging.Logger) error {
 	return nil
 }
 
+// stunRetryInterval is how often to retry STUN detection after the initial
+// probe failed with a transient error (NATError / NATUnknown / NATBlocked).
+// These results usually mean STUN servers were unreachable at the moment of
+// the probe — DNS hiccup, transient UDP egress drop, packet loss spike, or
+// the configured STUN servers being briefly down. A periodic retry recovers
+// SUDPH for visors whose network became healthy after boot, instead of
+// requiring a full visor restart.
+const stunRetryInterval = 5 * time.Minute
+
+// stunIsTransientFail reports whether a NAT type indicates a probe-side
+// failure (worth retrying) rather than a genuine NAT topology that blocks
+// SUDPH (NATSymmetric, NATSymmetricUDPFirewall — those don't retry).
+func stunIsTransientFail(t stun.NATType) bool {
+	switch t {
+	case stun.NATError, stun.NATUnknown, stun.NATBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
 func initStunClient(_ context.Context, v *Visor, log *logging.Logger) error {
 
 	sc := network.GetStunDetails(v.conf.StunServers, log)
@@ -173,7 +194,64 @@ func initStunClient(_ context.Context, v *Visor, log *logging.Logger) error {
 	v.stun.client = sc
 	v.initLock.Unlock()
 	v.stun.readyOnce.Do(func() { close(v.stun.ready) })
+
+	// If the initial probe failed transiently, schedule a background retry.
+	// On first successful probe the goroutine updates v.stun.client and
+	// lazily starts the SUDPH client (which initSudphClient skipped at boot).
+	if sc != nil && stunIsTransientFail(sc.NATType) {
+		go v.retryStunOnTransientFail(log)
+	}
+
 	return nil
+}
+
+// retryStunOnTransientFail periodically re-runs STUN detection until either
+// the visor shuts down or a probe returns a usable NAT type. On success it
+// installs the new StunDetails and starts the SUDPH transport client. Idle
+// when the initial probe was already successful.
+func (v *Visor) retryStunOnTransientFail(log *logging.Logger) {
+	ctx := v.ctx
+	if ctx == nil {
+		return
+	}
+
+	ticker := time.NewTicker(stunRetryInterval)
+	defer ticker.Stop()
+
+	log.Infof("STUN: scheduling background retry every %v after transient failure", stunRetryInterval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		sc := network.GetStunDetails(v.conf.StunServers, log)
+		if sc == nil || stunIsTransientFail(sc.NATType) {
+			continue
+		}
+
+		// Install the new result regardless of whether SUDPH ends up usable
+		// (NATSymmetric still gets recorded for telemetry / diagnostics).
+		v.initLock.Lock()
+		v.stun.client = sc
+		v.initLock.Unlock()
+		log.Infof("STUN: detection succeeded on retry, NAT type: %v, public IP: %v", sc.NATType.String(), sc.PublicIP.String())
+
+		// Symmetric NAT means STUN worked but SUDPH won't — stop retrying.
+		if sc.NATType == stun.NATSymmetric || sc.NATType == stun.NATSymmetricUDPFirewall {
+			log.Warnf("SUDPH transport wont be available as visor is under %v", sc.NATType.String())
+			return
+		}
+
+		// Lazy-start SUDPH now that STUN has classified a usable NAT.
+		// Mirrors the default branch of initSudphClient. tpM.InitClient is
+		// safe to call post-init: it locks, registers the client, runs it.
+		log.Info("STUN: lazy-starting SUDPH transport client now that STUN succeeded")
+		v.tpM.InitClient(ctx, types.SUDPH, v.conf.Transport.SudphPort)
+		return
+	}
 }
 
 func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
@@ -189,7 +267,10 @@ func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
 		case stun.NATSymmetric, stun.NATSymmetricUDPFirewall:
 			log.Warnf("SUDPH transport wont be available as visor is under %v", v.stun.client.NATType.String())
 		case stun.NATError, stun.NATUnknown, stun.NATBlocked:
-			log.Warnf("SUDPH transport wont be available: STUN detection failed (%v)", v.stun.client.NATType.String())
+			// Initial STUN probe failed transiently — initStunClient has
+			// scheduled a background retry that will lazy-start SUDPH if
+			// detection later succeeds.
+			log.Warnf("SUDPH transport wont be available yet: STUN detection failed (%v); will retry in background", v.stun.client.NATType.String())
 		default:
 			v.tpM.InitClient(ctx, types.SUDPH, v.conf.Transport.SudphPort)
 		}


### PR DESCRIPTION
## Summary

Three independent fixes for visors silently losing SUDPH and never recovering. Production symptom: 1079 STCPR entries vs only 138 SUDPH entries in AR `/transports`, far larger than NAT distribution alone explains. Individual visors reporting "sudph worked yesterday" disappeared from AR with no path back short of a restart.

- **SUDPH reconnect loop** in `addrresolver.httpClient.BindSUDPH`. Was: dial once, spawn heartbeat / re-register / read goroutines, return. If `arConn` died (AR restart, KCP session reset, network blip) the goroutines exited silently and `addrCh` closed — visor permanently invisible via SUDPH until restarted. Now: connect logic split into `connectSUDPH`; per-connection loops wrapped in `serveSUDPHReconnect` which redials with backoff (2s → 60s) on conn death. `addrCh` survives reconnects. `delBindSUDPHLoop` writes the unbind on the current `arConn` at shutdown rather than a captured stale one. Read loop uses `SetReadDeadline` to interrupt cleanly without closing `arConn` (so the unbind packet can still go out).
- **STUN retry on transient failure** in `pkg/visor/init_transport.go`. Was: one-shot at boot; `NATError` / `NATUnknown` / `NATBlocked` permanently disabled SUDPH. Now: `initStunClient` spawns `retryStunOnTransientFail` on those classes, retries every 5min off `v.ctx`, lazy-starts SUDPH via `tpM.InitClient` on first usable result. `NATSymmetric` / `NATSymmetricUDPFirewall` still don't retry — those are real NAT topologies, not probe failures.
- **AR handshake timeout 3s → 5s** in `pkg/address-resolver/api/api.go`. The 3s cap from the bound-handshake-queue change was tight enough that visors on slow/lossy links timed out during KCP's 3-frame handshake and never appeared in AR. 5s keeps most scanner-mitigation benefit vs. the original 10s while leaving budget for high-RTT real handshakes. The 256 in-flight semaphore and Accept-Fatal fix are unchanged.

No public API changes; `APIClient` interface unchanged. `delBindSudphWg.Add(1)` ownership moves from `Close()` into `BindSUDPH` (Add at spawn, not at shutdown) which avoids a class of races if `Close()` ever interleaves with a re-bind during reconnect.

## Test plan
- [ ] Build clean: `go build ./...` (verified locally)
- [ ] Vet clean: `go vet ./pkg/transport/network/addrresolver/... ./pkg/address-resolver/... ./pkg/visor/...` (verified locally)
- [ ] Existing tests: `go test ./pkg/transport/network/addrresolver/... ./pkg/visor/...` (passes locally; redis store TestRedis fails identically on `develop` baseline due to redis password — pre-existing, unrelated)
- [ ] After deploy: AR `/transports` `sudph` entry count should rise toward the steady-state STCPR count over hours as visors with previously-dead SUDPH connections re-bind on the next reconnect tick
- [ ] Visors that boot during a transient network issue should show `STUN: scheduling background retry every 5m0s` and eventually `STUN: lazy-starting SUDPH transport client` in logs without a restart
- [ ] Real-client SUDPH handshake completion rate should improve modestly with the 5s budget (no clean way to measure without instrumenting the AR `bindSUDPH` Accept loop, but stuck-handshake goroutine count should stay <30 in steady state)