### PR TITLE
cli: migrate remaining commands to PrintOutput; fix integration tests

### DIFF
--- a/cmd/skywire-cli/commands/config/show.go
+++ b/cmd/skywire-cli/commands/config/show.go
@@ -42,16 +42,15 @@ Use --path to print just the config file path.`,
 			// Ask the running visor for the path it actually loaded.
 			// Falls back to the default install path only when no visor
 			// is reachable (CLI invoked without a running visor).
+			path := visorconfig.SkywireConfig()
 			rpcClient, err := clirpc.Client(cmd.Flags())
-			if err != nil {
-				fmt.Println(visorconfig.SkywireConfig())
-				return
+			if err == nil {
+				configPath, err := rpcClient.GetConfigPath()
+				if err == nil && configPath != "" {
+					path = configPath
+				}
 			}
-			configPath, err := rpcClient.GetConfigPath()
-			if err != nil || configPath == "" {
-				configPath = visorconfig.SkywireConfig()
-			}
-			fmt.Println(configPath)
+			internal.PrintOutput(cmd.Flags(), path, path+"\n")
 			return
 		}
 
@@ -74,11 +73,13 @@ Use --path to print just the config file path.`,
 
 		var v interface{}
 		if err := json.Unmarshal(configData, &v); err != nil {
-			fmt.Println(string(configData))
+			internal.PrintOutput(cmd.Flags(), string(configData), string(configData)+"\n")
 			return
 		}
 
-		// Apply jq filter if provided.
+		// Apply jq filter if provided. Collect results so --json emits a
+		// single array (when multiple) or the lone value, matching how
+		// jq itself behaves with -c off.
 		if len(args) > 0 && args[0] != "" {
 			query, err := gojq.Parse(args[0])
 			if err != nil {
@@ -88,6 +89,8 @@ Use --path to print just the config file path.`,
 			if err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("compile filter: %w", err))
 			}
+			var results []interface{}
+			var text string
 			iter := code.Run(v)
 			for {
 				result, ok := iter.Next()
@@ -98,8 +101,14 @@ Use --path to print just the config file path.`,
 					internal.PrintFatalError(cmd.Flags(), err)
 				}
 				out, _ := json.MarshalIndent(result, "", "  ") //nolint:errcheck
-				fmt.Println(string(out))
+				text += string(out) + "\n"
+				results = append(results, result)
 			}
+			var payload interface{} = results
+			if len(results) == 1 {
+				payload = results[0]
+			}
+			internal.PrintOutput(cmd.Flags(), payload, text)
 			return
 		}
 

--- a/cmd/skywire-cli/commands/dmsg/diag.go
+++ b/cmd/skywire-cli/commands/dmsg/diag.go
@@ -2,8 +2,8 @@
 package clidmsg
 
 import (
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -37,11 +37,13 @@ var porterStatsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Printf("DMSG Porter Status\n")
-		fmt.Printf("  Main client ports:  %d / 16384\n", s.MainPorts)
+		var buf strings.Builder
+		buf.WriteString("DMSG Porter Status\n")
+		fmt.Fprintf(&buf, "  Main client ports:  %d / 16384\n", s.MainPorts)
 		if s.RSNPorts > 0 {
-			fmt.Printf("  RSN client ports:   %d / 16384\n", s.RSNPorts)
+			fmt.Fprintf(&buf, "  RSN client ports:   %d / 16384\n", s.RSNPorts)
 		}
+		internal.PrintOutput(cmd.Flags(), s, buf.String())
 	},
 }
 
@@ -62,11 +64,13 @@ Well-known ports (listeners) are preserved.`,
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Printf("Porter reset complete\n")
-		fmt.Printf("  Main: freed %d ports (%d remaining)\n", s.MainFreed, s.MainPorts)
+		var buf strings.Builder
+		buf.WriteString("Porter reset complete\n")
+		fmt.Fprintf(&buf, "  Main: freed %d ports (%d remaining)\n", s.MainFreed, s.MainPorts)
 		if s.RSNFreed > 0 || s.RSNPorts > 0 {
-			fmt.Printf("  RSN:  freed %d ports (%d remaining)\n", s.RSNFreed, s.RSNPorts)
+			fmt.Fprintf(&buf, "  RSN:  freed %d ports (%d remaining)\n", s.RSNFreed, s.RSNPorts)
 		}
+		internal.PrintOutput(cmd.Flags(), s, buf.String())
 	},
 }
 
@@ -87,8 +91,7 @@ Use this to investigate ephemeral port exhaustion root causes.`,
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		pretty, _ := json.MarshalIndent(diag, "", "  ") //nolint:errcheck
-		fmt.Println(string(pretty))
+		internal.PrintOutput(cmd.Flags(), diag, fmt.Sprintf("%+v\n", diag))
 	},
 }
 
@@ -104,6 +107,8 @@ var reconnectCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Printf("Closed %d DMSG sessions. Reconnect loop will re-dial within 15s.\n", n)
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"closed": n},
+			fmt.Sprintf("Closed %d DMSG sessions. Reconnect loop will re-dial within 15s.\n", n))
 	},
 }

--- a/cmd/skywire-cli/commands/route/rsn_remote.go
+++ b/cmd/skywire-cli/commands/route/rsn_remote.go
@@ -64,9 +64,9 @@ visor's config.`,
 		var v interface{}
 		if err := json.Unmarshal(body, &v); err == nil {
 			pretty, _ := json.MarshalIndent(v, "", "  ") //nolint:errcheck
-			fmt.Println(string(pretty))
-		} else {
-			fmt.Println(string(body))
+			internal.PrintOutput(cmd.Flags(), v, string(pretty)+"\n")
+			return
 		}
+		internal.PrintOutput(cmd.Flags(), string(body), string(body)+"\n")
 	},
 }

--- a/cmd/skywire-cli/commands/svc/fetch.go
+++ b/cmd/skywire-cli/commands/svc/fetch.go
@@ -3,7 +3,6 @@ package clisvc
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -46,15 +45,19 @@ func fetchViaVisorOrDirect(cmd *cobra.Command, service, path, directURL string) 
 	return clirpc.FetchServiceURL(cmd.Flags(), url)
 }
 
-func prettyJSON(data []byte) string {
+// emitPretty routes the response through cliutil.PrintOutput so that
+// --json yields the parsed value (no envelope, no pretty wrap), while
+// the human path still shows pretty-indented JSON.
+func emitPretty(cmd *cobra.Command, data []byte) {
 	var v interface{}
 	if json.Unmarshal(data, &v) == nil {
 		pretty, err := json.MarshalIndent(v, "", "  ")
 		if err == nil {
-			return string(pretty)
+			internal.PrintOutput(cmd.Flags(), v, string(pretty)+"\n")
+			return
 		}
 	}
-	return string(data)
+	internal.PrintOutput(cmd.Flags(), string(data), string(data)+"\n")
 }
 
 // --- TPD subcommands ---
@@ -87,7 +90,7 @@ var tpdStatsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -99,7 +102,7 @@ var tpdVersionsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -111,7 +114,7 @@ var tpdPerKeyStatsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -130,7 +133,7 @@ var tpdVisorStatsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -152,7 +155,7 @@ var tpdBandwidthCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -171,7 +174,7 @@ var tpdBandwidthTpCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -190,7 +193,7 @@ var tpdVersionsPKCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -209,7 +212,7 @@ var tpdMetricsVisorCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -228,7 +231,7 @@ var tpdMetricsTpCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -256,7 +259,7 @@ var dmsgdAllServersCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -268,7 +271,7 @@ var dmsgdServerClientsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -287,7 +290,7 @@ var dmsgdServerClientsPKCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -302,7 +305,7 @@ var arCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }
 
@@ -319,6 +322,6 @@ var nmCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		fmt.Println(prettyJSON(data))
+		emitPretty(cmd, data)
 	},
 }

--- a/cmd/skywire-cli/commands/tp/tp-all.go
+++ b/cmd/skywire-cli/commands/tp/tp-all.go
@@ -3,8 +3,6 @@ package clitp
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -32,9 +30,13 @@ transport discovery HTTP API.`,
 		}
 
 		// Try local DHT full node first.
-		result, err := rpcClient.DHTGetAll("tp")
-		if err == nil && result != "[]" && result != "" {
-			fmt.Fprintln(os.Stdout, result) //nolint:errcheck
+		if result, err := rpcClient.DHTGetAll("tp"); err == nil && result != "[]" && result != "" {
+			var v interface{}
+			if json.Unmarshal([]byte(result), &v) == nil {
+				internal.PrintOutput(cmd.Flags(), v, result+"\n")
+				return
+			}
+			internal.PrintOutput(cmd.Flags(), result, result+"\n")
 			return
 		}
 
@@ -47,9 +49,9 @@ transport discovery HTTP API.`,
 		var v interface{}
 		if json.Unmarshal(body, &v) == nil {
 			pretty, _ := json.MarshalIndent(v, "", "  ") //nolint:errcheck
-			fmt.Fprintln(os.Stdout, string(pretty))      //nolint:errcheck
-		} else {
-			fmt.Fprintln(os.Stdout, string(body)) //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), v, string(pretty)+"\n")
+			return
 		}
+		internal.PrintOutput(cmd.Flags(), string(body), string(body)+"\n")
 	},
 }

--- a/cmd/skywire-cli/commands/tp/tp-uptime.go
+++ b/cmd/skywire-cli/commands/tp/tp-uptime.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -34,7 +35,6 @@ var (
 	tpUptimeVisors   []string
 	tpUptimeOnline   bool
 	tpUptimeType     string
-	tpUptimeJSON     bool
 	tpUptimeTimeout  time.Duration
 	tpUptimeCacheDir string
 	tpUptimeCacheAge int
@@ -56,7 +56,7 @@ func init() {
 	tpUptimeCmd.Flags().StringSliceVar(&tpUptimeVisors, "visors", nil, "filter to transports touching these visor PKs (comma-separated) — uses /metrics/uptime/visor/{pks}")
 	tpUptimeCmd.Flags().BoolVarP(&tpUptimeOnline, "on", "o", false, "only include currently online transports")
 	tpUptimeCmd.Flags().StringVarP(&tpUptimeType, "type", "t", "", "filter by transport type (stcpr / sudph / dmsg / stcp)")
-	tpUptimeCmd.Flags().BoolVar(&tpUptimeJSON, "json", false, "emit raw JSON")
+	tpUptimeCmd.Flags().Bool("json", false, "emit raw JSON")
 	tpUptimeCmd.Flags().DurationVar(&tpUptimeTimeout, "timeout", 30*time.Second, "HTTP timeout")
 	tpUptimeCmd.Flags().StringVar(&tpUptimeCacheDir, "cache-dir", defaultTpUptimeCacheDir(), "cache directory (\"\" disables)")
 	tpUptimeCmd.Flags().IntVar(&tpUptimeCacheAge, "cache-age", 5, "re-fetch if cache is older than N minutes (0 disables)")
@@ -101,11 +101,7 @@ transport type, or --json to dump raw JSON for piping.`,
 			if err := json.Unmarshal([]byte(raw), &nu); err != nil {
 				fatal(cmd, fmt.Errorf("parse /metrics/uptime: %w", err))
 			}
-			if tpUptimeJSON {
-				_ = json.NewEncoder(os.Stdout).Encode(nu) //nolint:errcheck,gosec
-				return
-			}
-			printNetworkUptime(nu)
+			internal.PrintOutput(cmd.Flags(), nu, formatNetworkUptime(nu))
 		case len(tpUptimeIDs) > 0:
 			ids, err := parseUUIDs(tpUptimeIDs)
 			if err != nil {
@@ -121,7 +117,7 @@ transport type, or --json to dump raw JSON for piping.`,
 			if err := json.Unmarshal([]byte(raw), &entries); err != nil {
 				fatal(cmd, fmt.Errorf("parse %s: %w", path, err))
 			}
-			emitTransports(filterTransports(entries), tpUptimeJSON)
+			emitTransports(cmd, filterTransports(entries))
 		case len(tpUptimeVisors) > 0:
 			pks, err := parsePubKeys(tpUptimeVisors)
 			if err != nil {
@@ -137,7 +133,7 @@ transport type, or --json to dump raw JSON for piping.`,
 			if err := json.Unmarshal([]byte(raw), &entries); err != nil {
 				fatal(cmd, fmt.Errorf("parse %s: %w", path, err))
 			}
-			emitTransports(filterTransports(entries), tpUptimeJSON)
+			emitTransports(cmd, filterTransports(entries))
 		default:
 			q := ""
 			if tpUptimeVersion != "" && tpUptimeVersion != "v1" {
@@ -148,7 +144,7 @@ transport type, or --json to dump raw JSON for piping.`,
 			if err := json.Unmarshal([]byte(raw), &entries); err != nil {
 				fatal(cmd, fmt.Errorf("parse /uptimes/transports: %w", err))
 			}
-			emitTransports(filterTransports(entries), tpUptimeJSON)
+			emitTransports(cmd, filterTransports(entries))
 		}
 	},
 }
@@ -201,11 +197,8 @@ func filterTransports(in []uptimestats.TransportSummary) []uptimestats.Transport
 	return out
 }
 
-func emitTransports(entries []uptimestats.TransportSummary, asJSON bool) {
-	if asJSON {
-		_ = json.NewEncoder(os.Stdout).Encode(entries) //nolint:errcheck,gosec
-		return
-	}
+func emitTransports(cmd *cobra.Command, entries []uptimestats.TransportSummary) {
+	var buf strings.Builder
 	for _, t := range entries {
 		state := "off"
 		if t.Online {
@@ -215,18 +208,20 @@ func emitTransports(entries []uptimestats.TransportSummary, asJSON bool) {
 		if typ == "" {
 			typ = "-"
 		}
-		fmt.Printf("%s %s %-6s %s <-> %s\n", state, t.ID, typ, t.EdgeA, t.EdgeB)
+		fmt.Fprintf(&buf, "%s %s %-6s %s <-> %s\n", state, t.ID, typ, t.EdgeA, t.EdgeB)
 	}
+	internal.PrintOutput(cmd.Flags(), entries, buf.String())
 }
 
-func printNetworkUptime(nu uptimestats.NetworkUptime) {
+func formatNetworkUptime(nu uptimestats.NetworkUptime) string {
+	var buf strings.Builder
 	pct := 0.0
 	if nu.TotalTransports > 0 {
 		pct = 100 * float64(nu.Online) / float64(nu.TotalTransports)
 	}
-	fmt.Printf("transports: %d total, %d online (%.1f%%)\n", nu.TotalTransports, nu.Online, pct)
+	fmt.Fprintf(&buf, "transports: %d total, %d online (%.1f%%)\n", nu.TotalTransports, nu.Online, pct)
 	if len(nu.ByType) > 0 {
-		fmt.Println("by type:")
+		buf.WriteString("by type:\n")
 		keys := make([]string, 0, len(nu.ByType))
 		for k := range nu.ByType {
 			keys = append(keys, k)
@@ -238,9 +233,10 @@ func printNetworkUptime(nu uptimestats.NetworkUptime) {
 			if b.Total > 0 {
 				typePct = 100 * float64(b.Online) / float64(b.Total)
 			}
-			fmt.Printf("  %-6s %5d / %5d online (%.1f%%)\n", k, b.Online, b.Total, typePct)
+			fmt.Fprintf(&buf, "  %-6s %5d / %5d online (%.1f%%)\n", k, b.Online, b.Total, typePct)
 		}
 	}
+	return buf.String()
 }
 
 func parseUUIDs(in []string) ([]uuid.UUID, error) {

--- a/cmd/skywire-cli/commands/visor/proxies.go
+++ b/cmd/skywire-cli/commands/visor/proxies.go
@@ -12,9 +12,8 @@
 package clivisor
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -24,10 +23,8 @@ import (
 	"github.com/skycoin/skywire/pkg/visor"
 )
 
-var proxiesJSON bool
-
 func init() {
-	proxiesCmd.Flags().BoolVar(&proxiesJSON, "json", false, "emit raw JSON")
+	proxiesCmd.Flags().Bool("json", false, "emit raw JSON")
 	proxiesCmd.AddCommand(proxiesSetCmd)
 	proxiesCmd.AddCommand(proxiesUpstreamCmd)
 	RootCmd.AddCommand(proxiesCmd)
@@ -50,11 +47,7 @@ Print the runtime state + cumulative stats of the visor-hosted
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("EmbeddedProxies RPC failed: %w", err))
 		}
-		if proxiesJSON {
-			_ = json.NewEncoder(os.Stdout).Encode(status) //nolint:errcheck,gosec
-			return
-		}
-		printProxies(status)
+		internal.PrintOutput(cmd.Flags(), status, formatProxies(status))
 	},
 }
 
@@ -90,7 +83,9 @@ reverts to the config's 'enable' flag. Use this to experiment with
 		if enable {
 			state = "enabled"
 		}
-		fmt.Printf("%s resolver %s\n", kind, state)
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"kind": kind, "enabled": enable},
+			fmt.Sprintf("%s resolver %s\n", kind, state))
 	},
 }
 
@@ -120,20 +115,24 @@ Example chain: browser → dmsgweb (.dmsg) → skynetweb (.skynet) → skysocks 
 		if err := rpcClient.SetEmbeddedProxyUpstream(kind, addr); err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("SetEmbeddedProxyUpstream failed: %w", err))
 		}
+		var msg string
 		if addr == "" {
-			fmt.Printf("%s resolver upstream cleared (direct connect)\n", kind)
+			msg = fmt.Sprintf("%s resolver upstream cleared (direct connect)\n", kind)
 		} else {
-			fmt.Printf("%s resolver upstream set to %s\n", kind, addr)
+			msg = fmt.Sprintf("%s resolver upstream set to %s\n", kind, addr)
 		}
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"kind": kind, "upstream": addr},
+			msg)
 	},
 }
 
-func printProxies(s *visor.EmbeddedProxiesStatus) {
+func formatProxies(s *visor.EmbeddedProxiesStatus) string {
 	if s == nil || (s.DmsgWeb == nil && s.SkynetWeb == nil) {
-		fmt.Println("(no embedded proxies configured)")
-		return
+		return "(no embedded proxies configured)\n"
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "name\tenabled\trunning\tdomain\tsocks\tweb\tupstream\trequests\tactive\tfailures") //nolint:errcheck,gosec
 	fmt.Fprintln(w, "----\t-------\t-------\t------\t-----\t---\t--------\t--------\t------\t--------") //nolint:errcheck,gosec
 	row := func(name string, p *visor.EmbeddedProxyInfo) {
@@ -159,14 +158,13 @@ func printProxies(s *visor.EmbeddedProxiesStatus) {
 	row("skynetweb", s.SkynetWeb)
 	_ = w.Flush() //nolint:errcheck,gosec
 
-	// Last-error blurb below the table when any resolver has one —
-	// helpful for quick triage without going to --json.
 	if s.DmsgWeb != nil && s.DmsgWeb.Stats != nil && s.DmsgWeb.Stats.LastError != "" {
-		fmt.Printf("\ndmsgweb last error: %s\n", s.DmsgWeb.Stats.LastError)
+		fmt.Fprintf(&buf, "\ndmsgweb last error: %s\n", s.DmsgWeb.Stats.LastError)
 	}
 	if s.SkynetWeb != nil && s.SkynetWeb.Stats != nil && s.SkynetWeb.Stats.LastError != "" {
-		fmt.Printf("\nskynetweb last error: %s\n", s.SkynetWeb.Stats.LastError)
+		fmt.Fprintf(&buf, "\nskynetweb last error: %s\n", s.SkynetWeb.Stats.LastError)
 	}
+	return buf.String()
 }
 
 func dashIfEmpty(s string) string {

--- a/cmd/skywire-cli/commands/visor/tprpc.go
+++ b/cmd/skywire-cli/commands/visor/tprpc.go
@@ -4,7 +4,6 @@ package clivisor
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -63,6 +62,6 @@ Examples:
 		}
 
 		pretty, _ := json.MarshalIndent(result, "", "  ") //nolint:errcheck
-		fmt.Fprintln(os.Stdout, string(pretty))           //nolint:errcheck
+		internal.PrintOutput(cmd.Flags(), result, string(pretty)+"\n")
 	},
 }

--- a/internal/integration/diagnostics_test.go
+++ b/internal/integration/diagnostics_test.go
@@ -194,26 +194,19 @@ func (env *TestEnv) checkVisorDmsgEntry(visor string) bool {
 		Client    *dmsgClient `json:"client,omitempty"`
 		Timestamp int64       `json:"timestamp"`
 	}
-	cliOut := struct {
-		Output *dmsgEntry `json:"output,omitempty"`
-		Err    *string    `json:"error,omitempty"`
-	}{}
+	var entry dmsgEntry
 
-	if err := env.ExecJSON(cmd, &cliOut); err != nil {
+	if err := env.ExecJSON(cmd, &entry); err != nil {
 		env.logger.Warnf("VISOR DMSG ENTRY [%s]: mdisc query failed: %v", visor, err)
 		return false
 	}
-	if cliOut.Err != nil {
-		env.logger.Warnf("VISOR DMSG ENTRY [%s]: mdisc returned error: %s", visor, *cliOut.Err)
-		return false
-	}
-	if cliOut.Output == nil || cliOut.Output.Client == nil {
+	if entry.Client == nil {
 		env.logger.Warnf("VISOR DMSG ENTRY [%s]: no client entry in discovery", visor)
 		return false
 	}
-	delegated := cliOut.Output.Client.DelegatedServers
+	delegated := entry.Client.DelegatedServers
 	// Timestamp is nanoseconds since epoch — pass as the nsec arg, not sec.
-	age := time.Since(time.Unix(0, cliOut.Output.Timestamp)).Round(time.Second)
+	age := time.Since(time.Unix(0, entry.Timestamp)).Round(time.Second)
 	env.logger.Infof("VISOR DMSG ENTRY [%s]: %d delegated servers, entry age %v", visor, len(delegated), age)
 	for i, srv := range delegated {
 		env.logger.Infof("   [%d] %s", i, truncatePK(srv))
@@ -283,11 +276,9 @@ func (env *TestEnv) checkVisorTransports(visor string) {
 //
 // The CLI output matches []remoteResult in cmd/skywire-cli/commands/tp/tp.go:
 //
-//	{
-//	  "output": [
-//	    {"TargetPK": "...", "Transports": [...], "Error": ""}
-//	  ]
-//	}
+//	[
+//	  {"TargetPK": "...", "Transports": [...], "Error": ""}
+//	]
 func (env *TestEnv) checkVisorTransportsViaTPS(visor, pk string, localIDs map[string]bool) {
 	cmd := fmt.Sprintf("/release/skywire cli tp --remote %s --json", pk)
 	type remoteTP struct {
@@ -300,23 +291,16 @@ func (env *TestEnv) checkVisorTransportsViaTPS(visor, pk string, localIDs map[st
 		Transports []remoteTP `json:"Transports"`
 		Error      string     `json:"Error"`
 	}
-	cliOut := struct {
-		Output []remoteResult `json:"output,omitempty"`
-		Err    *string        `json:"error,omitempty"`
-	}{}
-	if err := env.ExecJSON(cmd, &cliOut); err != nil {
+	var results []remoteResult
+	if err := env.ExecJSON(cmd, &results); err != nil {
 		env.logger.Warnf("VISOR TRANSPORTS [%s]: TPS remote query failed: %v", visor, err)
 		return
 	}
-	if cliOut.Err != nil {
-		env.logger.Warnf("VISOR TRANSPORTS [%s]: TPS remote query error: %s", visor, *cliOut.Err)
-		return
-	}
-	if len(cliOut.Output) == 0 {
+	if len(results) == 0 {
 		env.logger.Warnf("VISOR TRANSPORTS [%s]: TPS remote query returned no results", visor)
 		return
 	}
-	res := cliOut.Output[0]
+	res := results[0]
 	if res.Error != "" {
 		env.logger.Warnf("VISOR TRANSPORTS [%s]: TPS remote query for target reported error: %s", visor, res.Error)
 		return
@@ -450,22 +434,19 @@ func (env *TestEnv) checkDmsgServiceNode(label, pk string) bool {
 		Client    *dmsgClient `json:"client,omitempty"`
 		Timestamp int64       `json:"timestamp"`
 	}
-	cliOut := struct {
-		Output *dmsgEntry `json:"output,omitempty"`
-		Err    *string    `json:"error,omitempty"`
-	}{}
+	var entry dmsgEntry
 
-	if err := env.ExecJSON(cmd, &cliOut); err != nil {
+	if err := env.ExecJSON(cmd, &entry); err != nil {
 		env.logger.Warnf("%s DMSG ENTRY: query failed: %v", label, err)
 		return false
 	}
-	if cliOut.Err != nil || cliOut.Output == nil || cliOut.Output.Client == nil {
+	if entry.Client == nil {
 		env.logger.Warnf("%s DMSG ENTRY: no client entry in discovery", label)
 		return false
 	}
-	delegated := cliOut.Output.Client.DelegatedServers
+	delegated := entry.Client.DelegatedServers
 	// Timestamp is nanoseconds — pass as the nsec arg, not sec.
-	age := time.Since(time.Unix(0, cliOut.Output.Timestamp)).Round(time.Second)
+	age := time.Since(time.Unix(0, entry.Timestamp)).Round(time.Second)
 	env.logger.Infof("%s DMSG ENTRY: %d delegated servers, entry age %v", label, len(delegated), age)
 	return len(delegated) > 0
 }

--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -110,21 +110,12 @@ func (env *TestEnv) GatherContainersInfo() *TestEnv {
 }
 
 func (env *TestEnv) VisorAppLs(visor string) ([]AppState, error) {
-
-	cliOutput := struct {
-		Output []AppState `json:"output,omitempty"`
-		Err    *string    `json:"error,omitempty"`
-	}{}
-
+	var apps []AppState
 	cmd := fmt.Sprintf("/release/skywire cli visor --rpc %v:3435 app ls --json", visor)
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	if err := env.ExecJSON(cmd, &apps); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return apps, nil
 }
 
 // VerifyAppRunning checks if an app is running and fails the test if not.
@@ -318,12 +309,7 @@ func (env *TestEnv) StopAppBestEffort(app AppToRun) *TestEnv {
 }
 
 func (env *TestEnv) VisorAppStart(app AppToRun) (string, error) {
-
-	cliOutput := struct {
-		Output string  `json:"output,omitempty"`
-		Err    *string `json:"error,omitempty"`
-	}{}
-
+	var out string
 	launcherFlag := ""
 	if app.LauncherMode == "internal" {
 		launcherFlag = " --internal"
@@ -332,36 +318,22 @@ func (env *TestEnv) VisorAppStart(app AppToRun) (string, error) {
 	}
 
 	cmd := fmt.Sprintf("/release/skywire cli visor --rpc %v:3435 app start %s%s --json", app.VisorHostName, app.AppName, launcherFlag)
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	if err := env.ExecJSON(cmd, &out); err != nil {
 		return "", err
 	}
-	if cliOutput.Err != nil {
-		return "", errors.New(*cliOutput.Err)
-	}
-
-	err = env.waitForVisorApp(app)
-	if err != nil {
+	if err := env.waitForVisorApp(app); err != nil {
 		return "", err
 	}
-	return cliOutput.Output, nil
+	return out, nil
 }
 
 func (env *TestEnv) VisorAppStop(app AppToRun) (string, error) {
-	cliOutput := struct {
-		Output string  `json:"output,omitempty"`
-		Err    *string `json:"error,omitempty"`
-	}{}
-
+	var out string
 	cmd := fmt.Sprintf("/release/skywire cli visor --rpc %v:3435 app stop %s --json", app.VisorHostName, app.AppName)
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	if err := env.ExecJSON(cmd, &out); err != nil {
 		return "", err
 	}
-	if cliOutput.Err != nil {
-		return "", errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return out, nil
 }
 
 func (env *TestEnv) VisorSetAppArg(t *testing.T, arg AppArg) *TestEnv {
@@ -398,38 +370,24 @@ func (env *TestEnv) VisorCHVPK(visor string) ([]string, error) {
 }
 
 func (env *TestEnv) VisorRouteLsRules(visor string) ([]RouteRule, error) {
-	cliOutput := struct {
-		Output []RouteRule `json:"output,omitempty"`
-		Err    *string     `json:"error,omitempty"`
-	}{}
+	var rules []RouteRule
 	cmd := fmt.Sprintf("/release/skywire cli route --rpc %v:3435 --json", visor)
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	if err := env.ExecJSON(cmd, &rules); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	if cliOutput.Output == nil {
+	if rules == nil {
 		return []RouteRule{}, nil
 	}
-	return cliOutput.Output, nil
+	return rules, nil
 }
 
 func (env *TestEnv) VisorRouteRule(visor string, routeID routing.RouteID) (*RouteRule, error) {
-	cliOutput := struct {
-		Output []RouteRule `json:"output,omitempty"`
-		Err    *string     `json:"error,omitempty"`
-	}{}
+	var rules []RouteRule
 	cmd := fmt.Sprintf("/release/skywire cli route --rpc %v:3435 rule %v --json", visor, routeID)
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	if err := env.ExecJSON(cmd, &rules); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return &cliOutput.Output[0], nil
+	return &rules[0], nil
 }
 
 func (env *TestEnv) VisorRouteAddAppRule(visor, routeID, localPK, localPort, remotePK, remotePort string) (*RouteKey, error) {
@@ -448,19 +406,11 @@ func (env *TestEnv) VisorRouteAddIntFwdRule(visor, routeID, nextRouteID, nextTpI
 }
 
 func (env *TestEnv) visorRouteAddRule(cmd string) (*RouteKey, error) {
-
-	cliOutput := struct {
-		Output *RouteKey `json:"output,omitempty"`
-		Err    *string   `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var key RouteKey
+	if err := env.ExecJSON(cmd, &key); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return &key, nil
 }
 
 func (env *TestEnv) VisorRouteRmRule(visor string, routeID routing.RouteID) (string, error) {
@@ -482,18 +432,11 @@ func (env *TestEnv) VisorStart(visor string) (string, error) {
 
 func (env *TestEnv) VisorTpType(visor string) ([]tptypes.Type, error) {
 	cmd := fmt.Sprintf("/release/skywire cli --rpc %v:3435 tp --tptypes --json", visor)
-	cliOutput := struct {
-		Output []tptypes.Type `json:"output,omitempty"`
-		Err    *string        `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var types []tptypes.Type
+	if err := env.ExecJSON(cmd, &types); err != nil {
 		return []tptypes.Type{}, err
 	}
-	if cliOutput.Err != nil {
-		return []tptypes.Type{}, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return types, nil
 }
 
 func (env *TestEnv) VisorTpLs(visor string) ([]*skyvisor.TransportSummary, error) {
@@ -605,34 +548,20 @@ func (env *TestEnv) visorTpExec(cmd string) ([]*skyvisor.TransportSummary, error
 // list. Used for tp list / tp discover style commands where zero results is
 // a valid state.
 func (env *TestEnv) visorTpExecAllowEmpty(cmd string) ([]*skyvisor.TransportSummary, error) {
-	cliOutput := struct {
-		Output []*skyvisor.TransportSummary `json:"output,omitempty"`
-		Err    *string                      `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var summaries []*skyvisor.TransportSummary
+	if err := env.ExecJSON(cmd, &summaries); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return summaries, nil
 }
 
 func (env *TestEnv) VPNList(visor string) ([]servicedisc.Service, error) {
 	cmd := fmt.Sprintf("/release/skywire cli vpn --rpc %v:3435 list --sdurl http://service-discovery:9091 --json", visor)
-	cliOutput := struct {
-		Output []servicedisc.Service `json:"output,omitempty"`
-		Err    *string               `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var services []servicedisc.Service
+	if err := env.ExecJSON(cmd, &services); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return services, nil
 }
 
 func (env *TestEnv) VPNStart(app AppToRun, serverPk string) (string, error) {
@@ -677,13 +606,10 @@ func (env *TestEnv) VPNStart(app AppToRun, serverPk string) (string, error) {
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		env.logger.Infof("VPN start attempt %d/%d for %s -> %s (timeout: %v)", attempt, maxRetries, app.VisorHostName, serverPk, vpnStartTimeout)
 
-		cliOutput := struct {
-			Output VPNStart `json:"output,omitempty"`
-			Err    *string  `json:"error,omitempty"`
-		}{}
+		var startResult VPNStart
 
 		// Use timeout version to prevent indefinite hangs
-		err := env.ExecJSONWithTimeout(cmd, &cliOutput, vpnStartTimeout)
+		err := env.ExecJSONWithTimeout(cmd, &startResult, vpnStartTimeout)
 		if err != nil {
 			lastErr = err
 			env.logger.WithError(err).Warnf("VPN start command failed on attempt %d", attempt)
@@ -709,8 +635,8 @@ func (env *TestEnv) VPNStart(app AppToRun, serverPk string) (string, error) {
 		// If successful, we're done
 		if err == nil {
 			env.logger.Infof("VPN client started successfully on attempt %d", attempt)
-			if cliOutput.Output.AppError != "" {
-				return cliOutput.Output.AppError, nil
+			if startResult.AppError != "" {
+				return startResult.AppError, nil
 			}
 			return "OK", nil
 		}
@@ -796,18 +722,11 @@ func (env *TestEnv) VPNStop(app AppToRun) (string, error) {
 
 func (env *TestEnv) VPNStatus(visor string) (*VPNStatus, error) {
 	cmd := fmt.Sprintf("/release/skywire cli vpn --rpc %v:3435 status --json", visor)
-	cliOutput := struct {
-		Output VPNStatus `json:"output,omitempty"`
-		Err    *string   `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var status VPNStatus
+	if err := env.ExecJSON(cmd, &status); err != nil {
 		return nil, err
 	}
-	if cliOutput.Err != nil {
-		return nil, errors.New(*cliOutput.Err)
-	}
-	return &cliOutput.Output, nil
+	return &status, nil
 }
 
 func (env *TestEnv) TestVisorAddTp(t *testing.T, tp Transport) *TestEnv {
@@ -980,33 +899,19 @@ func (env *TestEnv) ExecJSON(cmd string, output interface{}) error {
 	return err
 }
 func (env *TestEnv) ExecJSONReturnString(cmd string) (string, error) {
-	cliOutput := struct {
-		Output string  `json:"output,omitempty"`
-		Err    *string `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var out string
+	if err := env.ExecJSON(cmd, &out); err != nil {
 		return "", err
 	}
-	if cliOutput.Err != nil {
-		return "", errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return out, nil
 }
 
 func (env *TestEnv) ExecJSONReturnSlice(cmd string) ([]string, error) {
-	cliOutput := struct {
-		Output []string `json:"output,omitempty"`
-		Err    *string  `json:"error,omitempty"`
-	}{}
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var out []string
+	if err := env.ExecJSON(cmd, &out); err != nil {
 		return []string{}, err
 	}
-	if cliOutput.Err != nil {
-		return []string{}, errors.New(*cliOutput.Err)
-	}
-	return cliOutput.Output, nil
+	return out, nil
 }
 
 func (env *TestEnv) ExecInContainerByName(cmd string, containerName string) (string, error) {
@@ -1311,21 +1216,16 @@ func (env *TestEnv) WaitForVisorDmsgReady(visor string, timeout time.Duration) e
 		type dmsgServer struct {
 			PK string `json:"pk"`
 		}
-		cliOutput := struct {
-			Output []dmsgServer `json:"output,omitempty"`
-			Err    *string      `json:"error,omitempty"`
-		}{}
+		var servers []dmsgServer
 
-		err := env.ExecJSON(cmd, &cliOutput)
-		if err == nil && cliOutput.Err == nil && len(cliOutput.Output) > 0 {
-			env.logger.Infof("Visor %s connected to %d DMSG servers", visor, len(cliOutput.Output))
+		err := env.ExecJSON(cmd, &servers)
+		if err == nil && len(servers) > 0 {
+			env.logger.Infof("Visor %s connected to %d DMSG servers", visor, len(servers))
 			return nil
 		}
 
 		if err != nil {
 			env.logger.Debugf("dmsg-servers query for %s failed: %v", visor, err)
-		} else if cliOutput.Err != nil {
-			env.logger.Debugf("dmsg-servers error for %s: %s", visor, *cliOutput.Err)
 		} else {
 			env.logger.Debugf("Visor %s has no DMSG servers connected yet", visor)
 		}
@@ -1427,26 +1327,17 @@ func (env *TestEnv) waitForDmsgDiscoveryEntryAfter(visor string, timeout time.Du
 			Timestamp int64       `json:"timestamp"`
 		}
 
-		cliOutput := struct {
-			Output *dmsgEntry `json:"output,omitempty"`
-			Err    *string    `json:"error,omitempty"`
-		}{}
+		var entry dmsgEntry
 
-		err := env.ExecJSON(cmd, &cliOutput)
+		err := env.ExecJSON(cmd, &entry)
 		if err != nil {
 			env.logger.Debugf("mdisc query for %s failed: %v", visor, err)
 			time.Sleep(checkInterval)
 			continue
 		}
 
-		if cliOutput.Err != nil {
-			env.logger.Debugf("mdisc error for %s: %s", visor, *cliOutput.Err)
-			time.Sleep(checkInterval)
-			continue
-		}
-
-		if cliOutput.Output != nil && cliOutput.Output.Client != nil && len(cliOutput.Output.Client.DelegatedServers) > 0 {
-			entryTime := time.Unix(cliOutput.Output.Timestamp, 0)
+		if entry.Client != nil && len(entry.Client.DelegatedServers) > 0 {
+			entryTime := time.Unix(entry.Timestamp, 0)
 			if !notBefore.IsZero() && entryTime.Before(notBefore) {
 				env.logger.Debugf("Visor %s has stale DMSG entry (timestamp %v < notBefore %v), waiting for fresh registration",
 					visor, entryTime.Format(time.RFC3339), notBefore.Format(time.RFC3339))
@@ -1454,7 +1345,7 @@ func (env *TestEnv) waitForDmsgDiscoveryEntryAfter(visor string, timeout time.Du
 				continue
 			}
 			env.logger.Infof("Visor %s registered in DMSG discovery with %d delegated servers (entry age: %v)",
-				visor, len(cliOutput.Output.Client.DelegatedServers), time.Since(entryTime).Round(time.Second))
+				visor, len(entry.Client.DelegatedServers), time.Since(entryTime).Round(time.Second))
 			return nil
 		}
 
@@ -1804,21 +1695,11 @@ type RouteFinderResult struct {
 func (env *TestEnv) QueryRouteFinder(srcPK, dstPK string) (*RouteFinderResult, error) {
 	cmd := fmt.Sprintf("/release/skywire cli route find %s %s --addr http://route-finder:9092 --json --timeout 10s", srcPK, dstPK)
 
-	cliOutput := struct {
-		Output *RouteFinderResult `json:"output,omitempty"`
-		Err    *string            `json:"error,omitempty"`
-	}{}
-
-	err := env.ExecJSON(cmd, &cliOutput)
-	if err != nil {
+	var result RouteFinderResult
+	if err := env.ExecJSON(cmd, &result); err != nil {
 		return nil, fmt.Errorf("route finder query failed: %w", err)
 	}
-
-	if cliOutput.Err != nil {
-		return nil, fmt.Errorf("route finder error: %s", *cliOutput.Err)
-	}
-
-	return cliOutput.Output, nil
+	return &result, nil
 }
 
 // DumpRouteFinderState queries and logs route finder results between visors
@@ -2095,15 +1976,13 @@ func (env *TestEnv) waitForNonZeroBandwidth(visor, peerPK string, timeout time.D
 	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		var result struct {
-			Output []tpBW `json:"output"`
-		}
+		var tps []tpBW
 		err := env.ExecJSON(
 			fmt.Sprintf("/release/skywire cli --rpc %s:3435 tp --json", visor),
-			&result,
+			&tps,
 		)
 		if err == nil {
-			for _, tp := range result.Output {
+			for _, tp := range tps {
 				if tp.RemotePK == peerPK && (tp.RecvBytes+tp.SentBytes) > 0 {
 					return true
 				}

--- a/internal/integration/mux_test.go
+++ b/internal/integration/mux_test.go
@@ -123,9 +123,7 @@ func testMuxDistributesTraffic(t *testing.T, env *TestEnv) {
 		RecvBytes uint64 `json:"recv_bytes,omitempty"`
 		SentBytes uint64 `json:"sent_bytes,omitempty"`
 	}
-	var tpResult struct {
-		Output []tpWithBW `json:"output"`
-	}
+	var tpResult []tpWithBW
 	err = env.ExecJSON(
 		fmt.Sprintf("/release/skywire cli --rpc %s:3435 tp --json", visorC),
 		&tpResult,
@@ -133,7 +131,7 @@ func testMuxDistributesTraffic(t *testing.T, env *TestEnv) {
 	require.NoError(t, err, "Failed to list transports after traffic")
 
 	var dmsgBytes, stcprBytes uint64
-	for _, tp := range tpResult.Output {
+	for _, tp := range tpResult {
 		if tp.RemotePK != serverPK {
 			continue
 		}
@@ -170,16 +168,14 @@ func testMuxDistributesTraffic(t *testing.T, env *TestEnv) {
 
 	// Also verify on the server side
 	clientPK := env.visorPKs[visorC]
-	var serverResult struct {
-		Output []tpWithBW `json:"output"`
-	}
+	var serverResult []tpWithBW
 	err = env.ExecJSON(
 		fmt.Sprintf("/release/skywire cli --rpc %s:3435 tp --json", visorA),
 		&serverResult,
 	)
 	if err == nil {
 		var serverDmsgBW, serverStcprBW uint64
-		for _, tp := range serverResult.Output {
+		for _, tp := range serverResult {
 			if tp.RemotePK != clientPK {
 				continue
 			}


### PR DESCRIPTION
## Summary

Follow-up to #2375. Routes the remaining direct `json.NewEncoder` /
`fmt.Println(prettyJSON(...))` sites through `cliutil.PrintOutput`, so
every `--json` invocation yields raw values to stdout (matching gh /
kubectl / stripe) and any errors go to stderr.

Migrated commands:
- `cli tp all`, `cli tp uptime`
- `cli svc fetch ...` (single helper, 14 call sites)
- `cli route rsn-remote-stats`
- `cli visor tp-rpc`, `cli visor proxies` (deprecated, still uses old text path)
- `cli config show` (top-level + jq filter mode)
- `cli dmsg diag {porter, porter-reset, porter-diag, reconnect}`

Notable details:
- `tp uptime` drops its local `tpUptimeJSON` var — `cliutil.PrintOutput`
  reads the cobra flag directly, so the global JSON contract holds.
- `svc fetch` picks up a single `emitPretty(cmd, data)` helper that
  unmarshals once and routes through `PrintOutput`, so all 14
  subcommands stay in sync.
- `config show .a.b.c` (jq filter) now collects results into a slice and
  emits one bare value (or an array when jq produced multiple). Previous
  behavior streamed each result on its own line in `--json` mode, which
  produced unparseable concatenated JSON.

## Integration tests

Tests under `internal/integration/` decoded the legacy
`{"output": ..., "error": ...}` envelope at every CLI call site. With
#2375 the envelope is gone, so:
- `ExecJSONReturnString` / `ExecJSONReturnSlice` decode the bare value.
- ~17 inline `struct { Output X json:\"output\"; Err *string ... }` decoder
  structs replaced with the bare type.
- The dead `cliOutput.Err` checks were dropped — errors now arrive via
  `execResult`'s non-zero exit because the CLI writes JSON errors to
  stderr and exits 1.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/skywire-cli/... ./internal/integration/...` clean
- [x] `gofmt -l` clean
- [x] `go test -tags=integration -run NONEXISTENT_DRY ./internal/integration/...` (compile check)
- [x] Smoke: `cli config show --path --json` → `\"skywire-config.json\"`
- [x] Smoke: `cli visor proxies --help` shows `--json` flag
- [ ] Run integration suite end-to-end against this branch (CI)