### PR TITLE
visor: fix WebSocket upgrade on port-80 reverse proxy; refresh forwarding docs

### DIFF
--- a/docs/skywire_forwarding.md
+++ b/docs/skywire_forwarding.md
@@ -1,80 +1,99 @@
-# Skynet Port Forwarding
+# Serving Localhost Ports Over Skywire
 
-Forward local TCP ports over the Skywire network (skynet and/or DMSG).
-Remote visors can connect to forwarded ports via skynet routes or DMSG.
+Expose local TCP ports over the Skywire network (skynet and/or DMSG).
+Remote visors can connect via skynet routes or DMSG.
 
-## Managing Forwarded Ports
+The CLI tree lives under `skywire cli serve`. The legacy
+`skywire cli skynet port {add,ls,rm}` commands still work but are
+deprecated.
+
+## Managing Served Ports
 
 ### Add a port
 
 ```bash
-skywire cli skynet port add <port> [flags]
+skywire cli serve add <port> [flags]
 ```
 
 Flags:
-- `-l, --label` — human-readable label (shown on landing page)
-- `-d, --desc` — description
-- `--skynet` — forward over skynet (default: true)
-- `--dmsg` — forward over DMSG (default: true)
-- `--landing` — show link on visor landing page (default: true)
-- `--proxy-addr` — reverse proxy to a local address (e.g., `127.0.0.1:3000`); for port 80, replaces the landing page
+- `--to <host:port|port>` — local target (`127.0.0.1:9883`, or just
+  `9883` → `localhost:9883`). Required for non-default forwarding.
+- `-l, --label` — label shown on the visor landing page
+- `-d, --desc` — description on the landing page
+- `--skynet` / `--dmsg` — expose over each network face (default: both)
+- `--landing` — show a link on the visor landing page (default: true)
+- `--whitelist` — comma-separated PKs allowed to access the port
+  (empty = allow all peers)
 
 Examples:
 
 ```bash
-# Forward port 8080 with defaults
-skywire cli skynet port add 8080
+# Forward port 8080 with defaults (skynet + DMSG, landing-page link)
+skywire cli serve add 8080 --to 8080
 
-# Forward with metadata
-skywire cli skynet port add 8080 --label "My App" --desc "Web dashboard"
+# Same thing with metadata
+skywire cli serve add 8080 --to 8080 --label "My App" --desc "Web dashboard"
 
-# Forward over skynet only (no DMSG)
-skywire cli skynet port add 3000 --dmsg=false
+# Skynet only
+skywire cli serve add 3000 --to 3000 --dmsg=false
 
-# Host a website on port 80 (replaces landing page)
-skywire cli skynet port add 80 --proxy-addr 127.0.0.1:3000 --label "My Website"
+# Host a website on port 80 (HTTP reverse-proxy through the
+# landing-page handler — replaces the visor's default landing page)
+skywire cli serve add 80 --to 127.0.0.1:3000 --label "My Website"
 ```
+
+`--to` accepts either `host:port` (only `127.0.0.1` / `localhost` for raw
+TCP forwarding) or a bare port. Port 80 wires up an HTTP reverse-proxy
+through the dmsghttp logserver; every other port is raw TCP.
 
 ### Remove a port
 
 ```bash
-skywire cli skynet port rm <port>
+skywire cli serve rm <port>
 ```
 
-### List forwarded ports
+### List served ports
 
 ```bash
-skywire cli skynet port ls
+skywire cli serve            # bare command lists (default action)
+skywire cli serve ls         # explicit alias
 ```
 
-Output columns: PORT, LABEL, SKYNET, DMSG, LANDING, DESCRIPTION
+Output columns: `PORT`, `TO`, `LABEL`, `SKYNET`, `DMSG`, `LANDING`,
+`DESCRIPTION`.
 
 ## Hosting a Website
 
-To serve a static website over skynet/DMSG on your visor's port 80:
+To serve a static website on your visor's port 80:
 
 ```bash
-# Start a local file server
+# Start a local file server (the static-file helper)
 skywire cli util serve /path/to/site
 # Output: Serving /path/to/site on http://127.0.0.1:43210
 
-# Forward port 80 to it
-skywire cli skynet port add 80 --proxy-addr 127.0.0.1:43210 --label "My Site"
+# Reverse-proxy port 80 to it
+skywire cli serve add 80 --to 127.0.0.1:43210 --label "My Site"
 ```
 
 The visor's system endpoints (`/health`, `/node-info`, `/services`) are
-always accessible — the website only replaces unmatched routes.
+always reachable — the website only replaces unmatched routes.
+
+> **Note (WebSockets):** the port-80 reverse-proxy serves plain HTTP
+> requests via the dmsghttp logserver. WebSocket upgrades are not
+> currently fully supported on port 80; if your app needs WebSockets,
+> serve it on its native port (e.g. `serve add 8085 --to 8085`) and let
+> clients connect over `.skynet:8085` / `.dmsg:8085` directly.
 
 ## Access Control
 
-Forwarded ports support a PK whitelist. When set, only visors with
-listed public keys can access the port. An empty whitelist means
-the port is accessible to all authenticated peers.
+Served ports support a PK whitelist. When set, only visors with listed
+public keys can access the port. Empty whitelist = open to all
+authenticated peers.
 
 Port 80 has three tiers of access control:
 - `/health`, `/services` — open to everyone
 - `/node-info`, `/visor.log`, `/debug/pprof` — survey whitelist
-- Website (everything else) — forwarded port whitelist
+- Website (everything else) — the served port's `--whitelist`
 
 ## Making HTTP Requests Over Skynet
 
@@ -87,18 +106,18 @@ skywire cli skynet curl -o output.file skynet://<public-key>/large-file
 
 ## Persistence
 
-Forwarded port configuration is stored in `local/forwarded_ports.json`
-and persists across visor restarts. It is separate from the visor
-config file.
+Served-port configuration lives in `local/forwarded_ports.json` and
+persists across visor restarts. It is separate from the visor config
+file.
 
 ## RPC Integration
 
-Applications can manage forwarded ports programmatically via the visor's
-RPC interface:
+Applications can manage served ports programmatically:
 
 ```go
 rpcClient.RegisterForwardedPort(visor.ForwardedPort{
     Port:          8080,
+    LocalPort:     8080,
     Label:         "My App",
     Skynet:        true,
     DMSG:          true,

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -37,21 +37,21 @@ import (
 //   - ErrorHandler logs reverse-proxy and upgrade failures so the
 //     symptom isn't a silently broken WS connection.
 func buildReverseProxy(log *logging.Logger, target *url.URL) *httputil.ReverseProxy {
-	proxy := httputil.NewSingleHostReverseProxy(target)
-	origDirector := proxy.Director
-	proxy.Director = func(req *http.Request) {
-		origDirector(req)
-		req.Host = target.Host
-		if req.Header.Get("Origin") != "" {
-			req.Header.Set("Origin", target.Scheme+"://"+target.Host)
-		}
-	}
-	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.WithError(err).
-			WithField("path", r.URL.Path).
-			WithField("upgrade", r.Header.Get("Upgrade")).
-			Warn("port-80 reverse proxy: backend error")
-		w.WriteHeader(http.StatusBadGateway)
+	proxy := &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.SetURL(target)
+			r.Out.Host = target.Host
+			if r.In.Header.Get("Origin") != "" {
+				r.Out.Header.Set("Origin", target.Scheme+"://"+target.Host)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.WithError(err).
+				WithField("path", r.URL.Path).
+				WithField("upgrade", r.Header.Get("Upgrade")).
+				Warn("port-80 reverse proxy: backend error")
+			w.WriteHeader(http.StatusBadGateway)
+		},
 	}
 	return proxy
 }

--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"sync"
@@ -22,6 +23,38 @@ import (
 	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
+
+// buildReverseProxy returns a *httputil.ReverseProxy targeting the local
+// app at `target`. Behaviors beyond NewSingleHostReverseProxy:
+//
+//   - Host header is rewritten to the backend's host so apps that
+//     verify the Host header accept the request.
+//   - Origin header (when present) is rewritten to the backend's URL so
+//     WebSocket upgrades through the visor's port-80 reverse proxy
+//     pass same-origin checks. Without this, audioprism and any other
+//     app that rejects cross-origin WS handshakes silently fail their
+//     audio/data channel even though the WASM/HTML loaded fine.
+//   - ErrorHandler logs reverse-proxy and upgrade failures so the
+//     symptom isn't a silently broken WS connection.
+func buildReverseProxy(log *logging.Logger, target *url.URL) *httputil.ReverseProxy {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	origDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		origDirector(req)
+		req.Host = target.Host
+		if req.Header.Get("Origin") != "" {
+			req.Header.Set("Origin", target.Scheme+"://"+target.Host)
+		}
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.WithError(err).
+			WithField("path", r.URL.Path).
+			WithField("upgrade", r.Header.Get("Upgrade")).
+			Warn("port-80 reverse proxy: backend error")
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	return proxy
+}
 
 // refreshWebsiteHandler (re)applies the right website handler to the
 // dmsghttp logserver based on current config + forwarded-port state.
@@ -76,7 +109,7 @@ func (v *Visor) refreshWebsiteHandler(log *logging.Logger) {
 				return
 			}
 			log.WithField("addr", addr).Info("Reverse-proxying custom website (port 80)")
-			lsAPI.SetWebsiteHandler(httputil.NewSingleHostReverseProxy(target))
+			lsAPI.SetWebsiteHandler(buildReverseProxy(log, target))
 			return
 		}
 	}


### PR DESCRIPTION
## Summary

WebSocket upgrades through the visor's port-80 HTTP reverse proxy were
silently dropped. Plain HTTP and WASM loaded fine, but \`ws://\` /
\`wss://\` upgrade requests failed before the backend could handshake.

Reproduced by serving audioprism on \`localhost:8085\` and exposing it
two different ways:

| Setup | HTTP | WebSocket |
|---|---|---|
| \`cli serve add 80 --to 127.0.0.1:8085\` (HTTP reverse-proxy) | works | **fails** (WASM loads, audio never streams) |
| \`cli serve add 8085 --to 8085\` (raw TCP) | works | works |

This isolates the bug to the port-80 HTTP layer. Two issues there:

1. \`httputil.NewSingleHostReverseProxy\`'s default Director does not
   rewrite \`req.Host\`, so the backend sees \`Host: <visor-pk>.dmsg\`.
   Anything that validates Host on a WS handshake rejects the upgrade.
2. The browser's \`Origin: http://<visor-pk>.dmsg\` is forwarded
   unchanged. Same-origin WS checks (used by audioprism and most WS
   frameworks) reject it.

Plain GETs aren't affected because they don't trigger the upgrade-path
validation that WS handshakes go through.

## Fix

\`pkg/visor/api_network.go\` now wires the reverse proxy through a
\`buildReverseProxy\` helper that:

- rewrites \`req.Host\` to the backend's host:port,
- rewrites \`Origin\` (when present) to \`<backend-scheme>://<backend-host>\`,
- installs an ErrorHandler that logs upgrade and dial failures, so a
  silent WS death turns into a visible warning in the visor log.

## Docs

\`docs/skywire_forwarding.md\` was using the pre-rename
\`cli skynet port add ... --proxy-addr ...\` syntax — fully outdated since
\`cli serve\` landed. Rewritten for the current surface:

- \`cli serve add <port> --to <host:port|port>\`
- bare \`cli serve\` lists; \`cli serve ls\` is an explicit alias
- whitelist + landing-page semantics
- a note about the WS caveat for port-80 hosting

## Test plan

- [x] \`go build ./...\` clean
- [x] \`gofmt -l\` / \`go vet\` clean
- [ ] Serve audioprism on port 80 and confirm WS audio stream connects
      (manual, on the reporter's setup)
- [ ] Confirm raw-TCP forwarding (\`cli serve add 8085 --to 8085\`) still
      works (regression check)