### PR TITLE
cli: drop `{output: ...}` envelope; route JSON errors to stderr

### DIFF
--- a/cmd/skywire-cli/cliutil/cliutil.go
+++ b/cmd/skywire-cli/cliutil/cliutil.go
@@ -25,20 +25,15 @@ func Catch(cmdFlags *pflag.FlagSet, err error) {
 	}
 }
 
-// PrintFatalError prints errors for skywire-cli commands packages
+// PrintFatalError prints errors for skywire-cli commands packages.
+// In --json mode the JSON error is written to stderr (so success
+// output on stdout stays parseable), then the process exits 1.
 //
 //nolint:errcheck
 func PrintFatalError(cmdFlags *pflag.FlagSet, err error) {
 	isJSON, _ := cmdFlags.GetBool(JSONString)
 	if isJSON {
-		errJSON := CLIOutput{
-			Err: err.Error(),
-		}
-		b, err := json.MarshalIndent(errJSON, "", "  ")
-		if err != nil {
-			fmt.Println(err)
-		}
-		fmt.Print(string(b) + "\n")
+		writeJSONError(os.Stderr, err)
 		os.Exit(1)
 	}
 	log.Fatal(err)
@@ -54,20 +49,15 @@ func PrintRPCError(cmdFlags *pflag.FlagSet, err error) {
 	PrintError(cmdFlags, fmt.Errorf("Failed to connect to visor RPC or RPC method not found; is skywire running?: %v", err))
 }
 
-// PrintError prints errors for skywire-cli commands packages
+// PrintError prints errors for skywire-cli commands packages.
+// JSON mode writes to stderr; non-JSON path uses the package logger.
 //
 //nolint:errcheck
 func PrintError(cmdFlags *pflag.FlagSet, err error) {
 	isJSON, _ := cmdFlags.GetBool(JSONString)
 	if isJSON {
-		errJSON := CLIOutput{
-			Err: err.Error(),
-		}
-		b, err := json.MarshalIndent(errJSON, "", "  ")
-		if err != nil {
-			fmt.Println(err)
-		}
-		fmt.Print(string(b) + "\n")
+		writeJSONError(os.Stderr, err)
+		return
 	}
 	log.Error(err)
 }
@@ -91,33 +81,60 @@ func ParseUUID(cmdFlags *pflag.FlagSet, name, v string) uuid.UUID {
 	return id
 }
 
-// CLIOutput is used to print the cli output in json
+// CLIOutput is the legacy success-envelope shape kept around so external
+// callers that imported the type don't break. New code should not
+// construct it; PrintOutput emits raw JSON values directly.
 type CLIOutput struct {
 	Output interface{} `json:"output,omitempty"`
 	Err    string      `json:"error,omitempty"`
 }
 
-// PrintOutput prints either the normal output or the json output as per the global `--json` flag
+// PrintOutput prints the value as raw JSON (no `{"output": ...}`
+// envelope) in --json mode, or the human text otherwise.
+//
+// Migrated from the legacy CLIOutput envelope: previously the JSON
+// path emitted `{"output": <value>}`, which forced every consumer
+// through `jq '.output...'`. Now consumers pipe `jq '...'` directly
+// against the value — matching gh, kubectl, and stripe.
+//
+// Errors continue to go through PrintFatalError / PrintError, which
+// emit `{"error": "..."}` to stderr — so a successful pipe sees only
+// values, and an interrupted pipe sees only errors.
 //
 //nolint:errcheck
 func PrintOutput(cmdFlags *pflag.FlagSet, outputJSON, output interface{}) {
 	isJSON, _ := cmdFlags.GetBool(JSONString)
 	if isJSON {
-		if outputJSON != nil {
-			outputJSON := CLIOutput{
-				Output: outputJSON,
-			}
-			b, err := json.MarshalIndent(outputJSON, "", "  ")
-			if err != nil {
-				fmt.Println(err)
-			}
-			fmt.Print(string(b) + "\n")
+		if outputJSON == nil {
+			return
 		}
+		b, err := json.MarshalIndent(outputJSON, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		fmt.Print(string(b) + "\n")
 		return
 	}
 	if output != "" {
 		fmt.Print(output)
 	}
+}
+
+// writeJSONError emits a JSON-encoded error to w, matching the shape
+// `{"error": "..."}` and including a trailing newline.
+//
+//nolint:errcheck
+func writeJSONError(w *os.File, err error) {
+	errJSON := struct {
+		Err string `json:"error"`
+	}{Err: err.Error()}
+	b, mErr := json.MarshalIndent(errJSON, "", "  ")
+	if mErr != nil {
+		fmt.Fprintln(w, mErr)
+		return
+	}
+	fmt.Fprint(w, string(b)+"\n")
 }
 
 // GetData was a direct-HTTP fetch+cache helper that has been removed.

--- a/cmd/skywire-cli/commands/resolver/resolver.go
+++ b/cmd/skywire-cli/commands/resolver/resolver.go
@@ -19,9 +19,8 @@
 package cliresolver
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -39,7 +38,6 @@ const (
 )
 
 var (
-	resolverJSON       bool
 	resolverDmsgOnly   bool
 	resolverSkynetOnly bool
 	resolverUpstream   string
@@ -47,8 +45,6 @@ var (
 )
 
 func init() {
-	RootCmd.Flags().BoolVar(&resolverJSON, "json", false, "emit raw JSON")
-
 	upCmd.Flags().BoolVar(&resolverDmsgOnly, "dmsg-only", false, "only enable the .dmsg resolver")
 	upCmd.Flags().BoolVar(&resolverSkynetOnly, "skynet-only", false, "only enable the .skynet resolver")
 	upCmd.Flags().StringVar(&resolverUpstream, "upstream", "", "upstream SOCKS5 for non-matching traffic (e.g. 127.0.0.1:1080)")
@@ -90,11 +86,7 @@ Examples:
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("EmbeddedProxies RPC failed: %w", err))
 		}
-		if resolverJSON {
-			_ = json.NewEncoder(os.Stdout).Encode(status) //nolint:errcheck,gosec
-			return
-		}
-		printResolverStatus(status)
+		internal.PrintOutput(cmd.Flags(), status, renderResolverStatus(status))
 	},
 }
 
@@ -157,14 +149,22 @@ different flags update the upstream.`,
 			}
 		}
 
-		fmt.Println("Resolver up.")
+		var msg strings.Builder
+		msg.WriteString("Resolver up.\n")
 		if resolverUpstream != "" {
-			fmt.Printf("  upstream: %s\n", resolverUpstream)
+			fmt.Fprintf(&msg, "  upstream: %s\n", resolverUpstream)
 		}
 		if wantDmsg && wantSkynet && !resolverNoChain {
-			fmt.Printf("  chain:    127.0.0.1:%d (dmsg) → 127.0.0.1:%d (skynet) → %s\n",
+			fmt.Fprintf(&msg, "  chain:    127.0.0.1:%d (dmsg) → 127.0.0.1:%d (skynet) → %s\n",
 				dmsgwebSOCKSPort, skynetwebSOCKSPort, dashIfEmpty(resolverUpstream))
 		}
+		internal.PrintOutput(cmd.Flags(), map[string]any{
+			"up":       true,
+			"dmsg":     wantDmsg,
+			"skynet":   wantSkynet,
+			"upstream": resolverUpstream,
+			"chained":  wantDmsg && wantSkynet && !resolverNoChain,
+		}, msg.String())
 	},
 }
 
@@ -190,16 +190,23 @@ turn off just one.`,
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("disable skynet resolver: %w", err))
 			}
 		}
-		fmt.Println("Resolver down.")
+		internal.PrintOutput(cmd.Flags(), map[string]any{
+			"down":   true,
+			"dmsg":   wantDmsg,
+			"skynet": wantSkynet,
+		}, "Resolver down.\n")
 	},
 }
 
-func printResolverStatus(s *visor.EmbeddedProxiesStatus) {
+// renderResolverStatus formats the status table for human display.
+// Returns the rendered string so PrintOutput can decide to print it
+// (text mode) or skip it in favor of raw JSON (--json mode).
+func renderResolverStatus(s *visor.EmbeddedProxiesStatus) string {
 	if s == nil || (s.DmsgWeb == nil && s.SkynetWeb == nil) {
-		fmt.Println("(no embedded resolvers configured)")
-		return
+		return "(no embedded resolvers configured)\n"
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "name\tenabled\trunning\tdomain\tsocks\tweb\tupstream\trequests\tactive\tfailures") //nolint:errcheck,gosec
 	fmt.Fprintln(w, "----\t-------\t-------\t------\t-----\t---\t--------\t--------\t------\t--------") //nolint:errcheck,gosec
 	row := func(name string, p *visor.EmbeddedProxyInfo) {
@@ -226,11 +233,12 @@ func printResolverStatus(s *visor.EmbeddedProxiesStatus) {
 	_ = w.Flush() //nolint:errcheck,gosec
 
 	if s.DmsgWeb != nil && s.DmsgWeb.Stats != nil && s.DmsgWeb.Stats.LastError != "" {
-		fmt.Printf("\ndmsgweb last error: %s\n", s.DmsgWeb.Stats.LastError)
+		fmt.Fprintf(&buf, "\ndmsgweb last error: %s\n", s.DmsgWeb.Stats.LastError)
 	}
 	if s.SkynetWeb != nil && s.SkynetWeb.Stats != nil && s.SkynetWeb.Stats.LastError != "" {
-		fmt.Printf("\nskynetweb last error: %s\n", s.SkynetWeb.Stats.LastError)
+		fmt.Fprintf(&buf, "\nskynetweb last error: %s\n", s.SkynetWeb.Stats.LastError)
 	}
+	return buf.String()
 }
 
 func dashIfEmpty(s string) string {

--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -171,14 +171,16 @@ Examples:
 		if err := rpcClient.RegisterForwardedPort(fp); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Printf("Serving port %d", port)
+		var msg strings.Builder
+		fmt.Fprintf(&msg, "Serving port %d", port)
 		if serveTo != "" {
-			fmt.Printf(" → %s", serveTo)
+			fmt.Fprintf(&msg, " → %s", serveTo)
 		}
 		if serveLabel != "" {
-			fmt.Printf(" (%s)", serveLabel)
+			fmt.Fprintf(&msg, " (%s)", serveLabel)
 		}
-		fmt.Println()
+		msg.WriteString("\n")
+		internal.PrintOutput(cmd.Flags(), fp, msg.String())
 	},
 }
 
@@ -198,7 +200,8 @@ var servePortRmCmd = &cobra.Command{
 		if err := rpcClient.DeregisterTCPPort(port); err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Printf("Port %d removed\n", port)
+		internal.PrintOutput(cmd.Flags(), map[string]any{"port": port, "removed": true},
+			fmt.Sprintf("Port %d removed\n", port))
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/cxo_feeds.go
+++ b/cmd/skywire-cli/commands/visor/cxo_feeds.go
@@ -11,10 +11,9 @@
 package clivisor
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -23,13 +22,9 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 )
 
-var (
-	cxoJSON            bool
-	cxoFeedDescription string
-)
+var cxoFeedDescription string
 
 func init() {
-	cxoFeedsCmd.Flags().BoolVar(&cxoJSON, "json", false, "emit raw JSON")
 	cxoFeedAddCmd.Flags().StringVarP(&cxoFeedDescription, "desc", "d", "", "human-readable description")
 	cxoFeedsCmd.AddCommand(cxoFeedAddCmd)
 	cxoFeedsCmd.AddCommand(cxoFeedRmCmd)
@@ -67,11 +62,8 @@ var cxoFeedLsCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		feeds := rpcClient.ListCXOFeeds()
-		if cxoJSON {
-			_ = json.NewEncoder(os.Stdout).Encode(feeds) //nolint:errcheck,gosec
-			return
-		}
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		var buf strings.Builder
+		w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "NAME\tDMSG PORT\tSYSTEM\tDESCRIPTION") //nolint:errcheck,gosec
 		for _, f := range feeds {
 			desc := f.Description
@@ -81,6 +73,7 @@ var cxoFeedLsCmd = &cobra.Command{
 			fmt.Fprintf(w, "%s\t%d\t%v\t%s\n", f.Name, f.DmsgPort, f.System, desc) //nolint:errcheck,gosec
 		}
 		w.Flush() //nolint:errcheck,gosec
+		internal.PrintOutput(cmd.Flags(), feeds, buf.String())
 	},
 }
 
@@ -104,7 +97,9 @@ setup, 50 system telemetry).`,
 		if err := rpcClient.RegisterCXOFeed(args[0], uint16(port), cxoFeedDescription); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("RegisterCXOFeed failed: %w", err))
 		}
-		fmt.Printf("Feed %q registered on dmsg:%d\n", args[0], port)
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"name": args[0], "dmsg_port": port, "registered": true},
+			fmt.Sprintf("Feed %q registered on dmsg:%d\n", args[0], port))
 	},
 }
 
@@ -120,6 +115,8 @@ var cxoFeedRmCmd = &cobra.Command{
 		if err := rpcClient.UnregisterCXOFeed(args[0]); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("UnregisterCXOFeed failed: %w", err))
 		}
-		fmt.Printf("Feed %q removed\n", args[0])
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"name": args[0], "removed": true},
+			fmt.Sprintf("Feed %q removed\n", args[0]))
 	},
 }


### PR DESCRIPTION
## Summary

Three changes to make \`--json\` output behave the way modern CLIs do:

### 1. \`PrintOutput\` emits raw values

Previously the JSON path wrapped everything in a \`CLIOutput\` envelope:

\`\`\`
$ cli skynet port ls --json
{"output": [{"port":80,...},{"port":8080,...}]}
\`\`\`

Every consumer had to climb \`jq '.output...'\` to get to the data. Now it's just:

\`\`\`
$ cli serve --json
[{"port":80,...},{"port":8080,...}]

$ cli pk --json
"0323272a60895f56aad82cb767fb5c413807adcf7c9fb0578b1b1c5807c7f29d4c"
\`\`\`

Matches \`gh\`, \`kubectl\`, \`stripe\`.

### 2. Errors go to stderr in \`--json\` mode

Mixing \`{\"error\": \"...\"}\` into the same stream as success values broke pipes — every script that did \`cli foo --json | jq ...\` had to handle \"this might be an error envelope or might be the data.\" Now errors land on fd 2; pipes on fd 1 stay parseable.

### 3. Direct \`json.NewEncoder(os.Stdout)\` calls migrated to \`PrintOutput\`

In the recently-touched commands (\`cli resolver\`, \`cli serve\`, \`cli visor cxo feeds\`). Those used to bypass the helper and emit non-indented JSON inconsistent with other commands. Also routes their success-path \`fmt.Print\` lines through \`PrintOutput\` so \`--json\` mode no longer prints \"Resolver up.\" or \"Port 80 removed\" alongside the JSON output.

## Backward compatibility

\`CLIOutput\` type kept around as a no-op shim — anything that imported it externally still compiles. Future commands shouldn't construct it.

Older command files still using the helper get the new behavior automatically. Direct \`json.NewEncoder\` calls in commands not touched here will keep their old (raw, no-envelope) output until migrated; that's a gradual cleanup, not blocking.

## Migration notes for scripts

Anyone parsing skywire CLI output with \`jq '.output...'\`:

\`\`\`
# before
cli skynet port ls --json | jq '.output[] | .port'

# after (works regardless of which command)
cli serve --json | jq '.[] | .port'
\`\`\`

Anyone catching errors from \`--json\` invocations: errors moved from stdout to stderr. \`2>/dev/null\` discards them; \`2>&1 | jq\` preserves both streams (mixed shape, but at least visible).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`make lint\` clean (0 issues)
- [x] Manual: \`cli pk --json\` returns a JSON string
- [x] Manual: \`cli serve --json\` returns a JSON array of ports (no envelope)
- [x] Manual: \`cli resolver --json\` returns the indented status JSON (no envelope)
- [x] Manual: \`cli serve add ... --json\` emits only JSON on stdout (no human-text leak)
- [x] Manual: \`cli serve add 80 --to badaddress --json\` writes the error to stderr only

## Follow-ups

- Migrate the remaining ~10 commands that still call \`json.NewEncoder(os.Stdout)\` directly (\`tp\`, \`route\`, \`dmsg diag\`, \`svc fetch\`, \`rewards\`, etc.). Each is mechanical; can land in batches as they're touched for other reasons.