### PR TITLE
cxo/treestore: add subscriber allowlist on Publisher

### DIFF
--- a/pkg/cxo/treestore/allowlist.go
+++ b/pkg/cxo/treestore/allowlist.go
@@ -1,0 +1,105 @@
+// Package treestore — pkg/cxo/treestore/allowlist.go: subscriber
+// access control for Publisher.
+//
+// A publisher with an empty allowlist accepts subscribe requests from
+// any peer (the historical default). A populated allowlist gates the
+// CXO node's OnSubscribeRemote callback so only listed PKs may
+// subscribe. The check is intentionally conservative: rejection
+// returns a generic error so a probing peer can't distinguish "feed
+// not found" from "you are not on the allowlist."
+//
+// The state lives in *allowState so that NewWithDMSG can wire the
+// CXO node's OnSubscribeRemote hook BEFORE the node is constructed
+// (the hook is read from cfg by node.NewNode), then hand the same
+// pointer to the resulting Publisher so SetAllowlist updates the live
+// state the hook is consulting.
+package treestore
+
+import (
+	"errors"
+	"sync"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+)
+
+// errSubscribeRejected is the generic error returned by the
+// OnSubscribeRemote hook when an allowlist denies a peer. The text
+// is intentionally non-specific: a probing peer can't distinguish
+// "feed not found" from "you are not on the allowlist."
+var errSubscribeRejected = errors.New("subscribe rejected")
+
+// subscribeHook returns an OnSubscribeRemoteFunc bound to the given
+// allowState. Used by NewWithDMSG to wire the CXO node's hook before
+// the node is constructed.
+func subscribeHook(allow *allowState) func(*node.Conn, skycipher.PubKey) error {
+	return func(c *node.Conn, _ skycipher.PubKey) error {
+		if !allow.permits(cipher.PubKey(c.PeerID())) {
+			return errSubscribeRejected
+		}
+		return nil
+	}
+}
+
+// allowState is the shared, mutex-protected allowlist. nil-membership
+// (set == false) means the gate is disabled and every subscribe is
+// permitted. Non-nil membership means only listed PKs are allowed.
+type allowState struct {
+	mu      sync.RWMutex
+	set     bool
+	members map[cipher.PubKey]struct{}
+}
+
+func newAllowState(initial []cipher.PubKey) *allowState {
+	a := &allowState{}
+	a.replace(initial)
+	return a
+}
+
+// replace atomically swaps the allowlist. Passing nil disables the
+// gate (open to all). Passing an empty non-nil slice enables the gate
+// with zero allowed PKs (closed to all) — useful for staging a feed
+// before authorizing any subscribers.
+func (a *allowState) replace(pks []cipher.PubKey) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if pks == nil {
+		a.set = false
+		a.members = nil
+		return
+	}
+	a.set = true
+	a.members = make(map[cipher.PubKey]struct{}, len(pks))
+	for _, pk := range pks {
+		a.members[pk] = struct{}{}
+	}
+}
+
+// permits reports whether pk may subscribe. Returns true when the
+// gate is disabled.
+func (a *allowState) permits(pk cipher.PubKey) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if !a.set {
+		return true
+	}
+	_, ok := a.members[pk]
+	return ok
+}
+
+// list returns a snapshot copy of the current allowed PKs. Returns
+// nil when the gate is disabled.
+func (a *allowState) list() []cipher.PubKey {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if !a.set {
+		return nil
+	}
+	out := make([]cipher.PubKey, 0, len(a.members))
+	for pk := range a.members {
+		out = append(out, pk)
+	}
+	return out
+}

--- a/pkg/cxo/treestore/allowlist_test.go
+++ b/pkg/cxo/treestore/allowlist_test.go
@@ -1,0 +1,125 @@
+package treestore
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestAllowStateOpenByDefault(t *testing.T) {
+	a := newAllowState(nil)
+	pk, _ := cipher.GenerateKeyPair()
+	if !a.permits(pk) {
+		t.Fatal("nil allowlist must permit any PK")
+	}
+	if a.list() != nil {
+		t.Fatalf("disabled gate should report nil list, got %v", a.list())
+	}
+}
+
+func TestAllowStateClosedWhenEmptyNonNil(t *testing.T) {
+	a := newAllowState([]cipher.PubKey{})
+	pk, _ := cipher.GenerateKeyPair()
+	if a.permits(pk) {
+		t.Fatal("empty non-nil allowlist must reject all PKs")
+	}
+}
+
+func TestAllowStateMembership(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	pk3, _ := cipher.GenerateKeyPair()
+
+	a := newAllowState([]cipher.PubKey{pk1, pk2})
+	if !a.permits(pk1) || !a.permits(pk2) {
+		t.Fatal("listed PKs must be permitted")
+	}
+	if a.permits(pk3) {
+		t.Fatal("unlisted PK must be rejected")
+	}
+
+	got := a.list()
+	if len(got) != 2 {
+		t.Fatalf("list len = %d, want 2", len(got))
+	}
+}
+
+func TestAllowStateReplace(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	a := newAllowState([]cipher.PubKey{pk1})
+	if !a.permits(pk1) || a.permits(pk2) {
+		t.Fatal("initial state wrong")
+	}
+
+	a.replace([]cipher.PubKey{pk2})
+	if a.permits(pk1) {
+		t.Fatal("pk1 should no longer be permitted after replace")
+	}
+	if !a.permits(pk2) {
+		t.Fatal("pk2 should be permitted after replace")
+	}
+
+	a.replace(nil)
+	if !a.permits(pk1) || !a.permits(pk2) {
+		t.Fatal("nil replace must reopen the gate")
+	}
+}
+
+func TestPublisherAllowlistAccessors(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	// Construct a publisher with an open gate (no allowlist set).
+	p, _ := newTestPublisher(t)
+	if got := p.Allowlist(); got != nil {
+		t.Fatalf("default Allowlist() = %v, want nil", got)
+	}
+	if !p.AllowsSubscriber(pk1) {
+		t.Fatal("default publisher must allow any subscriber")
+	}
+
+	// Raise the gate at runtime.
+	p.SetAllowlist([]cipher.PubKey{pk1})
+	if !p.AllowsSubscriber(pk1) {
+		t.Fatal("pk1 should be allowed after SetAllowlist")
+	}
+	if p.AllowsSubscriber(pk2) {
+		t.Fatal("pk2 must be rejected when not listed")
+	}
+	if got := p.Allowlist(); len(got) != 1 || got[0] != pk1 {
+		t.Fatalf("Allowlist() = %v, want [pk1]", got)
+	}
+
+	// Drop the gate.
+	p.SetAllowlist(nil)
+	if !p.AllowsSubscriber(pk2) {
+		t.Fatal("pk2 should be allowed after SetAllowlist(nil)")
+	}
+}
+
+func TestPublisherInitialAllowlistFromConfig(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	_, sk := cipher.GenerateKeyPair()
+	p, err := New(nopNode(t), sk, Config{
+		SubscriberAllowlist: []cipher.PubKey{pk1},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := p.Close(); err != nil {
+			t.Logf("publisher.Close: %v", err)
+		}
+	})
+
+	if !p.AllowsSubscriber(pk1) {
+		t.Fatal("pk1 from initial Config should be allowed")
+	}
+	if p.AllowsSubscriber(pk2) {
+		t.Fatal("pk2 must be rejected when not in initial Config allowlist")
+	}
+}

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -45,6 +45,13 @@ type Publisher struct {
 	// changes; cleared by the publish loop after a successful Save.
 	dirty bool
 
+	// allow gates which subscriber PKs may connect. nil-set means the
+	// allowlist is disabled (any subscriber is accepted). NewWithDMSG
+	// wires this state into the CXO node's OnSubscribeRemote hook
+	// pre-NewNode so SetAllowlist takes effect immediately and there
+	// is no window where the gate is unconfigured.
+	allow *allowState
+
 	batchWindow time.Duration
 	wakeup      chan struct{}
 	done        chan struct{}
@@ -77,6 +84,24 @@ type Config struct {
 
 	// Logger overrides the default tag-based logger.
 	Logger *logging.Logger
+
+	// SubscriberAllowlist, when non-nil, restricts which remote PKs
+	// may subscribe to the publisher's feed. nil means the gate is
+	// disabled (any subscriber accepted, the historical default). An
+	// empty non-nil slice means "no subscribers allowed yet" — useful
+	// when staging a feed before authorizing peers via SetAllowlist.
+	//
+	// Callers using New directly with their own CXO node are
+	// responsible for wiring the node's OnSubscribeRemote hook to
+	// consult Publisher.AllowsSubscriber. NewWithDMSG wires it
+	// automatically.
+	SubscriberAllowlist []cipher.PubKey
+
+	// sharedAllow is set internally by NewWithDMSG when it builds the
+	// allowState before constructing the CXO node, so the OnSubscribeRemote
+	// closure and the resulting Publisher share the same state. Not
+	// exported.
+	sharedAllow *allowState
 }
 
 // PubConfig configures NewWithDMSG. Mirrors the relevant CXO knobs
@@ -92,6 +117,10 @@ type PubConfig struct {
 	// PK can coexist as long as they use distinct ports — useful for
 	// hosting independent CXO feeds on a single visor.
 	DmsgPort uint16
+
+	// SubscriberAllowlist, when non-nil, gates the OnSubscribeRemote
+	// hook so only listed PKs may subscribe. See Config.SubscriberAllowlist.
+	SubscriberAllowlist []cipher.PubKey
 }
 
 // NewWithDMSG is a convenience wrapper around New: it constructs a
@@ -114,6 +143,13 @@ func NewWithDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, conf PubConfig) (*Publish
 	cfg.UDP.Listen = ""
 	cfg.RPC = ""
 
+	// Build the allowState before NewNode so the OnSubscribeRemote
+	// closure captures live state. Wired even when the allowlist is
+	// disabled (nil set) so SetAllowlist can later raise the gate
+	// without restarting the node.
+	allow := newAllowState(conf.SubscriberAllowlist)
+	cfg.OnSubscribeRemote = subscribeHook(allow)
+
 	cxoNode, err := node.NewNode(cfg)
 	if err != nil {
 		return nil, err
@@ -128,7 +164,11 @@ func NewWithDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, conf PubConfig) (*Publish
 		return nil, err
 	}
 
-	p, err := New(cxoNode, sk, Config{BatchWindow: conf.BatchWindow, Logger: conf.Logger})
+	p, err := New(cxoNode, sk, Config{
+		BatchWindow: conf.BatchWindow,
+		Logger:      conf.Logger,
+		sharedAllow: allow,
+	})
 	if err != nil {
 		_ = cxoNode.Close() //nolint:errcheck
 		return nil, err
@@ -166,12 +206,18 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 		}
 	}
 
+	allow := conf.sharedAllow
+	if allow == nil {
+		allow = newAllowState(conf.SubscriberAllowlist)
+	}
+
 	p := &Publisher{
 		log:         conf.Logger,
 		cxoNode:     cxoNode,
 		pk:          pk,
 		sk:          sk,
 		root:        newMemNode(),
+		allow:       allow,
 		batchWindow: conf.BatchWindow,
 		wakeup:      make(chan struct{}, 1),
 		done:        make(chan struct{}),
@@ -184,6 +230,32 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 // this PK.
 func (p *Publisher) Feed() cipher.PubKey {
 	return p.pk
+}
+
+// SetAllowlist atomically replaces the subscriber allowlist. nil
+// disables the gate (any subscriber accepted). An empty non-nil
+// slice closes the gate to all subscribers — useful for staging a
+// feed before authorizing peers.
+//
+// Existing subscribers keep their connections; the change applies
+// to subsequent subscribe attempts.
+func (p *Publisher) SetAllowlist(pks []cipher.PubKey) {
+	p.allow.replace(pks)
+}
+
+// Allowlist returns a snapshot of the current allowed PKs. nil means
+// the gate is disabled (open to all).
+func (p *Publisher) Allowlist() []cipher.PubKey {
+	return p.allow.list()
+}
+
+// AllowsSubscriber reports whether a subscribe request from pk would
+// pass the gate. NewWithDMSG wires this into the underlying CXO
+// node's OnSubscribeRemote hook automatically. Callers using New
+// directly with their own CXO node should consult this method from
+// their own hook implementation.
+func (p *Publisher) AllowsSubscriber(pk cipher.PubKey) bool {
+	return p.allow.permits(pk)
 }
 
 // AnnounceTo brings up (or refreshes) a CXO conn to peerPK over the


### PR DESCRIPTION
## Summary

Adds a per-publisher subscriber allowlist to \`treestore.Publisher\` so
the publisher can restrict which remote PKs may subscribe to its feed.

The hook lives in CXO already (\`OnSubscribeRemote(c *Conn, feed) error\`
in \`pkg/cxo/node\`); this PR wires it up at the TreeStore layer with
runtime mutability.

## API surface

\`\`\`go
// Initial allowlist via Config / PubConfig.
type Config struct {
    ...
    SubscriberAllowlist []cipher.PubKey
}

// Runtime mutation.
func (p *Publisher) SetAllowlist(pks []cipher.PubKey)
func (p *Publisher) Allowlist() []cipher.PubKey
func (p *Publisher) AllowsSubscriber(pk cipher.PubKey) bool
\`\`\`

Semantics:
- \`nil\` allowlist → gate disabled, any subscriber accepted (current behaviour).
- empty non-nil slice → gate closed to all (useful for staging a feed before authorising peers).
- non-empty slice → only listed PKs accepted.

\`NewWithDMSG\` wires the underlying CXO node's \`OnSubscribeRemote\`
hook automatically; the closure and the resulting Publisher share
the same \`allowState\`, so \`SetAllowlist\` takes effect immediately
without a node restart and without a race window. Callers using
\`New\` directly with their own CXO node should consult
\`Publisher.AllowsSubscriber\` from their own hook.

## Privacy detail

Rejected subscribe attempts return a generic
\`subscribe rejected\` error — a probing peer can't distinguish
"feed not found" from "you are not on the allowlist." This matters
for the per-pair-feed use case where the existence of a feed is
itself sensitive.

## Why now

Foundation for the upcoming skychat per-pair-feed work (each chat
partner gets a dedicated CXO publisher with an allowlist of exactly
one PK), but generally useful for any TreeStore consumer that wants
read-side access control: private telemetry, restricted forums,
authorised file shares, etc.

## Test plan

- [x] Unit tests cover the allowState semantics (open / closed / replace), Publisher accessors, and Config-driven initial allowlist.
- [x] \`go test ./pkg/cxo/treestore/...\` passes.
- [x] \`golangci-lint\` clean against the project's config.
- [ ] End-to-end test (real DMSG, two CXO nodes) lands with the chat-pair work in PR-2; the unit tests here cover the state machine deterministically.