### PR TITLE
cli: rename `visor proxies` → `resolver`; split `skynet port` → `serve`

### DIFF
--- a/cmd/skywire-cli/commands/resolver/resolver.go
+++ b/cmd/skywire-cli/commands/resolver/resolver.go
@@ -1,0 +1,241 @@
+// Package cliresolver cmd/skywire-cli/commands/resolver/resolver.go
+//
+// `skywire cli resolver` — surface for the embedded `.dmsg` and
+// `.skynet` resolving SOCKS5 proxies that live inside the visor.
+// Replaces the older `skywire cli visor proxies` tree:
+//
+//	visor proxies set dmsg on        →  resolver up      (or: resolver up --dmsg-only)
+//	visor proxies set skynet off     →  resolver down --skynet-only
+//	visor proxies upstream <k> <a>   →  resolver up --upstream <a>
+//	visor proxies                    →  resolver
+//
+// Behavior conventions:
+//   - bare `resolver` prints status (same table as before).
+//   - `up` and `down` are subcommands, not "on/off" arguments.
+//   - by default both .dmsg and .skynet are toggled together; the
+//     auto-chain (dmsgweb → skynetweb → upstream) is wired up
+//     client-side from the single `--upstream` flag.
+//   - --dmsg-only / --skynet-only narrow the scope when needed.
+package cliresolver
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// Listener ports of the embedded resolvers. Match
+// pkg/visor/embedded_dmsgweb.go and embedded_skynetweb.go defaults.
+const (
+	dmsgwebSOCKSPort   = 4445
+	skynetwebSOCKSPort = 4446
+)
+
+var (
+	resolverJSON       bool
+	resolverDmsgOnly   bool
+	resolverSkynetOnly bool
+	resolverUpstream   string
+	resolverNoChain    bool
+)
+
+func init() {
+	RootCmd.Flags().BoolVar(&resolverJSON, "json", false, "emit raw JSON")
+
+	upCmd.Flags().BoolVar(&resolverDmsgOnly, "dmsg-only", false, "only enable the .dmsg resolver")
+	upCmd.Flags().BoolVar(&resolverSkynetOnly, "skynet-only", false, "only enable the .skynet resolver")
+	upCmd.Flags().StringVar(&resolverUpstream, "upstream", "", "upstream SOCKS5 for non-matching traffic (e.g. 127.0.0.1:1080)")
+	upCmd.Flags().BoolVar(&resolverNoChain, "no-chain", false, "skip the dmsgweb→skynetweb auto-chain even when both resolvers are up")
+	upCmd.MarkFlagsMutuallyExclusive("dmsg-only", "skynet-only")
+
+	downCmd.Flags().BoolVar(&resolverDmsgOnly, "dmsg-only", false, "only disable the .dmsg resolver")
+	downCmd.Flags().BoolVar(&resolverSkynetOnly, "skynet-only", false, "only disable the .skynet resolver")
+	downCmd.MarkFlagsMutuallyExclusive("dmsg-only", "skynet-only")
+
+	RootCmd.AddCommand(upCmd)
+	RootCmd.AddCommand(downCmd)
+}
+
+// RootCmd is the resolver command tree.
+var RootCmd = &cobra.Command{
+	Use:   "resolver",
+	Short: "Embedded .dmsg / .skynet resolving SOCKS5 proxies",
+	Long: `Status, enable, and disable the visor's embedded resolving
+SOCKS5 proxies. Point a browser at 127.0.0.1:4445 (dmsgweb) and the
+.dmsg / .skynet domain suffixes are tunneled directly through the
+visor; everything else hits the optional upstream SOCKS5.
+
+Without arguments, prints the current state of both resolvers.
+
+Examples:
+  skywire cli resolver                                  # status
+  skywire cli resolver up                               # both, no upstream
+  skywire cli resolver up --upstream 127.0.0.1:1080     # both, chained → skysocks
+  skywire cli resolver up --dmsg-only                   # only .dmsg
+  skywire cli resolver down                             # both off
+`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		status, err := rpcClient.EmbeddedProxies()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("EmbeddedProxies RPC failed: %w", err))
+		}
+		if resolverJSON {
+			_ = json.NewEncoder(os.Stdout).Encode(status) //nolint:errcheck,gosec
+			return
+		}
+		printResolverStatus(status)
+	},
+}
+
+var upCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Enable the embedded resolving proxies",
+	Long: `Enable the visor's embedded .dmsg / .skynet resolving SOCKS5
+proxies. By default both come up and the dmsgweb resolver is auto-
+chained to skynetweb so a single browser proxy entry (127.0.0.1:4445)
+covers .dmsg and .skynet plus everything routed through --upstream.
+
+  --upstream <addr>      where non-matching traffic goes (after the chain)
+  --dmsg-only            only enable the .dmsg resolver
+  --skynet-only          only enable the .skynet resolver
+  --no-chain             keep the resolvers independent (skip auto-chain)
+
+The bare command turns ON both resolvers; subsequent calls with
+different flags update the upstream.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		wantDmsg := !resolverSkynetOnly
+		wantSkynet := !resolverDmsgOnly
+
+		if wantDmsg {
+			if err := rpcClient.SetEmbeddedProxyEnabled("dmsg", true); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("enable dmsg resolver: %w", err))
+			}
+		}
+		if wantSkynet {
+			if err := rpcClient.SetEmbeddedProxyEnabled("skynet", true); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("enable skynet resolver: %w", err))
+			}
+		}
+
+		// Wire upstream and the auto-chain. If both resolvers are up
+		// and the user didn't explicitly opt out, chain dmsgweb to
+		// skynetweb (so .skynet still resolves through the same
+		// browser proxy entry) and skynetweb to --upstream. With
+		// --no-chain or only-one, point that resolver directly at
+		// --upstream (or clear it if the flag's empty).
+		switch {
+		case wantDmsg && wantSkynet && !resolverNoChain:
+			if err := rpcClient.SetEmbeddedProxyUpstream("dmsg", fmt.Sprintf("127.0.0.1:%d", skynetwebSOCKSPort)); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("chain dmsg → skynet: %w", err))
+			}
+			if err := rpcClient.SetEmbeddedProxyUpstream("skynet", resolverUpstream); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("set skynet upstream: %w", err))
+			}
+		case wantDmsg:
+			if err := rpcClient.SetEmbeddedProxyUpstream("dmsg", resolverUpstream); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("set dmsg upstream: %w", err))
+			}
+		case wantSkynet:
+			if err := rpcClient.SetEmbeddedProxyUpstream("skynet", resolverUpstream); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("set skynet upstream: %w", err))
+			}
+		}
+
+		fmt.Println("Resolver up.")
+		if resolverUpstream != "" {
+			fmt.Printf("  upstream: %s\n", resolverUpstream)
+		}
+		if wantDmsg && wantSkynet && !resolverNoChain {
+			fmt.Printf("  chain:    127.0.0.1:%d (dmsg) → 127.0.0.1:%d (skynet) → %s\n",
+				dmsgwebSOCKSPort, skynetwebSOCKSPort, dashIfEmpty(resolverUpstream))
+		}
+	},
+}
+
+var downCmd = &cobra.Command{
+	Use:   "down",
+	Short: "Disable the embedded resolving proxies",
+	Long: `Disable both resolvers. Use --dmsg-only or --skynet-only to
+turn off just one.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		wantDmsg := !resolverSkynetOnly
+		wantSkynet := !resolverDmsgOnly
+		if wantDmsg {
+			if err := rpcClient.SetEmbeddedProxyEnabled("dmsg", false); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("disable dmsg resolver: %w", err))
+			}
+		}
+		if wantSkynet {
+			if err := rpcClient.SetEmbeddedProxyEnabled("skynet", false); err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("disable skynet resolver: %w", err))
+			}
+		}
+		fmt.Println("Resolver down.")
+	},
+}
+
+func printResolverStatus(s *visor.EmbeddedProxiesStatus) {
+	if s == nil || (s.DmsgWeb == nil && s.SkynetWeb == nil) {
+		fmt.Println("(no embedded resolvers configured)")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "name\tenabled\trunning\tdomain\tsocks\tweb\tupstream\trequests\tactive\tfailures") //nolint:errcheck,gosec
+	fmt.Fprintln(w, "----\t-------\t-------\t------\t-----\t---\t--------\t--------\t------\t--------") //nolint:errcheck,gosec
+	row := func(name string, p *visor.EmbeddedProxyInfo) {
+		if p == nil {
+			return
+		}
+		var total, active uint64
+		var failed uint64
+		if p.Stats != nil {
+			total = p.Stats.TotalRequests
+			active = uint64(p.Stats.Active) //nolint:gosec
+			failed = p.Stats.Failed
+		}
+		fmt.Fprintf(w, "%s\t%v\t%v\t%s\t%s\t%s\t%s\t%d\t%d\t%d\n", //nolint:errcheck,gosec
+			name, p.Enabled, p.Running,
+			dashIfEmpty(p.DomainSuffix),
+			dashIfEmpty(p.SocksAddr),
+			dashIfEmpty(p.WebAddr),
+			dashIfEmpty(p.UpstreamSOCKS),
+			total, active, failed)
+	}
+	row("dmsgweb", s.DmsgWeb)
+	row("skynetweb", s.SkynetWeb)
+	_ = w.Flush() //nolint:errcheck,gosec
+
+	if s.DmsgWeb != nil && s.DmsgWeb.Stats != nil && s.DmsgWeb.Stats.LastError != "" {
+		fmt.Printf("\ndmsgweb last error: %s\n", s.DmsgWeb.Stats.LastError)
+	}
+	if s.SkynetWeb != nil && s.SkynetWeb.Stats != nil && s.SkynetWeb.Stats.LastError != "" {
+		fmt.Printf("\nskynetweb last error: %s\n", s.SkynetWeb.Stats.LastError)
+	}
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -19,12 +19,14 @@ import (
 	climdisc "github.com/skycoin/skywire/cmd/skywire-cli/commands/mdisc"
 	cliskysocksc "github.com/skycoin/skywire/cmd/skywire-cli/commands/proxy"
 	clipv "github.com/skycoin/skywire/cmd/skywire-cli/commands/pv"
+	cliresolver "github.com/skycoin/skywire/cmd/skywire-cli/commands/resolver"
 	clireward "github.com/skycoin/skywire/cmd/skywire-cli/commands/reward"
 	clirewards "github.com/skycoin/skywire/cmd/skywire-cli/commands/rewards"
 	clirg "github.com/skycoin/skywire/cmd/skywire-cli/commands/rg"
 	cliroute "github.com/skycoin/skywire/cmd/skywire-cli/commands/route"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	clisd "github.com/skycoin/skywire/cmd/skywire-cli/commands/sd"
+	cliserve "github.com/skycoin/skywire/cmd/skywire-cli/commands/serve"
 	cliskychat "github.com/skycoin/skywire/cmd/skywire-cli/commands/skychat"
 	cliskynet "github.com/skycoin/skywire/cmd/skywire-cli/commands/skynet"
 	clisurvey "github.com/skycoin/skywire/cmd/skywire-cli/commands/survey"
@@ -71,6 +73,8 @@ func init() {
 
 	clivisor.RootCmd.GroupID = groupVisor
 	cligotop.RootCmd.GroupID = groupVisor
+	cliresolver.RootCmd.GroupID = groupVisor
+	cliserve.RootCmd.GroupID = groupNet
 
 	clivpn.RootCmd.GroupID = groupApps
 	cliskysocksc.RootCmd.GroupID = groupApps
@@ -123,6 +127,8 @@ func init() {
 		clicompletion.RootCmd,
 		clilog.RootCmd,
 		cliskysocksc.RootCmd,
+		cliresolver.RootCmd,
+		cliserve.RootCmd,
 		clipv.RootCmd,
 		clisvc.RootCmd,
 		cliutil.RootCmd,

--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -1,56 +1,271 @@
-// Package cliserve cmd/skywire-cli/commands/serve/serve.go
+// Package cliserve cmd/skywire-cli/commands/serve/serve_port.go
 //
-// Simple static file server for use with skynet port forwarding.
-// Serves a directory over HTTP on localhost, suitable for use as
-// the proxy_addr target of a forwarded port.
+// `skywire cli serve` — register a localhost port to be served on the
+// network over .skynet / .dmsg. Replaces the older `skywire cli
+// skynet port {add,ls,rm}` tree:
+//
+//	skynet port ls          →  serve
+//	skynet port add <p> --proxy-addr <a>  →  serve add <p> --to <a>
+//	skynet port add <p> --local-port <l>  →  serve add <p> --to <l>
+//	skynet port rm <p>      →  serve rm <p>
+//
+// The single --to flag accepts either a full host:port (`127.0.0.1:9883`)
+// or just a port (`9883`, treated as `localhost:9883`). The visor side
+// chooses HTTP reverse-proxy vs raw TCP forwarding based on the
+// network port (port 80 → reverse proxy through the dmsghttp logserver;
+// everything else → raw TCP via the skynet/dmsg forwarders).
+//
+// The previous static-file helper is retained at `cli util serve`.
 package cliserve
 
 import (
 	"fmt"
-	"net"
-	"net/http"
-	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/visor"
 )
 
-var serveAddr string
+var (
+	serveTo        string
+	serveLabel     string
+	serveDesc      string
+	serveWhitelist string
+	serveSkynet    bool
+	serveDmsg      bool
+	serveLanding   bool
+	serveJSON      bool
+)
 
 func init() {
-	RootCmd.Flags().StringVarP(&serveAddr, "addr", "a", "127.0.0.1:0", "listen address (default: random port on localhost)")
+	servePortCmd.Flags().StringVar(&serveTo, "to", "", "local target — host:port (e.g. 127.0.0.1:9883) or just a port (9883 → localhost:9883)")
+	servePortCmd.Flags().StringVarP(&serveLabel, "label", "l", "", "label shown on the visor landing page")
+	servePortCmd.Flags().StringVarP(&serveDesc, "desc", "d", "", "description shown on the landing page")
+	servePortCmd.Flags().BoolVar(&serveSkynet, "skynet", true, "expose over skynet (sky-forwarding server)")
+	servePortCmd.Flags().BoolVar(&serveDmsg, "dmsg", true, "expose over DMSG")
+	servePortCmd.Flags().BoolVar(&serveLanding, "landing", true, "show on the visor landing page")
+	servePortCmd.Flags().StringVar(&serveWhitelist, "whitelist", "", "comma-separated PKs allowed to access this port (empty = allow all)")
+
+	servePortLsCmd.Flags().BoolVar(&serveJSON, "json", false, "emit raw JSON")
+	RootCmd.Flags().BoolVar(&serveJSON, "json", false, "emit raw JSON")
+
+	RootCmd.AddCommand(servePortCmd, servePortRmCmd, servePortLsCmd)
 }
 
-// RootCmd is the serve command.
+// RootCmd is the `serve` command tree. The bare command (no
+// subcommand) lists registered ports — same data as `serve ls`.
 var RootCmd = &cobra.Command{
-	Use:   "serve <directory>",
-	Short: "Serve static files over HTTP",
-	Long: `Start a local HTTP file server for a directory.
+	Use:   "serve",
+	Short: "Expose localhost ports over .skynet / .dmsg",
+	Long: `Register a localhost port to be served on the visor's
+.skynet and .dmsg network face. Without arguments, prints the table
+of currently-registered ports.
 
-Use with skynet port forwarding to host a website:
+Examples:
+  skywire cli serve                                         # list (default)
+  skywire cli serve add 8080 --to 8080                      # localhost:8080 → <pk>.skynet:8080
+  skywire cli serve add 80 --to 127.0.0.1:9883 --label "site" # reverse-proxy port 80 to a local HTTP service
+  skywire cli serve rm 8080                                 # unregister
 
-  skywire cli util serve /path/to/site
-  # prints the listen address, e.g. 127.0.0.1:43210
-  # then register it:
-  skywire cli skynet port add 80 --proxy-addr 127.0.0.1:43210`,
-	Args: cobra.ExactArgs(1),
-	Run: func(_ *cobra.Command, args []string) {
-		dir := args[0]
-		info, err := os.Stat(dir)
-		if err != nil || !info.IsDir() {
-			fmt.Fprintf(os.Stderr, "Error: %s is not a directory\n", dir)
-			os.Exit(1)
-		}
+Note:
+  Port 80 is owned by the visor's dmsghttp landing-page server.
+  --to N on port 80 wires up an HTTP reverse-proxy to localhost:N
+  through the landing-page handler (visor's built-in routes still win).
+  For other ports --to is a raw TCP forwarding target.
 
-		lis, err := net.Listen("tcp", serveAddr)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Fprintf(os.Stderr, "Serving %s on http://%s\n", dir, lis.Addr())
-
-		if err := http.Serve(lis, http.FileServer(http.Dir(dir))); err != nil { //nolint:gosec
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
-		}
+The previous "skynet port ..." commands still work (deprecated).
+The static-file helper that used to be at "cli serve <dir>" moved
+to "cli util serve <dir>".`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		listForwardedPorts(cmd)
 	},
+}
+
+// servePortLsCmd is the explicit `serve ls`. Bare `serve` already
+// lists; this is an explicit alias for muscle memory and scripts.
+var servePortLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List registered ports (same as bare `serve`)",
+	Run: func(cmd *cobra.Command, _ []string) {
+		listForwardedPorts(cmd)
+	},
+}
+
+var servePortCmd = &cobra.Command{
+	Use:   "add <port>",
+	Short: "Register a forwarded port",
+	Long: `Expose a localhost target over the visor's .skynet / .dmsg
+network face on <port>.
+
+Examples:
+  serve add 8080 --to 8080
+  serve add 80 --to 127.0.0.1:9883
+  serve add 3000 --to 9000 --label "blog" --desc "static blog"
+  serve add 5432 --to 5432 --skynet --dmsg=false --landing=false`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		port, err := strconv.Atoi(args[0])
+		if err != nil || port < 1 || port > 65535 {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid port: %s", args[0]))
+		}
+
+		fp := visor.ForwardedPort{
+			Port:          port,
+			Label:         serveLabel,
+			Description:   serveDesc,
+			Skynet:        serveSkynet,
+			DMSG:          serveDmsg,
+			ShowOnLanding: serveLanding,
+		}
+
+		// Resolve --to into the right field. The visor's existing
+		// schema has two: ProxyAddr (HTTP reverse-proxy via the
+		// logserver, used for port 80) and LocalPort (raw TCP). We
+		// pick by the on-the-wire port: 80 = reverse-proxy, else
+		// raw TCP. --to accepts either "host:port" or just a port.
+		if serveTo != "" {
+			host, p, err := splitTo(serveTo)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--to: %w", err))
+			}
+			if port == 80 {
+				if host == "" {
+					host = "127.0.0.1"
+				}
+				fp.ProxyAddr = fmt.Sprintf("%s:%d", host, p)
+			} else {
+				if host != "" && host != "127.0.0.1" && host != "localhost" {
+					internal.PrintFatalError(cmd.Flags(),
+						fmt.Errorf("--to: raw TCP forwarding only supports localhost targets, got %q", host))
+				}
+				fp.LocalPort = p
+			}
+		}
+
+		if serveWhitelist != "" {
+			var wl []cipher.PubKey
+			for _, pkStr := range strings.Split(serveWhitelist, ",") {
+				pkStr = strings.TrimSpace(pkStr)
+				if pkStr == "" {
+					continue
+				}
+				var pk cipher.PubKey
+				if err := pk.Set(pkStr); err != nil {
+					internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid whitelist PK %q: %w", pkStr, err))
+				}
+				wl = append(wl, pk)
+			}
+			fp.Whitelist = wl
+		}
+
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.RegisterForwardedPort(fp); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Serving port %d", port)
+		if serveTo != "" {
+			fmt.Printf(" → %s", serveTo)
+		}
+		if serveLabel != "" {
+			fmt.Printf(" (%s)", serveLabel)
+		}
+		fmt.Println()
+	},
+}
+
+var servePortRmCmd = &cobra.Command{
+	Use:   "rm <port>",
+	Short: "Unregister a forwarded port",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		port, err := strconv.Atoi(args[0])
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid port: %s", args[0]))
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.DeregisterTCPPort(port); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Printf("Port %d removed\n", port)
+	},
+}
+
+// splitTo accepts either "host:port" or "port" (where the bare port
+// resolves to localhost). Returns the parsed host (may be empty when
+// the input was port-only) and port.
+func splitTo(s string) (string, int, error) {
+	if !strings.Contains(s, ":") {
+		p, err := strconv.Atoi(s)
+		if err != nil || p < 1 || p > 65535 {
+			return "", 0, fmt.Errorf("expected host:port or a numeric port, got %q", s)
+		}
+		return "", p, nil
+	}
+	host, portStr, err := splitHostPort(s)
+	if err != nil {
+		return "", 0, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil || p < 1 || p > 65535 {
+		return "", 0, fmt.Errorf("invalid port in %q", s)
+	}
+	return host, p, nil
+}
+
+func splitHostPort(s string) (string, string, error) {
+	idx := strings.LastIndex(s, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("expected host:port, got %q", s)
+	}
+	return s[:idx], s[idx+1:], nil
+}
+
+func listForwardedPorts(cmd *cobra.Command) {
+	rpcClient, err := clirpc.Client(cmd.Flags())
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), err)
+	}
+	ports, err := rpcClient.ListForwardedPorts()
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), err)
+	}
+	if len(ports) == 0 {
+		internal.PrintOutput(cmd.Flags(), []visor.ForwardedPort{}, "No registered ports.\n")
+		return
+	}
+	var buf strings.Builder
+	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "PORT\tTO\tLABEL\tSKYNET\tDMSG\tLANDING\tDESCRIPTION") //nolint:errcheck,gosec
+	for _, p := range ports {
+		to := p.ProxyAddr
+		if to == "" {
+			to = fmt.Sprintf("localhost:%d", p.EffectiveLocalPort())
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%s\t%v\t%v\t%v\t%s\n", //nolint:errcheck,gosec
+			p.Port, to,
+			dashIfEmpty(p.Label),
+			p.Skynet, p.DMSG, p.ShowOnLanding,
+			dashIfEmpty(p.Description))
+	}
+	tw.Flush() //nolint:errcheck,gosec
+	internal.PrintOutput(cmd.Flags(), ports, buf.String())
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
 }

--- a/cmd/skywire-cli/commands/skynet/port.go
+++ b/cmd/skywire-cli/commands/skynet/port.go
@@ -43,9 +43,10 @@ func init() {
 }
 
 var portCmd = &cobra.Command{
-	Use:   "port",
-	Short: "Manage forwarded ports",
-	Long:  "List, add, and remove ports forwarded over skynet and/or DMSG.",
+	Use:        "port",
+	Short:      "Manage forwarded ports (deprecated; use `cli serve`)",
+	Long:       "Deprecated. Use `skywire cli serve` instead.\n\nList, add, and remove ports forwarded over skynet and/or DMSG.",
+	Deprecated: "use `skywire cli serve` instead",
 }
 
 var portLsCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/util/static.go
+++ b/cmd/skywire-cli/commands/util/static.go
@@ -1,0 +1,60 @@
+// Package cliutil cmd/skywire-cli/commands/util/static.go
+//
+// `skywire cli util serve` — a small static-file HTTP server for
+// pairing with `cli serve add 80 --to <addr>`. Lives under `util`
+// because it isn't part of the core visor RPC surface; the visor
+// itself doesn't host static files.
+//
+// Was top-level `cli serve <dir>` historically; the top-level name
+// was reclaimed for port registration. Old invocations should use
+// `cli util serve <dir>`.
+package cliutil
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var staticServeAddr string
+
+func init() {
+	staticServeCmd.Flags().StringVarP(&staticServeAddr, "addr", "a", "127.0.0.1:0", "listen address (default: random port on localhost)")
+}
+
+var staticServeCmd = &cobra.Command{
+	Use:   "serve <directory>",
+	Short: "Serve static files over HTTP",
+	Long: `Start a local HTTP file server for a directory.
+
+Use with skywire port forwarding to host a website:
+
+  skywire cli util serve /path/to/site
+  # prints the listen address, e.g. 127.0.0.1:43210
+  # then register it:
+  skywire cli serve add 80 --to 127.0.0.1:43210`,
+	Args: cobra.ExactArgs(1),
+	Run: func(_ *cobra.Command, args []string) {
+		dir := args[0]
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			fmt.Fprintf(os.Stderr, "Error: %s is not a directory\n", dir)
+			os.Exit(1)
+		}
+
+		lis, err := net.Listen("tcp", staticServeAddr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "Serving %s on http://%s\n", dir, lis.Addr())
+
+		if err := http.Serve(lis, http.FileServer(http.Dir(dir))); err != nil { //nolint:gosec
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/skywire-cli/commands/util/util.go
+++ b/cmd/skywire-cli/commands/util/util.go
@@ -7,7 +7,6 @@ import (
 	cliedit "github.com/skycoin/skywire/cmd/skywire-cli/commands/edit"
 	cligot "github.com/skycoin/skywire/cmd/skywire-cli/commands/got"
 	clijq "github.com/skycoin/skywire/cmd/skywire-cli/commands/jq"
-	cliserve "github.com/skycoin/skywire/cmd/skywire-cli/commands/serve"
 )
 
 func init() {
@@ -19,7 +18,7 @@ func init() {
 		clijq.RootCmd,
 		cliedit.RootCmd,
 		cligot.RootCmd,
-		cliserve.RootCmd,
+		staticServeCmd,
 	)
 }
 

--- a/cmd/skywire-cli/commands/visor/proxies.go
+++ b/cmd/skywire-cli/commands/visor/proxies.go
@@ -34,15 +34,13 @@ func init() {
 }
 
 var proxiesCmd = &cobra.Command{
-	Use:   "proxies",
-	Short: "Show embedded resolving-proxy status (dmsgweb, skynetweb)",
-	Long: `Print the runtime state + cumulative stats of the visor-hosted
-.dmsg / .skynet resolving proxies. Copy SocksAddr into a browser's
-SOCKS5 setting to browse the matched domain; paste WebAddr into curl
-for a direct smoke test.
+	Use:        "proxies",
+	Short:      "Show embedded resolving-proxy status (deprecated; use `cli resolver`)",
+	Deprecated: "use `skywire cli resolver` instead",
+	Long: `Deprecated. Use ` + "`skywire cli resolver`" + ` instead.
 
-Use "proxies set <kind> on|off" to toggle a resolver at runtime
-without editing the config file.`,
+Print the runtime state + cumulative stats of the visor-hosted
+.dmsg / .skynet resolving proxies.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {


### PR DESCRIPTION
## Summary

The CLI grew two awkward shapes that took new users a while to internalize:

\`\`\`
cli visor proxies set dmsg on              # operator-as-arg, nested too deep
cli skynet port add 80 --proxy-addr ...    # mixes app lifecycle with config
\`\`\`

Replace both with semantic top-level commands following verb conventions:

\`\`\`
cli resolver                          # status (bare = default action)
cli resolver up [--upstream <addr>]   # both .dmsg + .skynet, auto-chained
cli resolver up --dmsg-only           # selector flags narrow scope
cli resolver up --no-chain            # skip dmsgweb→skynetweb wiring
cli resolver down

cli serve                             # list (bare = default action)
cli serve add <port> --to <addr>      # single --to flag
cli serve rm <port>
\`\`\`

## Highlights

- \`up\`/\`down\` are subcommands, not \"on\"/\"off\" arguments. (Per user preference.)
- Bare \`resolver\` and bare \`serve\` print status — most-common operation has zero typing.
- \`--to\` consolidates the old \`--proxy-addr\` / \`--local-port\` split into one flag. Accepts \`127.0.0.1:9883\` or shorthand \`9883\` (= \`localhost:9883\`). Visor side still picks reverse-proxy vs raw-TCP based on the network port (80 = HTTP reverse-proxy through the dmsghttp logserver; else = raw TCP forwarding).
- \`cli resolver up\` wires the auto-chain (dmsgweb → skynetweb → upstream) in one call. Old surface needed four to set up the same browser proxy.
- Selector flags (\`--dmsg-only\`, \`--skynet-only\`, \`--no-chain\`) for advanced cases without bloating the subcommand tree.

## Examples (before → after)

\`\`\`
# Browser proxy chain
- cli visor proxies set dmsg on
- cli visor proxies set skynet on
- cli visor proxies upstream dmsg 127.0.0.1:4446
- cli visor proxies upstream skynet 127.0.0.1:1080
+ cli resolver up --upstream 127.0.0.1:1080

# Status
- cli visor proxies
+ cli resolver

# Forward port 80 to a local HTTP service
- cli skynet port add 80 --proxy-addr 127.0.0.1:9883 --label "site"
+ cli serve add 80 --to 127.0.0.1:9883 --label "site"

# Forward an arbitrary TCP port
- cli skynet port add 8080 --local-port 9999
+ cli serve add 8080 --to 9999

# List
- cli skynet port ls
+ cli serve
\`\`\`

## Static-file helper relocated

The old \`cli serve <dir>\` (the static-file HTTP helper) is now \`cli util serve <dir>\` — moved per user request because it's a utility, not part of the core visor RPC surface. The new \`cli serve\` lives at the top level.

## Backward compatibility

The old commands stay as deprecation shims printing a one-line hint pointing at the replacement. No flag-day. Can drop after a release once users migrate.

## Help layout

\`\`\`
Visor:        gotop, resolver, visor
Apps:         proxy, skychat, skynet, vpn
Networking:   dmsg, rg, route, serve, tp, tps
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean
- [x] \`go vet ./...\` clean
- [x] Manual: \`cli resolver\` status / \`up\` / \`down\` round-trip works
- [x] Manual: \`cli serve\` list / \`add 80 --to 127.0.0.1:9999\` / \`rm 80\` round-trip works
- [x] Manual: \`cli util serve <dir>\` still works
- [ ] Manual: deprecation hints from \`cli skynet port\` and \`cli visor proxies\` show on each invocation

## Follow-ups (separate PRs as discussed)

- App-management parity: standardize start/stop/status across \`proxy\`, \`vpn\`, \`skynet-client\` (will rename to \`forward\`)
- JSON output consistency: \`--json\` on every read command, single envelope shape
- Help-text examples: bake \`Examples:\` into ~15-20 commands following gh / tailscale style
- Top-level shortcuts: \`cli status\`, \`cli halt\`, \`cli pk\`, \`cli hv\`
- Shell completion: surface \`cli completion bash|zsh|fish\` in help