### PR TITLE
skychat/pairing: per-pair feed primitives + bolt store

### DIFF
--- a/cmd/apps/skychat/pairing/manager.go
+++ b/cmd/apps/skychat/pairing/manager.go
@@ -1,0 +1,259 @@
+// Package pairing — cmd/apps/skychat/pairing/manager.go: orchestrates
+// a visor's collection of chat pairs.
+//
+// The Manager owns the bbolt Store and a map[cipher.PubKey]*Pair of
+// live runtime state. It glues persistence to lifecycle: Add records
+// a pair and brings up its Pair, Resume walks the store on startup
+// and reopens every active pair, Remove transitions a record to
+// revoked and tears down its Pair.
+//
+// The pairing handshake itself (sending invite messages over legacy
+// skychat, awaiting ack, transitioning pending→active) is intentionally
+// out of scope — it lives one layer up in PR-3, where it can drive
+// the Manager via its public surface.
+package pairing
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// Manager owns the persistent record set and live Pair instances.
+// Safe for concurrent use.
+type Manager struct {
+	store   *Store
+	dmsgC   *dmsg.Client
+	myPK    cipher.PubKey
+	mySK    cipher.SecKey
+	dataDir string
+	log     *logging.Logger
+
+	// onMessage is the user-supplied callback for inbound messages.
+	// Set via SetMessageHandler; applied to every Pair created or
+	// resumed by the manager.
+	onMessageMu sync.RWMutex
+	onMessage   MessageHandler
+
+	mu    sync.RWMutex
+	pairs map[cipher.PubKey]*Pair
+}
+
+// ManagerConfig wires a Manager.
+type ManagerConfig struct {
+	// Store is required. The manager does not take ownership — call
+	// Store.Close yourself when shutting down.
+	Store *Store
+
+	// DmsgC is the shared DMSG client passed to every Pair.
+	DmsgC *dmsg.Client
+
+	// MyPK / MySK are this visor's identity (the publisher feed-PK
+	// for every pair this manager creates).
+	MyPK cipher.PubKey
+	MySK cipher.SecKey
+
+	// DataDir is the parent directory under which each Pair gets
+	// pub/<peer>/ and sub/<peer>/ subtrees.
+	DataDir string
+
+	// Logger is optional.
+	Logger *logging.Logger
+}
+
+// NewManager constructs a manager. Does not open any pairs; call
+// Resume to bring up everything in the store.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("pairing: NewManager: Store required")
+	}
+	if cfg.DmsgC == nil {
+		return nil, errors.New("pairing: NewManager: DmsgC required")
+	}
+	if cfg.DataDir == "" {
+		return nil, errors.New("pairing: NewManager: DataDir required")
+	}
+	log := cfg.Logger
+	if log == nil {
+		log = logging.MustGetLogger("skychat-pair-manager")
+	}
+	return &Manager{
+		store:   cfg.Store,
+		dmsgC:   cfg.DmsgC,
+		myPK:    cfg.MyPK,
+		mySK:    cfg.MySK,
+		dataDir: cfg.DataDir,
+		log:     log,
+		pairs:   make(map[cipher.PubKey]*Pair),
+	}, nil
+}
+
+// SetMessageHandler installs the callback that fires for every
+// inbound peer message across every pair. Replaces any prior handler
+// and is propagated to existing live pairs.
+func (m *Manager) SetMessageHandler(h MessageHandler) {
+	m.onMessageMu.Lock()
+	m.onMessage = h
+	m.onMessageMu.Unlock()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, p := range m.pairs {
+		p.SetMessageHandler(h)
+	}
+}
+
+// Add creates a new pending pair, persists its record, brings up the
+// Pair (publisher only — Connect is the caller's choice), and
+// returns it. Returns the existing Pair if one is already live for
+// peerPK.
+func (m *Manager) Add(peerPK cipher.PubKey) (*Pair, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if p, ok := m.pairs[peerPK]; ok {
+		return p, nil
+	}
+
+	ports, err := ComputePairPorts(m.myPK, peerPK)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: Add: %w", err)
+	}
+
+	rec := Record{
+		PeerPK:         peerPK,
+		MyPort:         ports.Publisher,
+		PeerPort:       ports.Publisher, // symmetric in the current scheme
+		SubscriberPort: ports.Subscriber,
+		Status:         StatusPending,
+		EstablishedAt:  time.Now().UTC(),
+	}
+	if err := m.store.Put(rec); err != nil {
+		return nil, fmt.Errorf("pairing: Add: persist: %w", err)
+	}
+
+	p, err := m.openPair(peerPK)
+	if err != nil {
+		// Roll back the persisted record so a retry isn't blocked
+		// by a stale entry. Best-effort: a delete failure here
+		// would only mean the next start sees a stale record and
+		// can heal via Resume.
+		_ = m.store.Delete(peerPK) //nolint:errcheck
+		return nil, err
+	}
+	m.pairs[peerPK] = p
+	return p, nil
+}
+
+// Get returns the live Pair for peerPK, or nil + false if none.
+func (m *Manager) Get(peerPK cipher.PubKey) (*Pair, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	p, ok := m.pairs[peerPK]
+	return p, ok
+}
+
+// MarkActive transitions the record for peerPK from pending to
+// active. Called by the pairing handshake (PR-3) when the peer's
+// pair-ack arrives.
+func (m *Manager) MarkActive(peerPK cipher.PubKey) error {
+	return m.store.SetStatus(peerPK, StatusActive)
+}
+
+// Remove tears down the pair, transitions its record to revoked, and
+// drops it from the live map. The record is kept (rather than
+// deleted) so the user can audit prior contacts; future tooling may
+// expose a hard-purge.
+func (m *Manager) Remove(peerPK cipher.PubKey) error {
+	m.mu.Lock()
+	p := m.pairs[peerPK]
+	delete(m.pairs, peerPK)
+	m.mu.Unlock()
+
+	var firstErr error
+	if p != nil {
+		if err := p.Close(); err != nil {
+			firstErr = fmt.Errorf("pairing: Remove: close pair: %w", err)
+		}
+	}
+	if err := m.store.SetStatus(peerPK, StatusRevoked); err != nil && firstErr == nil {
+		firstErr = fmt.Errorf("pairing: Remove: set status: %w", err)
+	}
+	return firstErr
+}
+
+// Resume brings up every active record from the store. Skips revoked
+// records. Pending records are also resumed (so a crash between
+// invite-send and ack doesn't lose state); the caller can decide
+// whether to re-send the invite.
+//
+// Errors on any single pair are logged and skipped — a corrupted or
+// transient-unavailable pair shouldn't block the rest from coming
+// up. The manager tracks how many resumed successfully.
+func (m *Manager) Resume() (resumed int, err error) {
+	records, err := m.store.List()
+	if err != nil {
+		return 0, fmt.Errorf("pairing: Resume: list: %w", err)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, rec := range records {
+		if rec.Status == StatusRevoked {
+			continue
+		}
+		if _, ok := m.pairs[rec.PeerPK]; ok {
+			continue
+		}
+		p, openErr := m.openPair(rec.PeerPK)
+		if openErr != nil {
+			m.log.WithError(openErr).
+				WithField("peer", rec.PeerPK.Hex()[:8]).
+				Warn("pairing: Resume: skip pair")
+			continue
+		}
+		m.pairs[rec.PeerPK] = p
+		resumed++
+	}
+	return resumed, nil
+}
+
+// Close tears down every live pair. Does not close the store —
+// callers manage the store lifetime themselves.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var firstErr error
+	for pk, p := range m.pairs {
+		if err := p.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		delete(m.pairs, pk)
+	}
+	return firstErr
+}
+
+// openPair builds a Pair for peerPK. Caller must hold m.mu.
+func (m *Manager) openPair(peerPK cipher.PubKey) (*Pair, error) {
+	p, err := Open(Config{
+		MyPK:    m.myPK,
+		MySK:    m.mySK,
+		PeerPK:  peerPK,
+		DmsgC:   m.dmsgC,
+		DataDir: m.dataDir,
+		Logger:  m.log,
+	})
+	if err != nil {
+		return nil, err
+	}
+	m.onMessageMu.RLock()
+	if h := m.onMessage; h != nil {
+		p.SetMessageHandler(h)
+	}
+	m.onMessageMu.RUnlock()
+	return p, nil
+}

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -1,0 +1,245 @@
+// Package pairing — cmd/apps/skychat/pairing/pair.go: a single chat
+// pair's runtime state.
+//
+// A Pair wraps two CXO TreeStore endpoints under one struct:
+//
+//   - a Publisher exposing this side's outbox feed, with an allowlist
+//     of exactly the peer's PK. The peer is the only entity permitted
+//     to subscribe to and read this feed.
+//   - a Subscriber connected to the peer's outbox feed, dialing the
+//     same deterministic publisher port on the peer's PK.
+//
+// Both run on dedicated CXO nodes attached to a shared dmsg.Client.
+// Within one visor, multiple pairs avoid DMSG-port collisions because
+// each pair's publisher port is derived from the unique (a, b) hash
+// and the subscriber port lives in a non-overlapping range
+// (see ports.go).
+//
+// Lifecycle: Open creates the publisher (no subscriber yet) and is
+// the act of "I'm ready to receive from this peer." Connect dials the
+// peer's publisher and registers the inbound message callback. The
+// two are split because the pairing handshake (PR-3) sends an invite
+// after Open and only Connects after the peer's ack arrives.
+package pairing
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// MessagePathPrefix is the prefix used for message leaves within a
+// pair feed. Subscribers set this on their TreeStore.Subscriber so
+// future non-message metadata (e.g. typing indicators) can land
+// under different prefixes without surfacing here.
+const MessagePathPrefix = "msgs"
+
+// Message is the on-the-wire form of a chat message inside a pair
+// feed. Body encryption (PR-5) wraps Text into a ciphertext field;
+// for now Text is plaintext.
+type Message struct {
+	Text string    `json:"text"`
+	TS   time.Time `json:"ts"`
+}
+
+// MessageHandler is invoked on every newly-arrived peer message.
+// Called from the subscriber's update goroutine; implementations
+// should be non-blocking (queue the message and return).
+type MessageHandler func(peerPK cipher.PubKey, msg Message)
+
+// Config bundles the inputs Pair.Open needs.
+type Config struct {
+	// MyPK / MySK are this visor's identity.
+	MyPK cipher.PubKey
+	MySK cipher.SecKey
+
+	// PeerPK is the chat partner.
+	PeerPK cipher.PubKey
+
+	// DmsgC is the shared DMSG client. Both publisher and subscriber
+	// CXO nodes attach to it.
+	DmsgC *dmsg.Client
+
+	// DataDir is the per-visor parent directory for CXO state. Each
+	// Pair carves its own pub/<peer-pk-hex>/ and sub/<peer-pk-hex>/
+	// subtrees inside it.
+	DataDir string
+
+	// Logger is optional; nil falls back to a tag-based default.
+	Logger *logging.Logger
+
+	// BatchWindow forwards to the publisher (see treestore.Config).
+	BatchWindow time.Duration
+}
+
+// Pair is one live chat pair. Safe for concurrent use after Open
+// returns; Send and Close may be called from any goroutine.
+type Pair struct {
+	cfg   Config
+	ports PairPorts
+
+	pub *treestore.Publisher
+	sub *treestore.Subscriber
+
+	// seq disambiguates messages with the same nanosecond timestamp.
+	// Per-pair scope so a sender posting in tight loops doesn't
+	// silently overwrite earlier leaves.
+	seq atomic.Uint64
+
+	handler MessageHandler
+
+	log *logging.Logger
+}
+
+// Open constructs the pair's publisher with allowlist=[PeerPK] and
+// records the deterministic ports. The subscriber is created but not
+// yet connected — call Connect after the peer has acknowledged the
+// pair invite (PR-3) or immediately when both sides are known to be
+// ready.
+func Open(cfg Config) (*Pair, error) {
+	if cfg.DmsgC == nil {
+		return nil, errors.New("pairing: Open: DmsgC required")
+	}
+	if cfg.PeerPK == (cipher.PubKey{}) {
+		return nil, errors.New("pairing: Open: PeerPK required")
+	}
+	if cfg.DataDir == "" {
+		return nil, errors.New("pairing: Open: DataDir required")
+	}
+	log := cfg.Logger
+	if log == nil {
+		log = logging.MustGetLogger("skychat-pair")
+	}
+
+	ports, err := ComputePairPorts(cfg.MyPK, cfg.PeerPK)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: Open: compute ports: %w", err)
+	}
+
+	peerHex := cfg.PeerPK.Hex()
+	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
+		BatchWindow:         cfg.BatchWindow,
+		Logger:              log,
+		DataDir:             filepath.Join(cfg.DataDir, "pub", peerHex),
+		DmsgPort:            ports.Publisher,
+		SubscriberAllowlist: []cipher.PubKey{cfg.PeerPK},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("pairing: Open: build publisher: %w", err)
+	}
+
+	sub, err := treestore.NewSubscriber(cfg.DmsgC, cfg.PeerPK, treestore.SubConfig{
+		Logger:   log,
+		DataDir:  filepath.Join(cfg.DataDir, "sub", peerHex),
+		DmsgPort: ports.Subscriber,
+	})
+	if err != nil {
+		_ = pub.Close() //nolint:errcheck
+		return nil, fmt.Errorf("pairing: Open: build subscriber: %w", err)
+	}
+	sub.SetPrefixes([]string{MessagePathPrefix})
+
+	p := &Pair{cfg: cfg, ports: ports, pub: pub, sub: sub, log: log}
+	sub.OnUpdate(p.onUpdate)
+	return p, nil
+}
+
+// Connect dials the peer's publisher and starts the subscribe
+// handshake. Idempotent: returns nil if already connected.
+//
+// Open + Connect are split so the pairing handshake (PR-3) can stage
+// the publisher before the peer is known to be ready, then activate
+// the inbound side once the peer's pair-ack arrives.
+func (p *Pair) Connect() error {
+	if err := p.sub.Connect(p.cfg.PeerPK); err != nil {
+		return fmt.Errorf("pairing: Connect: %w", err)
+	}
+	return nil
+}
+
+// Ports returns the publisher / subscriber DMSG ports this pair uses.
+// Persisted by the manager so a future restart resumes on the same
+// ports even if the deterministic computation later changes.
+func (p *Pair) Ports() PairPorts {
+	return p.ports
+}
+
+// PeerPK is a convenience accessor.
+func (p *Pair) PeerPK() cipher.PubKey {
+	return p.cfg.PeerPK
+}
+
+// SetMessageHandler registers (or replaces) the inbound-message
+// callback. Pass nil to unregister.
+func (p *Pair) SetMessageHandler(h MessageHandler) {
+	p.handler = h
+}
+
+// Send publishes a message to this side's outbox feed. The peer's
+// subscriber will see it on the next CXO publish-batch cycle.
+func (p *Pair) Send(text string) error {
+	now := time.Now().UTC()
+	msg := Message{Text: text, TS: now}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("pairing: Send: marshal: %w", err)
+	}
+	seq := p.seq.Add(1)
+	path := MessagePathPrefix + "/" + strconv.FormatInt(now.UnixNano(), 10) + "/" + strconv.FormatUint(seq, 10)
+	if err := p.pub.Put(path, body); err != nil {
+		return fmt.Errorf("pairing: Send: put %q: %w", path, err)
+	}
+	return nil
+}
+
+// Close tears down both endpoints. Idempotent.
+func (p *Pair) Close() error {
+	var firstErr error
+	if p.sub != nil {
+		if err := p.sub.Close(); err != nil {
+			firstErr = err
+		}
+		p.sub = nil
+	}
+	if p.pub != nil {
+		if err := p.pub.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		p.pub = nil
+	}
+	return firstErr
+}
+
+// onUpdate is the subscriber callback. Decodes each leaf as a Message
+// and dispatches via the registered handler. Tolerates non-msg leaves
+// (e.g. future typing indicators under a different prefix) by
+// silently ignoring decode failures.
+func (p *Pair) onUpdate(events []treestore.UpdateEvent) {
+	h := p.handler
+	if h == nil {
+		return
+	}
+	for _, ev := range events {
+		if ev.Value == nil {
+			// Deletion — no inbound message to surface.
+			continue
+		}
+		var msg Message
+		if err := json.Unmarshal(ev.Value, &msg); err != nil {
+			p.log.WithError(err).
+				WithField("path", ev.Path).
+				Debug("pairing: ignoring undecodable leaf")
+			continue
+		}
+		h(p.cfg.PeerPK, msg)
+	}
+}

--- a/cmd/apps/skychat/pairing/ports.go
+++ b/cmd/apps/skychat/pairing/ports.go
@@ -1,0 +1,138 @@
+// Package pairing — cmd/apps/skychat/pairing/ports.go: deterministic
+// DMSG port allocation for chat-pair feeds.
+//
+// Each ordered pair of visor public keys (Alice, Bob) maps to a stable
+// publisher port + subscriber port. Both sides of the pair compute the
+// same numbers from public information alone, so no out-of-band port
+// negotiation is needed.
+//
+// Port plan:
+//
+//   - Publisher port (where Alice's pair-with-Bob feed listens, and
+//     where Bob's subscriber dials Alice): in [pubBase, pubBase+pubSpan).
+//   - Subscriber port (where Alice's subscriber-to-Bob CXO node binds
+//     its inbound listener, since EnableDMSG always Listens): in
+//     [subBase, subBase+pubSpan), offset by pubSpan from the publisher.
+//
+// The two ranges don't overlap, and they sit clear of the system DMSG
+// port table (everything <300 + reserved ranges around port 80 / 100 /
+// 136). Collisions with the reserved set are still possible at the
+// boundaries; ResolvePublisherPort walks forward to the next free
+// port in pubBase..pubBase+pubSpan and panics on full saturation
+// (50000 deterministic slots is far more than any realistic chat-pair
+// count, so saturation here is an indication of either a bug or a
+// hostile workload).
+package pairing
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// Port-allocation tunables. Public constants so unit tests can assert
+// against them and the design intent is documented.
+const (
+	pubBase uint16 = 10000
+	pubSpan uint16 = 25000
+	subBase uint16 = 35000
+)
+
+// ReservedPorts is the set of DMSG ports already bound by visor
+// subsystems. The pair-feed allocator avoids these so a publisher can
+// always Listen and a subscriber's local listen can't shadow a system
+// service. Mirrors pkg/visor/cxo_user_feeds.go reservedDmsgPorts; kept
+// in sync manually because dragging in pkg/visor here would create an
+// import cycle (skychat is invoked by the launcher inside the visor).
+func ReservedPorts() map[uint16]struct{} {
+	return map[uint16]struct{}{
+		skyenv.DmsgCtrlPort:                  {},
+		skyenv.DmsgPingPort:                  {},
+		skyenv.DmsgPtyPort:                   {},
+		skyenv.DmsgSetupPort:                 {},
+		skyenv.DmsgHypervisorPort:            {},
+		skyenv.DmsgTransportSetupPort:        {},
+		skyenv.DmsgTransportSetupServicePort: {},
+		skyenv.DmsgGRPCPort:                  {},
+		skyenv.DmsgCXOPort:                   {},
+		80:                                   {}, // dmsg-http
+		skyenv.DmsgDHTPort:                   {},
+		skyenv.DmsgAwaitSetupPort:            {},
+	}
+}
+
+// PairPorts is the pair of DMSG ports a single side of a chat pair
+// uses. Both Alice and Bob compute the same PairPorts struct from the
+// same (alice_pk, bob_pk) input.
+type PairPorts struct {
+	Publisher  uint16
+	Subscriber uint16
+}
+
+// ComputePairPorts returns the deterministic publisher + subscriber
+// ports for the pair (a, b). Symmetric: ComputePairPorts(a, b) ==
+// ComputePairPorts(b, a). The caller must already have decided that
+// the pair should exist; ComputePairPorts has no side effects.
+//
+// Returns an error only when every port slot in pubBase..pubBase+pubSpan
+// is also in ReservedPorts (impossible with the current static
+// reserved table, but checked so future expansions of that table fail
+// loudly rather than infinite-loop).
+func ComputePairPorts(a, b cipher.PubKey) (PairPorts, error) {
+	pub, err := publisherPort(a, b, ReservedPorts())
+	if err != nil {
+		return PairPorts{}, err
+	}
+	return PairPorts{
+		Publisher:  pub,
+		Subscriber: pub + pubSpan,
+	}, nil
+}
+
+// publisherPort hashes the (min, max) of (a, b) and walks forward
+// past any reserved-port collision to the next free slot. Exported
+// for tests via ComputePairPorts; kept internal here so the
+// reserved-port table is the single configuration knob.
+func publisherPort(a, b cipher.PubKey, reserved map[uint16]struct{}) (uint16, error) {
+	lo, hi := orderedPair(a, b)
+	h := sha256.New()
+	h.Write(lo[:]) //nolint:errcheck
+	h.Write(hi[:]) //nolint:errcheck
+	sum := h.Sum(nil)
+	// Use the first 4 bytes of the hash; mod into the publisher span.
+	raw := binary.BigEndian.Uint32(sum[:4])
+	candidate := pubBase + uint16(raw%uint32(pubSpan))
+
+	// Walk forward through the publisher span until we find a non-
+	// reserved slot. Both ends must do the same walk for the result
+	// to stay symmetric.
+	for offset := uint16(0); offset < pubSpan; offset++ {
+		port := pubBase + ((candidate-pubBase)+offset)%pubSpan
+		if _, isReserved := reserved[port]; !isReserved {
+			// Also avoid the corresponding subscriber slot if it's
+			// reserved — keeps Pair.Open simple by guaranteeing both
+			// slots are free.
+			if _, subReserved := reserved[port+pubSpan]; !subReserved {
+				return port, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("pairing: no free publisher port in [%d, %d)", pubBase, pubBase+pubSpan)
+}
+
+// orderedPair returns (a, b) sorted byte-lexicographically so the
+// hash input is canonical regardless of which side computes it.
+func orderedPair(a, b cipher.PubKey) (cipher.PubKey, cipher.PubKey) {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i] < b[i] {
+			return a, b
+		}
+		if a[i] > b[i] {
+			return b, a
+		}
+	}
+	return a, b
+}

--- a/cmd/apps/skychat/pairing/ports_test.go
+++ b/cmd/apps/skychat/pairing/ports_test.go
@@ -1,0 +1,104 @@
+package pairing
+
+import (
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestComputePairPortsSymmetric(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+
+	ab, err := ComputePairPorts(a, b)
+	if err != nil {
+		t.Fatalf("a,b: %v", err)
+	}
+	ba, err := ComputePairPorts(b, a)
+	if err != nil {
+		t.Fatalf("b,a: %v", err)
+	}
+	if ab != ba {
+		t.Fatalf("ports must be symmetric: ab=%+v ba=%+v", ab, ba)
+	}
+}
+
+func TestComputePairPortsInRange(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		a, _ := cipher.GenerateKeyPair()
+		b, _ := cipher.GenerateKeyPair()
+		pp, err := ComputePairPorts(a, b)
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		if pp.Publisher < pubBase || pp.Publisher >= pubBase+pubSpan {
+			t.Errorf("iter %d: publisher port %d out of [%d, %d)", i, pp.Publisher, pubBase, pubBase+pubSpan)
+		}
+		if pp.Subscriber < subBase || pp.Subscriber >= subBase+pubSpan {
+			t.Errorf("iter %d: subscriber port %d out of [%d, %d)", i, pp.Subscriber, subBase, subBase+pubSpan)
+		}
+		if pp.Subscriber-pp.Publisher != pubSpan {
+			t.Errorf("iter %d: subscriber should be publisher+%d, got publisher=%d sub=%d", i, pubSpan, pp.Publisher, pp.Subscriber)
+		}
+	}
+}
+
+func TestComputePairPortsAvoidsReserved(t *testing.T) {
+	// Synthesize a reserved set that includes the deterministic slot
+	// for a given pair, and verify publisherPort walks past it.
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+
+	// First, find what the natural deterministic port would be.
+	natural, err := publisherPort(a, b, map[uint16]struct{}{})
+	if err != nil {
+		t.Fatalf("baseline: %v", err)
+	}
+	// Now reserve that exact slot and re-compute.
+	reserved := map[uint16]struct{}{natural: {}}
+	walked, err := publisherPort(a, b, reserved)
+	if err != nil {
+		t.Fatalf("with collision: %v", err)
+	}
+	if walked == natural {
+		t.Fatalf("expected walk past reserved port %d, still got %d", natural, walked)
+	}
+	// walked should be the next non-reserved slot in the span.
+	if walked < pubBase || walked >= pubBase+pubSpan {
+		t.Errorf("walked port %d out of pub range", walked)
+	}
+}
+
+func TestComputePairPortsAvoidsRealReservedTable(t *testing.T) {
+	// Cross-check that no random pair lands on a port from the real
+	// reserved table. With 50 random pairs and 12 reserved ports out
+	// of 50000 slots, the probability of a hit is ~1.2% per pair, so
+	// across 50 iterations we expect >40% chance of at least one
+	// collision IF the avoidance code didn't work — running the test
+	// repeatedly with avoidance on should never report one.
+	reserved := ReservedPorts()
+	for i := 0; i < 200; i++ {
+		a, _ := cipher.GenerateKeyPair()
+		b, _ := cipher.GenerateKeyPair()
+		pp, err := ComputePairPorts(a, b)
+		if err != nil {
+			t.Fatalf("iter %d: %v", i, err)
+		}
+		if _, hit := reserved[pp.Publisher]; hit {
+			t.Errorf("iter %d: publisher port %d landed on reserved", i, pp.Publisher)
+		}
+		if _, hit := reserved[pp.Subscriber]; hit {
+			t.Errorf("iter %d: subscriber port %d landed on reserved", i, pp.Subscriber)
+		}
+	}
+}
+
+func TestOrderedPair(t *testing.T) {
+	a, _ := cipher.GenerateKeyPair()
+	b, _ := cipher.GenerateKeyPair()
+	loAB, hiAB := orderedPair(a, b)
+	loBA, hiBA := orderedPair(b, a)
+	if loAB != loBA || hiAB != hiBA {
+		t.Fatal("orderedPair must be commutative")
+	}
+}

--- a/cmd/apps/skychat/pairing/store.go
+++ b/cmd/apps/skychat/pairing/store.go
@@ -1,0 +1,224 @@
+// Package pairing — cmd/apps/skychat/pairing/store.go: bbolt-backed
+// persistence for chat pairs.
+//
+// One bucket "pairs" with key = peer PK hex, value = JSON Record.
+// Crash-safe by virtue of bolt's single-writer semantics: each Put
+// is one transaction, each Resume is a read.
+//
+// The store is intentionally narrow — Add / Get / List / Delete / Set
+// — so the lifecycle code in pair.go can drive policy (e.g. when to
+// transition status from "pending" to "active") without the store
+// having to know about it.
+package pairing
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// Status enumerates a Record's lifecycle.
+type Status string
+
+const (
+	// StatusPending means we've created our publisher and sent (or
+	// are about to send) a pair-invite to the peer; the peer hasn't
+	// yet acknowledged.
+	StatusPending Status = "pending"
+
+	// StatusActive means both sides have publishers up and are
+	// subscribed to each other. Normal operating state.
+	StatusActive Status = "active"
+
+	// StatusRevoked means we've torn down the pair from our side
+	// (e.g. user removed the contact). The record is kept for audit
+	// or potential reactivation; pair.go skips revoked records on
+	// Resume.
+	StatusRevoked Status = "revoked"
+)
+
+// Record is the persisted form of a chat pair.
+type Record struct {
+	// PeerPK is the partner visor's public key.
+	PeerPK cipher.PubKey `json:"peer_pk"`
+
+	// MyPort is the DMSG port my outbox publisher listens on.
+	// Equal to the deterministic ComputePairPorts(myPK, peerPK).Publisher.
+	// Persisted (rather than recomputed every time) so a future
+	// reserved-port table change doesn't silently shift live pairs.
+	MyPort uint16 `json:"my_port"`
+
+	// PeerPort is the DMSG port the peer's outbox publisher listens on.
+	// Same value as MyPort under the current scheme — both ends share
+	// the deterministic publisher port — but stored separately so the
+	// schema can accommodate a future asymmetric variant without a
+	// migration.
+	PeerPort uint16 `json:"peer_port"`
+
+	// SubscriberPort is where my CXO subscriber's node binds its own
+	// listener. ComputePairPorts(myPK, peerPK).Subscriber.
+	SubscriberPort uint16 `json:"subscriber_port"`
+
+	Status        Status    `json:"status"`
+	EstablishedAt time.Time `json:"established_at"`
+	LastMessageAt time.Time `json:"last_message_at,omitempty"`
+}
+
+const pairsBucket = "pairs"
+
+// Store is a bolt-backed pair record store. Safe for concurrent use.
+type Store struct {
+	db *bolt.DB
+
+	mu sync.RWMutex
+}
+
+// OpenStore opens (or creates) the bolt file at path. The parent dir
+// is created if missing.
+func OpenStore(path string) (*Store, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("pairing: mkdir parent: %w", err)
+	}
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 2 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("pairing: open bolt: %w", err)
+	}
+	if err := db.Update(func(tx *bolt.Tx) error {
+		_, e := tx.CreateBucketIfNotExists([]byte(pairsBucket))
+		return e
+	}); err != nil {
+		_ = db.Close() //nolint:errcheck
+		return nil, fmt.Errorf("pairing: init bucket: %w", err)
+	}
+	return &Store{db: db}, nil
+}
+
+// Close releases the bolt file handle.
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// Put writes (or replaces) the record for r.PeerPK.
+func (s *Store) Put(r Record) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r.PeerPK == (cipher.PubKey{}) {
+		return fmt.Errorf("pairing: Put: empty PeerPK")
+	}
+	body, err := json.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("pairing: marshal record: %w", err)
+	}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		return b.Put([]byte(r.PeerPK.Hex()), body)
+	})
+}
+
+// Get returns the record for peerPK and a boolean indicating presence.
+func (s *Store) Get(peerPK cipher.PubKey) (Record, bool, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var (
+		r     Record
+		found bool
+	)
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		raw := b.Get([]byte(peerPK.Hex()))
+		if raw == nil {
+			return nil
+		}
+		found = true
+		return json.Unmarshal(raw, &r)
+	})
+	return r, found, err
+}
+
+// List returns every persisted record. Order is bolt's bucket-sorted
+// order (lexicographic on hex peer PK).
+func (s *Store) List() ([]Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Record
+	err := s.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		return b.ForEach(func(_, v []byte) error {
+			var r Record
+			if err := json.Unmarshal(v, &r); err != nil {
+				return err
+			}
+			out = append(out, r)
+			return nil
+		})
+	})
+	return out, err
+}
+
+// Delete removes the record for peerPK. No-op if absent.
+func (s *Store) Delete(peerPK cipher.PubKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		return b.Delete([]byte(peerPK.Hex()))
+	})
+}
+
+// SetStatus updates only the Status field of an existing record.
+// Returns an error if no record exists for peerPK.
+func (s *Store) SetStatus(peerPK cipher.PubKey, status Status) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		raw := b.Get([]byte(peerPK.Hex()))
+		if raw == nil {
+			return fmt.Errorf("pairing: SetStatus: no record for %s", peerPK.Hex())
+		}
+		var r Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return err
+		}
+		r.Status = status
+		body, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(peerPK.Hex()), body)
+	})
+}
+
+// MarkMessage updates LastMessageAt to the given timestamp without
+// touching other fields.
+func (s *Store) MarkMessage(peerPK cipher.PubKey, ts time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(pairsBucket))
+		raw := b.Get([]byte(peerPK.Hex()))
+		if raw == nil {
+			return fmt.Errorf("pairing: MarkMessage: no record for %s", peerPK.Hex())
+		}
+		var r Record
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return err
+		}
+		r.LastMessageAt = ts
+		body, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(peerPK.Hex()), body)
+	})
+}

--- a/cmd/apps/skychat/pairing/store_test.go
+++ b/cmd/apps/skychat/pairing/store_test.go
@@ -1,0 +1,179 @@
+package pairing
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "pairs.db")
+	s, err := OpenStore(path)
+	if err != nil {
+		t.Fatalf("OpenStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Logf("Store.Close: %v", err)
+		}
+	})
+	return s
+}
+
+func sampleRecord(t *testing.T) Record {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return Record{
+		PeerPK:         pk,
+		MyPort:         12345,
+		PeerPort:       12345,
+		SubscriberPort: 37345,
+		Status:         StatusPending,
+		EstablishedAt:  time.Now().UTC().Truncate(time.Millisecond),
+	}
+}
+
+func TestStorePutGet(t *testing.T) {
+	s := newTestStore(t)
+	r := sampleRecord(t)
+
+	if err := s.Put(r); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok, err := s.Get(r.PeerPK)
+	if err != nil || !ok {
+		t.Fatalf("Get: ok=%v err=%v", ok, err)
+	}
+	if got.PeerPK != r.PeerPK || got.MyPort != r.MyPort || got.Status != r.Status {
+		t.Errorf("roundtrip mismatch: got %+v want %+v", got, r)
+	}
+}
+
+func TestStoreGetMissing(t *testing.T) {
+	s := newTestStore(t)
+	pk, _ := cipher.GenerateKeyPair()
+	_, ok, err := s.Get(pk)
+	if err != nil {
+		t.Fatalf("Get(missing): err=%v", err)
+	}
+	if ok {
+		t.Error("Get(missing) should return ok=false")
+	}
+}
+
+func TestStoreList(t *testing.T) {
+	s := newTestStore(t)
+	for i := 0; i < 3; i++ {
+		if err := s.Put(sampleRecord(t)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := s.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Errorf("List len = %d, want 3", len(got))
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	s := newTestStore(t)
+	r := sampleRecord(t)
+	if err := s.Put(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Delete(r.PeerPK); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := s.Get(r.PeerPK)
+	if err != nil {
+		t.Fatalf("Get after Delete: %v", err)
+	}
+	if ok {
+		t.Error("record should be gone after Delete")
+	}
+}
+
+func TestStoreSetStatus(t *testing.T) {
+	s := newTestStore(t)
+	r := sampleRecord(t)
+	if err := s.Put(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetStatus(r.PeerPK, StatusActive); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := s.Get(r.PeerPK)
+	if err != nil {
+		t.Fatalf("Get after SetStatus: %v", err)
+	}
+	if got.Status != StatusActive {
+		t.Errorf("status = %s, want active", got.Status)
+	}
+	// Other fields preserved.
+	if got.MyPort != r.MyPort {
+		t.Errorf("MyPort changed: got %d want %d", got.MyPort, r.MyPort)
+	}
+}
+
+func TestStoreSetStatusMissing(t *testing.T) {
+	s := newTestStore(t)
+	pk, _ := cipher.GenerateKeyPair()
+	if err := s.SetStatus(pk, StatusActive); err == nil {
+		t.Fatal("SetStatus on missing record should error")
+	}
+}
+
+func TestStoreMarkMessage(t *testing.T) {
+	s := newTestStore(t)
+	r := sampleRecord(t)
+	if err := s.Put(r); err != nil {
+		t.Fatal(err)
+	}
+	ts := time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.MarkMessage(r.PeerPK, ts); err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := s.Get(r.PeerPK)
+	if err != nil {
+		t.Fatalf("Get after MarkMessage: %v", err)
+	}
+	if !got.LastMessageAt.Equal(ts) {
+		t.Errorf("LastMessageAt = %v, want %v", got.LastMessageAt, ts)
+	}
+}
+
+func TestStorePersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pairs.db")
+
+	r := sampleRecord(t)
+	s1, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.Put(r); err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = s2.Close() }() //nolint:errcheck
+
+	got, ok, err := s2.Get(r.PeerPK)
+	if err != nil || !ok {
+		t.Fatalf("after reopen: ok=%v err=%v", ok, err)
+	}
+	if got.PeerPK != r.PeerPK || got.Status != r.Status {
+		t.Errorf("roundtrip after reopen wrong: %+v", got)
+	}
+}

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -68,6 +68,18 @@ type SubConfig struct {
 	Logger     *logging.Logger
 	InMemoryDB bool
 	DataDir    string
+
+	// DmsgPort overrides both the listen port (where this subscriber's
+	// CXO node accepts inbound connections, typically unused for
+	// subscribe-only flows) and the dial port (where Connect dials
+	// the publisher). Zero falls back to cxotransport.DefaultCXOPort,
+	// matching the system telemetry feed.
+	//
+	// Per-pair-feed callers set this to the pair's deterministic
+	// publisher port so the subscriber dials the right place; multiple
+	// subscribers on one visor must use distinct DmsgPort values to
+	// avoid a Listen collision.
+	DmsgPort uint16
 }
 
 // NewSubscriber creates a Subscriber that will receive updates from
@@ -90,7 +102,11 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 		return nil, err
 	}
 
-	factory := cxotransport.NewDMSGFactory(dmsgC, cxotransport.DefaultCXOPort)
+	port := conf.DmsgPort
+	if port == 0 {
+		port = cxotransport.DefaultCXOPort
+	}
+	factory := cxotransport.NewDMSGFactory(dmsgC, port)
 	if err := cxoNode.EnableDMSG(factory); err != nil {
 		_ = cxoNode.Close() //nolint:errcheck
 		return nil, err


### PR DESCRIPTION
## Summary

Second of six PRs implementing CXO-based skychat with per-pair feeds
(see #2378 for the design discussion). This one adds the primitives
package — pure data structures and treestore integration with no
skychat or visor wiring yet. The pairing handshake and HTTP/UI changes
land in PR-3 onwards.

## What's in here

\`\`\`
cmd/apps/skychat/pairing/
├── ports.go         deterministic DMSG port allocation
├── ports_test.go
├── store.go         bbolt-backed Record persistence
├── store_test.go
├── pair.go          single-pair runtime (publisher + subscriber)
└── manager.go       pair set + Resume on startup
\`\`\`

Plus a small treestore.SubConfig.DmsgPort knob so subscribers can
dial a non-default publisher port (needed for per-pair feeds where
the publisher port is the deterministic pair port, not
DefaultCXOPort).

## Port allocation

\`\`\`
publisher port = (SHA256(min(pk_a, pk_b) || max(pk_a, pk_b))[:4] mod 25000) + 10000
subscriber port = publisher port + 25000
\`\`\`

Two non-overlapping ranges keep publisher and subscriber listens from
colliding within one visor (the publisher feed listens on its pair
port; the subscriber's CXO node also Listens on a port for inbound,
so the two need to be distinct). Reserved-port collisions (everything
<300 plus the visor-system table mirrored from \`pkg/visor/cxo_user_feeds.go\`)
are walked past so a pair can always Listen — both sides do the same
walk so the result stays symmetric.

## Lifecycle

\`\`\`
Manager.Add(peerPK)     → record (status=pending) + Pair.Open
Pair.Connect()          → dial peer's publisher, start receiving
Manager.MarkActive(...) → record status pending→active (PR-3 will
                          call this after pair-ack arrives)
Manager.Remove(peerPK)  → tear down Pair, record status→revoked
Manager.Resume()        → walk store, reopen non-revoked pairs
\`\`\`

Records are kept (rather than deleted) on revoke so the user can
audit prior contacts; future tooling can expose hard-purge.

## Tests

- Port-pair symmetry (\`ComputePairPorts(a,b) == ComputePairPorts(b,a)\`)
- Port range invariants (publisher in \`[10000, 35000)\`, subscriber in \`[35000, 60000)\`, offset \`pubSpan\`)
- Reserved-port collision avoidance — synthetic (force a collision and watch the walk pass it) + statistical (200 random pairs against the real reserved table, 0 hits)
- Store CRUD, persistence across reopen, \`SetStatus\` / \`MarkMessage\` field-preservation
- Manager-specific lifecycle tests deferred to PR-3 where a real DMSG client is in scope; the manager is mostly thin glue over Store + Pair, both well-covered here.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/pairing/... ./pkg/cxo/treestore/...\` passes
- [x] \`golangci-lint\` clean against project config
- [ ] End-to-end pair flow over real DMSG (lands with PR-3)

## What's next

PR-3: pairing handshake — \`pair-invite\` / \`pair-ack\` messages
sent over the legacy skychat direct path, behind \`--pair-enable=false\`.
Drives the Manager's lifecycle from \`messageHandler\` recognising the
structured types.