### PR TITLE
cli: top-level shortcuts for the high-traffic visor verbs

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -132,6 +132,13 @@ func init() {
 		clipv.RootCmd,
 		clisvc.RootCmd,
 		cliutil.RootCmd,
+
+		// Top-level shortcuts: high-traffic verbs reachable without
+		// the `visor` middle word. Long forms keep working at
+		// `cli visor pk`, `cli visor info`, `cli visor halt`.
+		pkCmd,
+		statusCmd,
+		haltCmd,
 	)
 	var jsonOutput bool
 	RootCmd.PersistentFlags().BoolVar(&jsonOutput, internal.JSONString, false, "print output as JSON")

--- a/cmd/skywire-cli/commands/shortcuts.go
+++ b/cmd/skywire-cli/commands/shortcuts.go
@@ -1,0 +1,53 @@
+// Package commands cmd/skywire-cli/commands/shortcuts.go
+//
+// Top-level convenience commands. The verbs typed most often
+// (pk / status / halt) live at the root so they don't need the
+// `visor` middle word. The longer forms (cli visor pk, etc.)
+// keep working unchanged.
+//
+// Each shortcut is a thin wrapper that delegates Run to the
+// existing visor subcommand. The two commands share Run logic
+// without sharing the *cobra.Command instance — that lets each
+// have its own GroupID for the parent's help template, since
+// root and `cli visor` use different group taxonomies.
+//
+// `hv` is intentionally not surfaced here: it has a subcommand
+// tree that doesn't lift cleanly with this wrapper pattern.
+// Promoting it is tracked as a follow-up.
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	clivisor "github.com/skycoin/skywire/cmd/skywire-cli/commands/visor"
+)
+
+func init() {
+	statusCmd.GroupID = groupVisor
+	pkCmd.GroupID = groupVisor
+	haltCmd.GroupID = groupVisor
+}
+
+// statusCmd is `skywire cli status` — equivalent to `cli visor info`.
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Summary of visor info (alias for `cli visor info`)",
+	Long:  "\n  Summary of visor info — same as `skywire cli visor info`.",
+	Run:   clivisor.SummaryCmd.Run,
+}
+
+// pkCmd is `skywire cli pk` — equivalent to `cli visor pk`.
+var pkCmd = &cobra.Command{
+	Use:   "pk",
+	Short: "Public key of the visor (alias for `cli visor pk`)",
+	Long:  "\n  Public key of the visor — same as `skywire cli visor pk`.",
+	Run:   clivisor.PKCmd.Run,
+}
+
+// haltCmd is `skywire cli halt` — equivalent to `cli visor halt`.
+var haltCmd = &cobra.Command{
+	Use:   "halt",
+	Short: "Stop a running visor (alias for `cli visor halt`)",
+	Long:  "\n  Stop a running visor — same as `skywire cli visor halt`.",
+	Run:   clivisor.HaltCmd.Run,
+}

--- a/cmd/skywire-cli/commands/visor/exports.go
+++ b/cmd/skywire-cli/commands/visor/exports.go
@@ -1,0 +1,20 @@
+// Package clivisor cmd/skywire-cli/commands/visor/exports.go
+//
+// Exposes visor subcommand handlers so the top-level shortcuts
+// (cli pk, cli status, cli halt) can delegate Run without sharing
+// the *cobra.Command instance. Each shortcut wraps one of these so
+// the help template renders correctly under both parents — root and
+// `cli visor` use different group taxonomies, and a single Command
+// can only carry one GroupID.
+package clivisor
+
+// PKCmd is the `cli visor pk` command. Top-level `cli pk` reuses its Run.
+var PKCmd = pkCmd
+
+// SummaryCmd is the `cli visor info` command. Top-level `cli status`
+// reuses its Run; the leaf name differs only at the root.
+var SummaryCmd = summaryCmd
+
+// HaltCmd is the `cli visor halt` command. Top-level `cli halt`
+// reuses its Run.
+var HaltCmd = shutdownCmd


### PR DESCRIPTION
## Summary

Surface \`cli pk\`, \`cli status\`, and \`cli halt\` at the root so the three verbs typed dozens of times a day don't need the \`visor\` middle word. The long forms (\`cli visor pk\`, \`cli visor info\`, \`cli visor halt\`) keep working unchanged.

\`\`\`
$ skywire cli --help | grep -E '^  (pk|status|halt|visor)'
  halt        Stop a running visor (alias for \`cli visor halt\`)
  pk          Public key of the visor (alias for \`cli visor pk\`)
  status      Summary of visor info (alias for \`cli visor info\`)
  visor       Query the Skywire Visor
\`\`\`

## Implementation note

Each shortcut is a thin wrapper that delegates \`Run\` to the existing visor subcommand. The two commands share Run logic without sharing the \`*cobra.Command\` instance — that lets each have its own \`GroupID\` for the parent's help template, since the root taxonomy (\`config\`/\`visor\`/\`apps\`/\`net\`/\`discovery\`/\`rewards\`/\`util\`) and visor's local taxonomy (\`lifecycle\`/\`identity\`/\`network\`/\`subsystems\`/\`diagnostics\`) don't overlap. Sharing the same Command between two parents with different group sets panics in cobra.

## Why these three (and not others)

These are the verbs you reach for during every diagnostic session:
- **pk** — needed to construct dmsg URLs, PR descriptions, log searches
- **status** — first thing you run after a restart
- **halt** — what you should reach for instead of pkill (per earlier feedback)

## Why not \`cli hv\`

\`hv\` has a subcommand tree (\`hv ls\`, \`hv add\`, \`hv ui\`, \`hv tui\`, ...). Lifting it with this wrapper pattern would require cloning every leaf, or a pattern shift where the leaves move into a sub-package and both parents import them. Worth doing as a follow-up where the hv tree itself can also get a polish pass.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] Manual: \`cli pk\` returns the same PK as \`cli visor pk\`
- [x] Manual: \`cli status\` produces the same summary as \`cli visor info\`
- [x] Manual: shortcuts appear in \`cli --help\` under the Visor group