### PR TITLE
visor: wire chat-pair feed manager + RPC surface

### DIFF
--- a/cmd/apps/skychat/pairing/ports.go
+++ b/cmd/apps/skychat/pairing/ports.go
@@ -9,16 +9,16 @@
 // Port plan:
 //
 //   - Publisher port (where Alice's pair-with-Bob feed listens, and
-//     where Bob's subscriber dials Alice): in [pubBase, pubBase+pubSpan).
+//     where Bob's subscriber dials Alice): in [PubBase, PubBase+PubSpan).
 //   - Subscriber port (where Alice's subscriber-to-Bob CXO node binds
 //     its inbound listener, since EnableDMSG always Listens): in
-//     [subBase, subBase+pubSpan), offset by pubSpan from the publisher.
+//     [SubBase, SubBase+PubSpan), offset by PubSpan from the publisher.
 //
 // The two ranges don't overlap, and they sit clear of the system DMSG
 // port table (everything <300 + reserved ranges around port 80 / 100 /
 // 136). Collisions with the reserved set are still possible at the
 // boundaries; ResolvePublisherPort walks forward to the next free
-// port in pubBase..pubBase+pubSpan and panics on full saturation
+// port in PubBase..PubBase+PubSpan and panics on full saturation
 // (50000 deterministic slots is far more than any realistic chat-pair
 // count, so saturation here is an indication of either a bug or a
 // hostile workload).
@@ -33,12 +33,13 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
-// Port-allocation tunables. Public constants so unit tests can assert
-// against them and the design intent is documented.
+// Port-allocation tunables. Public constants so callers (e.g. the
+// visor's CXO user-feed registry, which needs to reject overlapping
+// port allocations) can validate against the same numbers.
 const (
-	pubBase uint16 = 10000
-	pubSpan uint16 = 25000
-	subBase uint16 = 35000
+	PubBase uint16 = 10000
+	PubSpan uint16 = 25000
+	SubBase uint16 = 35000
 )
 
 // ReservedPorts is the set of DMSG ports already bound by visor
@@ -77,7 +78,7 @@ type PairPorts struct {
 // ComputePairPorts(b, a). The caller must already have decided that
 // the pair should exist; ComputePairPorts has no side effects.
 //
-// Returns an error only when every port slot in pubBase..pubBase+pubSpan
+// Returns an error only when every port slot in PubBase..PubBase+PubSpan
 // is also in ReservedPorts (impossible with the current static
 // reserved table, but checked so future expansions of that table fail
 // loudly rather than infinite-loop).
@@ -88,7 +89,7 @@ func ComputePairPorts(a, b cipher.PubKey) (PairPorts, error) {
 	}
 	return PairPorts{
 		Publisher:  pub,
-		Subscriber: pub + pubSpan,
+		Subscriber: pub + PubSpan,
 	}, nil
 }
 
@@ -104,23 +105,23 @@ func publisherPort(a, b cipher.PubKey, reserved map[uint16]struct{}) (uint16, er
 	sum := h.Sum(nil)
 	// Use the first 4 bytes of the hash; mod into the publisher span.
 	raw := binary.BigEndian.Uint32(sum[:4])
-	candidate := pubBase + uint16(raw%uint32(pubSpan))
+	candidate := PubBase + uint16(raw%uint32(PubSpan))
 
 	// Walk forward through the publisher span until we find a non-
 	// reserved slot. Both ends must do the same walk for the result
 	// to stay symmetric.
-	for offset := uint16(0); offset < pubSpan; offset++ {
-		port := pubBase + ((candidate-pubBase)+offset)%pubSpan
+	for offset := uint16(0); offset < PubSpan; offset++ {
+		port := PubBase + ((candidate-PubBase)+offset)%PubSpan
 		if _, isReserved := reserved[port]; !isReserved {
 			// Also avoid the corresponding subscriber slot if it's
 			// reserved — keeps Pair.Open simple by guaranteeing both
 			// slots are free.
-			if _, subReserved := reserved[port+pubSpan]; !subReserved {
+			if _, subReserved := reserved[port+PubSpan]; !subReserved {
 				return port, nil
 			}
 		}
 	}
-	return 0, fmt.Errorf("pairing: no free publisher port in [%d, %d)", pubBase, pubBase+pubSpan)
+	return 0, fmt.Errorf("pairing: no free publisher port in [%d, %d)", PubBase, PubBase+PubSpan)
 }
 
 // orderedPair returns (a, b) sorted byte-lexicographically so the

--- a/cmd/apps/skychat/pairing/ports_test.go
+++ b/cmd/apps/skychat/pairing/ports_test.go
@@ -31,14 +31,14 @@ func TestComputePairPortsInRange(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iter %d: %v", i, err)
 		}
-		if pp.Publisher < pubBase || pp.Publisher >= pubBase+pubSpan {
-			t.Errorf("iter %d: publisher port %d out of [%d, %d)", i, pp.Publisher, pubBase, pubBase+pubSpan)
+		if pp.Publisher < PubBase || pp.Publisher >= PubBase+PubSpan {
+			t.Errorf("iter %d: publisher port %d out of [%d, %d)", i, pp.Publisher, PubBase, PubBase+PubSpan)
 		}
-		if pp.Subscriber < subBase || pp.Subscriber >= subBase+pubSpan {
-			t.Errorf("iter %d: subscriber port %d out of [%d, %d)", i, pp.Subscriber, subBase, subBase+pubSpan)
+		if pp.Subscriber < SubBase || pp.Subscriber >= SubBase+PubSpan {
+			t.Errorf("iter %d: subscriber port %d out of [%d, %d)", i, pp.Subscriber, SubBase, SubBase+PubSpan)
 		}
-		if pp.Subscriber-pp.Publisher != pubSpan {
-			t.Errorf("iter %d: subscriber should be publisher+%d, got publisher=%d sub=%d", i, pubSpan, pp.Publisher, pp.Subscriber)
+		if pp.Subscriber-pp.Publisher != PubSpan {
+			t.Errorf("iter %d: subscriber should be publisher+%d, got publisher=%d sub=%d", i, PubSpan, pp.Publisher, pp.Subscriber)
 		}
 	}
 }
@@ -64,7 +64,7 @@ func TestComputePairPortsAvoidsReserved(t *testing.T) {
 		t.Fatalf("expected walk past reserved port %d, still got %d", natural, walked)
 	}
 	// walked should be the next non-reserved slot in the span.
-	if walked < pubBase || walked >= pubBase+pubSpan {
+	if walked < PubBase || walked >= PubBase+PubSpan {
 		t.Errorf("walked port %d out of pub range", walked)
 	}
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -196,6 +196,14 @@ type API interface {
 	UnregisterCXOFeed(name string) error
 	ListCXOFeeds() []logserver.CXOFeedEntry
 
+	// Chat-pair feeds — per-partner CXO feeds with read-side
+	// allowlists. See pkg/visor/pairing.go.
+	PairAdd(peerPK cipher.PubKey) error
+	PairList() ([]PairInfo, error)
+	PairRemove(peerPK cipher.PubKey) error
+	PairSend(peerPK cipher.PubKey, text string) error
+	PairPoll(since time.Time) ([]PairMessage, error)
+
 	// Embedded Transport Setup Node (TPS) controls
 	TPSStatus() (*TPSStatus, error)
 	TPSAddTransport(targetPK, remotePK cipher.PubKey, tpType string) (*TPSTransportResponse, error)

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -85,6 +86,15 @@ func (v *Visor) RegisterCXOFeed(name string, dmsgPort uint16, description string
 	}
 	if used, ok := reservedDmsgPorts()[dmsgPort]; ok {
 		return fmt.Errorf("cxo feed: dmsg port %d reserved for %s", dmsgPort, used)
+	}
+	// Reject ports inside the chat-pair allocator's deterministic
+	// range. A user feed at a pair-publisher port would shadow some
+	// pair's outbox; at a pair-subscriber port it would collide with
+	// some subscriber's local listener. Both are silent, hard-to-
+	// debug failures for the affected pair, so reject up front.
+	if dmsgPort >= pairing.PubBase && dmsgPort < pairing.SubBase+pairing.PubSpan {
+		return fmt.Errorf("cxo feed: dmsg port %d reserved for chat-pair feeds (range [%d, %d))",
+			dmsgPort, pairing.PubBase, pairing.SubBase+pairing.PubSpan)
 	}
 	if v.dmsgC == nil {
 		return errors.New("cxo feed: dmsg client not available")

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -128,6 +128,8 @@ var (
 	// Visor-local telemetry store (bbolt + sampler)
 	statsMod        vinit.Module
 	cxoUserFeedsMod vinit.Module
+	// Chat-pair feed manager (opt-in per-partner CXO feeds).
+	pairingMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -197,8 +199,11 @@ func registerModules(logger *logging.MasterLogger) {
 	// User-feed registry depends on stats (it shares the logserver
 	// hookup) and dmsgC (each user feed gets its own dmsg listener).
 	cxoUserFeedsMod = maker("cxo_user_feeds", initCXOUserFeeds, &statsMod, &dmsgC)
+	// Chat-pair manager: opt-in per-partner CXO feeds with allowlist.
+	// Depends only on dmsgC.
+	pairingMod = maker("pairing", initPairing, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &statsMod, &cxoUserFeedsMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &statsMod, &cxoUserFeedsMod, &pairingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_pairing.go
+++ b/pkg/visor/init_pairing.go
@@ -1,0 +1,94 @@
+// Package visor pkg/visor/init_pairing.go
+//
+// Init wiring for the chat-pair feed manager. Mirrors initStats and
+// initCXOUserFeeds: depends on dmsgC, opens its own bbolt store under
+// v.conf.LocalPath/pairing/, and resumes any pairs persisted from a
+// previous run.
+//
+// The pairing module sits intentionally low in the dependency graph
+// — it doesn't need transports, routes, or the launcher — so the
+// only init-ordering constraint is "after dmsgC."
+package visor
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// pairingState holds the visor-side runtime state for chat pairs.
+// Lives on the Visor struct so RPC handlers can reach it; populated
+// by initPairing during module startup.
+type pairingState struct {
+	store   *pairing.Store
+	manager *pairing.Manager
+	inbox   *pairInbox
+}
+
+// initPairing brings up the per-visor chat-pair feed manager. Best-
+// effort: a failure here logs and disables pairing for this run
+// rather than failing visor startup. Pairing is opt-in (pairs are
+// only created via PairAdd RPC) so a missing manager just yields
+// "no pairs" — no other subsystem depends on it.
+func initPairing(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dmsgC == nil {
+		log.Debug("Pairing: dmsg client absent; manager not started")
+		return nil
+	}
+	dataDir := filepath.Join(v.conf.LocalPath, "pairing")
+	storePath := filepath.Join(dataDir, "pairs.db")
+
+	store, err := pairing.OpenStore(storePath)
+	if err != nil {
+		log.WithError(err).Warn("Pairing: open store failed; pairing disabled this run")
+		return nil
+	}
+
+	mgr, err := pairing.NewManager(pairing.ManagerConfig{
+		Store:   store,
+		DmsgC:   v.dmsgC,
+		MyPK:    v.conf.PK,
+		MySK:    v.conf.SK,
+		DataDir: filepath.Join(dataDir, "cxo"),
+		Logger:  log,
+	})
+	if err != nil {
+		_ = store.Close() //nolint:errcheck
+		log.WithError(err).Warn("Pairing: NewManager failed; pairing disabled this run")
+		return nil
+	}
+
+	inbox := newPairInbox(defaultInboxCap)
+	mgr.SetMessageHandler(inbox.deliver)
+
+	v.initLock.Lock()
+	v.pairing.store = store
+	v.pairing.manager = mgr
+	v.pairing.inbox = inbox
+	v.initLock.Unlock()
+
+	resumed, err := mgr.Resume()
+	if err != nil {
+		log.WithError(err).Warn("Pairing: Resume returned error; partial recovery only")
+	}
+	log.WithField("resumed", resumed).Info("Pairing: manager ready")
+
+	v.pushCloseStack("pairing", func() error {
+		var firstErr error
+		if mgr != nil {
+			if err := mgr.Close(); err != nil {
+				firstErr = err
+			}
+		}
+		if store != nil {
+			if err := store.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		return firstErr
+	})
+
+	return nil
+}

--- a/pkg/visor/pairing.go
+++ b/pkg/visor/pairing.go
@@ -1,0 +1,211 @@
+// Package visor pkg/visor/pairing.go
+//
+// Visor-level wrapper around the cmd/apps/skychat/pairing package.
+//
+// The visor owns one pairing.Manager (initialized in init_pairing.go)
+// and an in-memory ring of recently-received messages. RPC clients
+// call PairAdd / PairRemove / PairList to manage their contact list,
+// PairSend to dispatch a message into the corresponding pair feed,
+// and PairPoll to drain inbound messages. The poll model is
+// intentionally simple — long-poll / SSE delivery to apps can layer
+// on later (PR-4) without changing the Visor surface.
+package visor
+
+import (
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// PairInfo is the public summary of a chat pair, returned by PairList
+// and used as the poll cursor for PairPoll.
+type PairInfo struct {
+	PeerPK         cipher.PubKey  `json:"peer_pk"`
+	Status         pairing.Status `json:"status"`
+	MyPort         uint16         `json:"my_port"`
+	PeerPort       uint16         `json:"peer_port"`
+	SubscriberPort uint16         `json:"subscriber_port"`
+	EstablishedAt  time.Time      `json:"established_at"`
+	LastMessageAt  time.Time      `json:"last_message_at,omitempty"`
+}
+
+// PairMessage is one inbound message delivered through the visor's
+// pair inbox. Outbound messages (sent via PairSend) are not echoed
+// here; the caller already knows what it sent.
+type PairMessage struct {
+	PeerPK cipher.PubKey `json:"peer_pk"`
+	Text   string        `json:"text"`
+	TS     time.Time     `json:"ts"`
+}
+
+// ErrPairingDisabled is returned by Visor pair methods when the
+// pairing manager isn't initialized (dmsg unavailable at startup,
+// or the bolt store failed to open).
+var ErrPairingDisabled = errors.New("pairing: manager not initialized")
+
+// defaultInboxCap is the bounded ring size for pair messages.
+// Sized for "few hundred messages a minute under burst" without
+// unbounded growth if the consumer is slow or absent.
+const defaultInboxCap = 1024
+
+// PairAdd creates a pair record for peerPK, brings up the local
+// publisher (allowlist=[peerPK]) and a subscriber dialing peerPK at
+// the deterministic pair-publisher port. The peer must independently
+// call PairAdd on its own visor for the connection to actually
+// succeed; until then the subscriber sits idle.
+//
+// Idempotent — calling PairAdd for an existing peer returns nil.
+func (v *Visor) PairAdd(peerPK cipher.PubKey) error {
+	mgr := v.pairManager()
+	if mgr == nil {
+		return ErrPairingDisabled
+	}
+	p, err := mgr.Add(peerPK)
+	if err != nil {
+		return err
+	}
+	if err := p.Connect(); err != nil {
+		// Connect-failure is non-fatal — the publisher side is up,
+		// and Resume on a future restart (or a manual retry) will
+		// pick up the subscriber side once the peer is reachable.
+		v.log.WithError(err).
+			WithField("peer", peerPK.Hex()[:8]).
+			Debug("Pairing: subscriber Connect failed; pair record kept")
+	}
+	return nil
+}
+
+// PairList returns a snapshot of every persisted pair (pending /
+// active / revoked).
+func (v *Visor) PairList() ([]PairInfo, error) {
+	v.initLock.RLock()
+	store := v.pairing.store
+	v.initLock.RUnlock()
+	if store == nil {
+		return nil, ErrPairingDisabled
+	}
+	records, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PairInfo, 0, len(records))
+	for _, r := range records {
+		out = append(out, PairInfo{
+			PeerPK:         r.PeerPK,
+			Status:         r.Status,
+			MyPort:         r.MyPort,
+			PeerPort:       r.PeerPort,
+			SubscriberPort: r.SubscriberPort,
+			EstablishedAt:  r.EstablishedAt,
+			LastMessageAt:  r.LastMessageAt,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].EstablishedAt.Before(out[j].EstablishedAt)
+	})
+	return out, nil
+}
+
+// PairRemove tears down the pair (closing publisher + subscriber)
+// and marks the record revoked. The bbolt record is preserved for
+// audit; future tooling may add hard-purge.
+func (v *Visor) PairRemove(peerPK cipher.PubKey) error {
+	mgr := v.pairManager()
+	if mgr == nil {
+		return ErrPairingDisabled
+	}
+	return mgr.Remove(peerPK)
+}
+
+// PairSend publishes one message to peerPK's pair feed. Returns
+// ErrNotFound if peerPK isn't a registered pair.
+func (v *Visor) PairSend(peerPK cipher.PubKey, text string) error {
+	mgr := v.pairManager()
+	if mgr == nil {
+		return ErrPairingDisabled
+	}
+	p, ok := mgr.Get(peerPK)
+	if !ok {
+		return errors.New("pairing: no live pair for peer")
+	}
+	if err := p.Send(text); err != nil {
+		return err
+	}
+	v.initLock.RLock()
+	store := v.pairing.store
+	v.initLock.RUnlock()
+	if store != nil {
+		_ = store.MarkMessage(peerPK, time.Now().UTC()) //nolint:errcheck
+	}
+	return nil
+}
+
+// PairPoll returns inbound pair messages with TS strictly after
+// `since`. Pass time.Time{} (zero) to retrieve the entire current
+// inbox window. Messages older than the inbox capacity are dropped
+// silently — clients that want guaranteed delivery should poll
+// often enough that the window doesn't roll over between polls.
+func (v *Visor) PairPoll(since time.Time) ([]PairMessage, error) {
+	v.initLock.RLock()
+	inbox := v.pairing.inbox
+	v.initLock.RUnlock()
+	if inbox == nil {
+		return nil, ErrPairingDisabled
+	}
+	return inbox.snapshotAfter(since), nil
+}
+
+func (v *Visor) pairManager() *pairing.Manager {
+	v.initLock.RLock()
+	defer v.initLock.RUnlock()
+	return v.pairing.manager
+}
+
+// pairInbox is a bounded ring buffer of inbound pair messages,
+// drained by PairPoll. Single mutex; all operations are O(n) over
+// the current ring contents on snapshot, which is fine at
+// defaultInboxCap.
+type pairInbox struct {
+	mu  sync.Mutex
+	cap int
+	buf []PairMessage
+}
+
+func newPairInbox(capacity int) *pairInbox {
+	if capacity <= 0 {
+		capacity = defaultInboxCap
+	}
+	return &pairInbox{cap: capacity, buf: make([]PairMessage, 0, capacity)}
+}
+
+func (p *pairInbox) deliver(peerPK cipher.PubKey, msg pairing.Message) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.buf = append(p.buf, PairMessage{
+		PeerPK: peerPK,
+		Text:   msg.Text,
+		TS:     msg.TS,
+	})
+	if len(p.buf) > p.cap {
+		// Drop the oldest entries to fit the cap. Slice copy keeps
+		// the backing array bounded.
+		drop := len(p.buf) - p.cap
+		p.buf = append(p.buf[:0], p.buf[drop:]...)
+	}
+}
+
+func (p *pairInbox) snapshotAfter(since time.Time) []PairMessage {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]PairMessage, 0, len(p.buf))
+	for _, m := range p.buf {
+		if m.TS.After(since) {
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/pkg/visor/pairing_test.go
+++ b/pkg/visor/pairing_test.go
@@ -1,0 +1,98 @@
+package visor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/cmd/apps/skychat/pairing"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestPairInboxDeliverAndSnapshot(t *testing.T) {
+	inbox := newPairInbox(8)
+	pkA, _ := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+
+	t1 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(1 * time.Second)
+	t3 := t1.Add(2 * time.Second)
+
+	inbox.deliver(pkA, pairing.Message{Text: "hi", TS: t1})
+	inbox.deliver(pkB, pairing.Message{Text: "yo", TS: t2})
+	inbox.deliver(pkA, pairing.Message{Text: "still here", TS: t3})
+
+	all := inbox.snapshotAfter(time.Time{})
+	if len(all) != 3 {
+		t.Fatalf("snapshotAfter(zero): got %d msgs, want 3", len(all))
+	}
+	if all[0].Text != "hi" || all[1].Text != "yo" || all[2].Text != "still here" {
+		t.Errorf("messages out of order: %+v", all)
+	}
+
+	since := t1.Add(500 * time.Millisecond)
+	after := inbox.snapshotAfter(since)
+	if len(after) != 2 {
+		t.Fatalf("snapshotAfter(t1+500ms): got %d, want 2", len(after))
+	}
+	if after[0].Text != "yo" {
+		t.Errorf("first after-snapshot = %q, want yo", after[0].Text)
+	}
+}
+
+func TestPairInboxRingEvictsOldest(t *testing.T) {
+	inbox := newPairInbox(3)
+	pk, _ := cipher.GenerateKeyPair()
+
+	base := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		inbox.deliver(pk, pairing.Message{
+			Text: "msg",
+			TS:   base.Add(time.Duration(i) * time.Second),
+		})
+	}
+
+	all := inbox.snapshotAfter(time.Time{})
+	if len(all) != 3 {
+		t.Fatalf("ring should cap at 3, got %d", len(all))
+	}
+	// Oldest two messages (i=0, i=1) should have been evicted.
+	want := base.Add(2 * time.Second)
+	if !all[0].TS.Equal(want) {
+		t.Errorf("oldest in ring should be %v, got %v", want, all[0].TS)
+	}
+}
+
+func TestPairInboxSnapshotIsCopy(t *testing.T) {
+	// Mutating a snapshot must not affect the inbox state.
+	inbox := newPairInbox(8)
+	pk, _ := cipher.GenerateKeyPair()
+	inbox.deliver(pk, pairing.Message{Text: "x", TS: time.Now().UTC()})
+
+	first := inbox.snapshotAfter(time.Time{})
+	first[0].Text = "tampered"
+
+	second := inbox.snapshotAfter(time.Time{})
+	if second[0].Text != "x" {
+		t.Errorf("snapshot mutation leaked into inbox: %q", second[0].Text)
+	}
+}
+
+func TestPairInboxEmpty(t *testing.T) {
+	inbox := newPairInbox(8)
+	got := inbox.snapshotAfter(time.Time{})
+	if len(got) != 0 {
+		t.Errorf("empty inbox should yield 0 messages, got %d", len(got))
+	}
+}
+
+func TestPairInboxSinceFuture(t *testing.T) {
+	inbox := newPairInbox(8)
+	pk, _ := cipher.GenerateKeyPair()
+	inbox.deliver(pk, pairing.Message{Text: "x", TS: time.Now().UTC()})
+
+	future := time.Now().UTC().Add(time.Hour)
+	got := inbox.snapshotAfter(future)
+	if len(got) != 0 {
+		t.Errorf("since-in-future should yield 0 messages, got %d", len(got))
+	}
+}

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1065,6 +1065,35 @@ func (rc *rpcClient) ListCXOFeeds() []logserver.CXOFeedEntry {
 	return resp
 }
 
+// PairAdd implements API.
+func (rc *rpcClient) PairAdd(peerPK cipher.PubKey) error {
+	return rc.Call("PairAdd", &PairAddRequest{PeerPK: peerPK}, &struct{}{})
+}
+
+// PairList implements API.
+func (rc *rpcClient) PairList() ([]PairInfo, error) {
+	var resp []PairInfo
+	err := rc.Call("PairList", &struct{}{}, &resp)
+	return resp, err
+}
+
+// PairRemove implements API.
+func (rc *rpcClient) PairRemove(peerPK cipher.PubKey) error {
+	return rc.Call("PairRemove", &peerPK, &struct{}{})
+}
+
+// PairSend implements API.
+func (rc *rpcClient) PairSend(peerPK cipher.PubKey, text string) error {
+	return rc.Call("PairSend", &PairSendRequest{PeerPK: peerPK, Text: text}, &struct{}{})
+}
+
+// PairPoll implements API.
+func (rc *rpcClient) PairPoll(since time.Time) ([]PairMessage, error) {
+	var resp []PairMessage
+	err := rc.Call("PairPoll", &PairPollRequest{Since: since}, &resp)
+	return resp, err
+}
+
 // TPSStatus returns the status of the embedded TPS.
 func (rc *rpcClient) TPSStatus() (*TPSStatus, error) {
 	var status TPSStatus

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1082,6 +1082,21 @@ func (mc *mockRPCClient) UnregisterCXOFeed(_ string) error { return nil }
 // ListCXOFeeds implements API.
 func (mc *mockRPCClient) ListCXOFeeds() []logserver.CXOFeedEntry { return nil }
 
+// PairAdd implements API.
+func (mc *mockRPCClient) PairAdd(_ cipher.PubKey) error { return nil }
+
+// PairList implements API.
+func (mc *mockRPCClient) PairList() ([]PairInfo, error) { return nil, nil }
+
+// PairRemove implements API.
+func (mc *mockRPCClient) PairRemove(_ cipher.PubKey) error { return nil }
+
+// PairSend implements API.
+func (mc *mockRPCClient) PairSend(_ cipher.PubKey, _ string) error { return nil }
+
+// PairPoll implements API.
+func (mc *mockRPCClient) PairPoll(_ time.Time) ([]PairMessage, error) { return nil, nil }
+
 // TPSStatus implements API.
 func (mc *mockRPCClient) TPSStatus() (*TPSStatus, error) {
 	return &TPSStatus{Enabled: false}, nil

--- a/pkg/visor/rpc_pairing.go
+++ b/pkg/visor/rpc_pairing.go
@@ -1,0 +1,84 @@
+// Package visor pkg/visor/rpc_pairing.go
+//
+// RPC adapter for the chat-pair feed manager. Thin wrappers over the
+// Visor methods in pairing.go.
+package visor
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/util/rpcutil"
+)
+
+// PairAddRequest is the input to RPC.PairAdd.
+type PairAddRequest struct {
+	PeerPK cipher.PubKey `json:"peer_pk"`
+}
+
+// PairSendRequest is the input to RPC.PairSend.
+type PairSendRequest struct {
+	PeerPK cipher.PubKey `json:"peer_pk"`
+	Text   string        `json:"text"`
+}
+
+// PairPollRequest is the input to RPC.PairPoll.
+type PairPollRequest struct {
+	// Since is the lower bound (exclusive). Pass time.Time{} (zero)
+	// to retrieve the entire current inbox window.
+	Since time.Time `json:"since"`
+}
+
+// PairAdd creates a pair record and brings up the local publisher /
+// subscriber.
+func (r *RPC) PairAdd(req *PairAddRequest, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "PairAdd", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.PairAdd(req.PeerPK)
+}
+
+// PairList returns every persisted pair (pending / active / revoked).
+func (r *RPC) PairList(_ *struct{}, out *[]PairInfo) (err error) {
+	defer rpcutil.LogCall(r.log, "PairList", nil)(out, &err)
+	pairs, err := r.visor.PairList()
+	if err != nil {
+		return err
+	}
+	*out = pairs
+	return nil
+}
+
+// PairRemove tears down the pair and marks the record revoked.
+func (r *RPC) PairRemove(peerPK *cipher.PubKey, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "PairRemove", peerPK)(nil, &err)
+	if peerPK == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.PairRemove(*peerPK)
+}
+
+// PairSend publishes one message into the pair feed.
+func (r *RPC) PairSend(req *PairSendRequest, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "PairSend", req)(nil, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.PairSend(req.PeerPK, req.Text)
+}
+
+// PairPoll drains inbound pair messages with TS strictly after Since.
+func (r *RPC) PairPoll(req *PairPollRequest, out *[]PairMessage) (err error) {
+	defer rpcutil.LogCall(r.log, "PairPoll", req)(out, &err)
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+	msgs, err := r.visor.PairPoll(req.Since)
+	if err != nil {
+		return err
+	}
+	*out = msgs
+	return nil
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -180,6 +180,12 @@ type Visor struct {
 	cxoUserFeeds   map[string]*cxoUserFeed
 	cxoUserFeedsMu sync.Mutex
 
+	// pairing holds the chat-pair feed manager + bbolt store +
+	// inbound message ring. Populated by init_pairing.go after
+	// dmsgC is up. nil when pairing is disabled (dmsgC absent or
+	// init failed); RPC handlers surface ErrPairingDisabled.
+	pairing pairingState
+
 	// Embedded DMSG Web resolver (nil if dmsg_web.enable is false).
 	// Provides a localhost SOCKS5 proxy that resolves .dmsg hosts.
 	embeddedDmsgWeb *EmbeddedDmsgWeb


### PR DESCRIPTION
## Summary

PR-3 of six (#2378, #2379 already merged). Wires the visor-side
machinery for the chat-pair feed manager so apps can drive pair
lifecycle over visor RPC, without each app needing its own DMSG
client. No skychat changes in this PR — that lands in PR-4 with the
handshake-over-skychat protocol and HTTP/UI surface.

## What's new

### Init (\`pkg/visor/init_pairing.go\`)

A new \`pairing\` init module, depends only on \`dmsgC\`. Opens a bolt
store at \`<localPath>/pairing/pairs.db\`, constructs a
\`pairing.Manager\` backed by \`v.dmsgC\` + \`v.conf.PK / v.conf.SK\`, and
\`Resume\`s any pairs persisted from a prior run.

Best-effort: a missing \`dmsgC\` or store-open failure logs and disables
pairing for this run rather than failing visor startup. RPC handlers
surface \`ErrPairingDisabled\` so callers can degrade gracefully.

### Visor surface (\`pkg/visor/pairing.go\`)

\`\`\`go
PairAdd(peerPK cipher.PubKey) error
PairList() ([]PairInfo, error)
PairRemove(peerPK cipher.PubKey) error
PairSend(peerPK cipher.PubKey, text string) error
PairPoll(since time.Time) ([]PairMessage, error)
\`\`\`

Inbound messages flow through a bounded ring (\`defaultInboxCap=1024\`)
drained by \`PairPoll\` — slow or absent consumers don't grow memory
unbounded; oldest entries are evicted on overflow. SSE / long-poll
delivery is a layering decision that PR-4 will make in the skychat
HTTP shim.

### RPC plumbing

Follows the existing CXO-feed pattern: \`rpc_pairing.go\` request types
+ handlers, \`rpc_client.go\` client methods, \`rpc_client_mock.go\` mock,
\`api.go\` interface entries.

### Port-range guard

\`RegisterCXOFeed\` now rejects ports inside the pair allocator's
deterministic range so a user feed can't shadow a pair publisher or
subscriber listener. The pairing port constants are exported from
\`cmd/apps/skychat/pairing/ports.go\` for this validation.

## What's intentionally NOT here

- **Skychat HTTP/UI changes**: PR-4 will add HTTP endpoints
  (\`POST /pair\`, etc.) and the structured \`pair-invite\` /
  \`pair-ack\` messages over the legacy skychat direct path that
  drive \`PairAdd\` on both ends.
- **End-to-end DMSG tests**: deferred to PR-4 where the handshake
  protocol actually pairs two test visors and exchanges a CXO
  message. Unit tests here cover the pair-inbox ring (deliver,
  snapshotAfter cursor semantics, eviction, snapshot-is-copy,
  since-in-future).
- **Body encryption**: PR-5.
- **Default-on**: PR-6.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/visor/... ./cmd/apps/skychat/...\` passes
- [x] \`golangci-lint\` clean against project config
- [ ] Two-visor pair flow over real DMSG (lands with PR-4)