### PR TITLE
skychat: cli visor pair tree + end-to-end pair integration test

### DIFF
--- a/cmd/apps/skychat/pairing/integration_test.go
+++ b/cmd/apps/skychat/pairing/integration_test.go
@@ -1,0 +1,183 @@
+// Package pairing — cmd/apps/skychat/pairing/integration_test.go:
+// end-to-end coverage of the pair primitive over a real DMSG mesh.
+//
+// Spins up a 1-server / 2-client dmsg env via dmsgtest, wires a
+// pairing.Manager on each side using shared PK/SK pairs (so the
+// pair-feed PK matches the dmsg PK, mirroring the visor wiring),
+// and exercises the full pipeline:
+//
+//   - Manager.Add bringing up publisher + subscriber
+//   - allowlist enforcement (publisher accepts only the peer)
+//   - deterministic port discovery (both sides hit the same port)
+//   - CXO publish + subscribe round-trip in both directions
+//
+// Skipped under -short because the in-process DMSG mesh + CXO node
+// startup add a few seconds of overhead.
+package pairing
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgtest"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func TestPairRoundTripOverDmsg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; skipped under -short")
+	}
+
+	// Generate keypairs first so dmsg client and pair manager share
+	// the same PK/SK on each side. Mirrors the visor wiring where
+	// v.dmsgC and the pair manager both use v.conf.PK / v.conf.SK.
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+
+	env := dmsgtest.NewEnv(t, dmsgtest.DefaultTimeout)
+	env.Discovery() // ensure mock disc is ready (no-op if already)
+	require.NoError(t, env.Startup(dmsgtest.DefaultTimeout, 1, 0, &dmsg.Config{MinSessions: 1}))
+	t.Cleanup(env.Shutdown)
+
+	// Use NewClientWithKeys so the dmsg client carries pkA/skA, etc.
+	dmsgA, err := env.NewClientWithKeys(pkA, skA, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+	dmsgB, err := env.NewClientWithKeys(pkB, skB, &dmsg.Config{MinSessions: 1})
+	require.NoError(t, err)
+
+	// Wait for both clients to be DMSG-ready before bringing up CXO
+	// nodes — Listen otherwise races the session handshake.
+	waitDmsgReady(t, dmsgA, 10*time.Second)
+	waitDmsgReady(t, dmsgB, 10*time.Second)
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	storeA, err := OpenStore(filepath.Join(dirA, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeA.Close() }) //nolint:errcheck
+
+	storeB, err := OpenStore(filepath.Join(dirB, "pairs.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = storeB.Close() }) //nolint:errcheck
+
+	mgrA, err := NewManager(ManagerConfig{
+		Store:   storeA,
+		DmsgC:   dmsgA,
+		MyPK:    pkA,
+		MySK:    skA,
+		DataDir: filepath.Join(dirA, "cxo"),
+		Logger:  logging.MustGetLogger("pair-A"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgrA.Close() }) //nolint:errcheck
+
+	mgrB, err := NewManager(ManagerConfig{
+		Store:   storeB,
+		DmsgC:   dmsgB,
+		MyPK:    pkB,
+		MySK:    skB,
+		DataDir: filepath.Join(dirB, "cxo"),
+		Logger:  logging.MustGetLogger("pair-B"),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgrB.Close() }) //nolint:errcheck
+
+	// Register handlers BEFORE Add so the very first Root the
+	// subscriber sees gets surfaced. Manager.SetMessageHandler
+	// propagates to any later-created Pair.
+	inboxA := newTestInbox()
+	inboxB := newTestInbox()
+	mgrA.SetMessageHandler(inboxA.deliver)
+	mgrB.SetMessageHandler(inboxB.deliver)
+
+	pairA, err := mgrA.Add(pkB)
+	require.NoError(t, err)
+	pairB, err := mgrB.Add(pkA)
+	require.NoError(t, err)
+
+	require.NoError(t, pairA.Connect())
+	require.NoError(t, pairB.Connect())
+
+	// A → B
+	require.NoError(t, pairA.Send("hello bob"))
+	require.NoError(t, inboxB.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == pkA && m.text == "hello bob" {
+				return true
+			}
+		}
+		return false
+	}))
+
+	// B → A
+	require.NoError(t, pairB.Send("hi alice"))
+	require.NoError(t, inboxA.waitFor(20*time.Second, func(msgs []testReceived) bool {
+		for _, m := range msgs {
+			if m.peer == pkB && m.text == "hi alice" {
+				return true
+			}
+		}
+		return false
+	}))
+}
+
+func waitDmsgReady(t *testing.T, c *dmsg.Client, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-c.Ready():
+	case <-time.After(timeout):
+		t.Fatalf("dmsg client %s not ready after %v", c.LocalPK().Hex()[:8], timeout)
+	}
+}
+
+// testInbox is a tiny test helper distinct from pkg/visor's pairInbox.
+// We don't reuse pairInbox because it lives in pkg/visor and dragging
+// it down here would force the test to depend on the visor's
+// PairMessage envelope; the raw (peer, text) shape is enough.
+
+type testReceived struct {
+	peer cipher.PubKey
+	text string
+}
+
+type testInbox struct {
+	mu   sync.Mutex
+	msgs []testReceived
+}
+
+func newTestInbox() *testInbox { return &testInbox{} }
+
+func (i *testInbox) deliver(peer cipher.PubKey, msg Message) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.msgs = append(i.msgs, testReceived{peer: peer, text: msg.Text})
+}
+
+func (i *testInbox) snapshot() []testReceived {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	out := make([]testReceived, len(i.msgs))
+	copy(out, i.msgs)
+	return out
+}
+
+var errInboxTimeout = errors.New("pairing: inbox wait timed out")
+
+func (i *testInbox) waitFor(timeout time.Duration, pred func([]testReceived) bool) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred(i.snapshot()) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return errInboxTimeout
+}

--- a/cmd/apps/skychat/pairing/manager.go
+++ b/cmd/apps/skychat/pairing/manager.go
@@ -120,18 +120,16 @@ func (m *Manager) Add(peerPK cipher.PubKey) (*Pair, error) {
 		return p, nil
 	}
 
-	ports, err := ComputePairPorts(m.myPK, peerPK)
+	port, err := ComputePairPort(m.myPK, peerPK)
 	if err != nil {
 		return nil, fmt.Errorf("pairing: Add: %w", err)
 	}
 
 	rec := Record{
-		PeerPK:         peerPK,
-		MyPort:         ports.Publisher,
-		PeerPort:       ports.Publisher, // symmetric in the current scheme
-		SubscriberPort: ports.Subscriber,
-		Status:         StatusPending,
-		EstablishedAt:  time.Now().UTC(),
+		PeerPK:        peerPK,
+		Port:          port,
+		Status:        StatusPending,
+		EstablishedAt: time.Now().UTC(),
 	}
 	if err := m.store.Put(rec); err != nil {
 		return nil, fmt.Errorf("pairing: Add: persist: %w", err)

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -1,25 +1,24 @@
 // Package pairing — cmd/apps/skychat/pairing/pair.go: a single chat
 // pair's runtime state.
 //
-// A Pair wraps two CXO TreeStore endpoints under one struct:
+// One CXO node per pair side, listening on the deterministic pair
+// port (ComputePairPort(my_pk, peer_pk)). The node hosts both roles:
 //
-//   - a Publisher exposing this side's outbox feed, with an allowlist
-//     of exactly the peer's PK. The peer is the only entity permitted
-//     to subscribe to and read this feed.
-//   - a Subscriber connected to the peer's outbox feed, dialing the
-//     same deterministic publisher port on the peer's PK.
+//   - Publisher: shares this side's outbox feed, with an allowlist of
+//     exactly the peer's PK. Only the peer may subscribe and read.
+//   - Subscriber: connected to the peer's outbox feed (same port,
+//     peer's PK as the feed identity). Receives messages from peer.
 //
-// Both run on dedicated CXO nodes attached to a shared dmsg.Client.
-// Within one visor, multiple pairs avoid DMSG-port collisions because
-// each pair's publisher port is derived from the unique (a, b) hash
-// and the subscriber port lives in a non-overlapping range
-// (see ports.go).
+// One node per pair (not two) keeps the DMSG port allocation simple
+// and matches the symmetric protocol: both ends listen on the same
+// port number, both ends dial the other at that port. The CXO node
+// multiplexes publisher and subscriber roles by feed PK.
 //
-// Lifecycle: Open creates the publisher (no subscriber yet) and is
-// the act of "I'm ready to receive from this peer." Connect dials the
-// peer's publisher and registers the inbound message callback. The
-// two are split because the pairing handshake (PR-3) sends an invite
-// after Open and only Connects after the peer's ack arrives.
+// Lifecycle: Open creates the publisher (ready to accept the peer's
+// subscribe) and constructs the subscriber attached to the publisher's
+// node. Connect dials the peer's node and registers the inbound
+// subscribe. Open + Connect are split so the pairing handshake (PR-5+)
+// can stage the publisher before the peer is known to be ready.
 package pairing
 
 import (
@@ -44,7 +43,7 @@ import (
 const MessagePathPrefix = "msgs"
 
 // Message is the on-the-wire form of a chat message inside a pair
-// feed. Body encryption (PR-5) wraps Text into a ciphertext field;
+// feed. Body encryption (PR-6) wraps Text into a ciphertext field;
 // for now Text is plaintext.
 type Message struct {
 	Text string    `json:"text"`
@@ -65,13 +64,11 @@ type Config struct {
 	// PeerPK is the chat partner.
 	PeerPK cipher.PubKey
 
-	// DmsgC is the shared DMSG client. Both publisher and subscriber
-	// CXO nodes attach to it.
+	// DmsgC is the shared DMSG client.
 	DmsgC *dmsg.Client
 
 	// DataDir is the per-visor parent directory for CXO state. Each
-	// Pair carves its own pub/<peer-pk-hex>/ and sub/<peer-pk-hex>/
-	// subtrees inside it.
+	// Pair carves its own pair/<peer-pk-hex>/ subtree inside it.
 	DataDir string
 
 	// Logger is optional; nil falls back to a tag-based default.
@@ -84,8 +81,8 @@ type Config struct {
 // Pair is one live chat pair. Safe for concurrent use after Open
 // returns; Send and Close may be called from any goroutine.
 type Pair struct {
-	cfg   Config
-	ports PairPorts
+	cfg  Config
+	port uint16
 
 	pub *treestore.Publisher
 	sub *treestore.Subscriber
@@ -100,11 +97,11 @@ type Pair struct {
 	log *logging.Logger
 }
 
-// Open constructs the pair's publisher with allowlist=[PeerPK] and
-// records the deterministic ports. The subscriber is created but not
-// yet connected — call Connect after the peer has acknowledged the
-// pair invite (PR-3) or immediately when both sides are known to be
-// ready.
+// Open constructs the pair's CXO node, brings up the publisher with
+// allowlist=[PeerPK], and prepares a subscriber attached to the same
+// node. The subscriber is not yet connected — call Connect after
+// the peer is known to be ready (or immediately when both sides are
+// brought up at once, e.g. in tests).
 func Open(cfg Config) (*Pair, error) {
 	if cfg.DmsgC == nil {
 		return nil, errors.New("pairing: Open: DmsgC required")
@@ -120,45 +117,45 @@ func Open(cfg Config) (*Pair, error) {
 		log = logging.MustGetLogger("skychat-pair")
 	}
 
-	ports, err := ComputePairPorts(cfg.MyPK, cfg.PeerPK)
+	port, err := ComputePairPort(cfg.MyPK, cfg.PeerPK)
 	if err != nil {
-		return nil, fmt.Errorf("pairing: Open: compute ports: %w", err)
+		return nil, fmt.Errorf("pairing: Open: compute port: %w", err)
 	}
 
 	peerHex := cfg.PeerPK.Hex()
 	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
 		BatchWindow:         cfg.BatchWindow,
 		Logger:              log,
-		DataDir:             filepath.Join(cfg.DataDir, "pub", peerHex),
-		DmsgPort:            ports.Publisher,
+		DataDir:             filepath.Join(cfg.DataDir, "pair", peerHex),
+		DmsgPort:            port,
 		SubscriberAllowlist: []cipher.PubKey{cfg.PeerPK},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("pairing: Open: build publisher: %w", err)
 	}
 
-	sub, err := treestore.NewSubscriber(cfg.DmsgC, cfg.PeerPK, treestore.SubConfig{
-		Logger:   log,
-		DataDir:  filepath.Join(cfg.DataDir, "sub", peerHex),
-		DmsgPort: ports.Subscriber,
+	// Subscriber piggybacks on the publisher's CXO node. One node
+	// per pair side hosts both roles, addressed by feed PK.
+	sub, err := treestore.NewSubscriberOnNode(pub.Node(), cfg.PeerPK, treestore.SubConfig{
+		Logger: log,
 	})
 	if err != nil {
 		_ = pub.Close() //nolint:errcheck
-		return nil, fmt.Errorf("pairing: Open: build subscriber: %w", err)
+		return nil, fmt.Errorf("pairing: Open: attach subscriber: %w", err)
 	}
 	sub.SetPrefixes([]string{MessagePathPrefix})
 
-	p := &Pair{cfg: cfg, ports: ports, pub: pub, sub: sub, log: log}
+	p := &Pair{cfg: cfg, port: port, pub: pub, sub: sub, log: log}
 	sub.OnUpdate(p.onUpdate)
 	return p, nil
 }
 
-// Connect dials the peer's publisher and starts the subscribe
+// Connect dials the peer's CXO node and starts the subscribe
 // handshake. Idempotent: returns nil if already connected.
 //
-// Open + Connect are split so the pairing handshake (PR-3) can stage
-// the publisher before the peer is known to be ready, then activate
-// the inbound side once the peer's pair-ack arrives.
+// Open + Connect are split so the pairing handshake can stage the
+// publisher before the peer is known to be ready, then activate the
+// inbound side once the peer's pair-ack arrives.
 func (p *Pair) Connect() error {
 	if err := p.sub.Connect(p.cfg.PeerPK); err != nil {
 		return fmt.Errorf("pairing: Connect: %w", err)
@@ -166,11 +163,9 @@ func (p *Pair) Connect() error {
 	return nil
 }
 
-// Ports returns the publisher / subscriber DMSG ports this pair uses.
-// Persisted by the manager so a future restart resumes on the same
-// ports even if the deterministic computation later changes.
-func (p *Pair) Ports() PairPorts {
-	return p.ports
+// Port returns the deterministic DMSG port this pair uses on both sides.
+func (p *Pair) Port() uint16 {
+	return p.port
 }
 
 // PeerPK is a convenience accessor.
@@ -201,7 +196,8 @@ func (p *Pair) Send(text string) error {
 	return nil
 }
 
-// Close tears down both endpoints. Idempotent.
+// Close tears down the subscriber + publisher (and the underlying
+// CXO node, owned by the publisher). Idempotent.
 func (p *Pair) Close() error {
 	var firstErr error
 	if p.sub != nil {
@@ -230,7 +226,6 @@ func (p *Pair) onUpdate(events []treestore.UpdateEvent) {
 	}
 	for _, ev := range events {
 		if ev.Value == nil {
-			// Deletion — no inbound message to surface.
 			continue
 		}
 		var msg Message

--- a/cmd/apps/skychat/pairing/ports.go
+++ b/cmd/apps/skychat/pairing/ports.go
@@ -1,27 +1,23 @@
 // Package pairing — cmd/apps/skychat/pairing/ports.go: deterministic
 // DMSG port allocation for chat-pair feeds.
 //
-// Each ordered pair of visor public keys (Alice, Bob) maps to a stable
-// publisher port + subscriber port. Both sides of the pair compute the
-// same numbers from public information alone, so no out-of-band port
-// negotiation is needed.
+// Each unordered pair of visor public keys (Alice, Bob) maps to a
+// stable DMSG port. Both sides of the pair compute the same number
+// from public information alone, so no out-of-band port negotiation
+// is needed.
 //
-// Port plan:
+// Port plan: one port per pair, in [PortBase, PortBase+PortSpan).
+// Each side's CXO node listens on this single port and hosts both
+// roles — Alice publishes her own pair-with-Bob feed and subscribes
+// to Bob's pair-with-Alice feed on the same node, with Bob's node
+// doing the symmetric thing on the same port number on his side.
+// One port suffices because publisher and subscriber operate on
+// distinct feed PKs (each side's own PK), so the CXO node multiplexes
+// them on the single DMSG conn.
 //
-//   - Publisher port (where Alice's pair-with-Bob feed listens, and
-//     where Bob's subscriber dials Alice): in [PubBase, PubBase+PubSpan).
-//   - Subscriber port (where Alice's subscriber-to-Bob CXO node binds
-//     its inbound listener, since EnableDMSG always Listens): in
-//     [SubBase, SubBase+PubSpan), offset by PubSpan from the publisher.
-//
-// The two ranges don't overlap, and they sit clear of the system DMSG
-// port table (everything <300 + reserved ranges around port 80 / 100 /
-// 136). Collisions with the reserved set are still possible at the
-// boundaries; ResolvePublisherPort walks forward to the next free
-// port in PubBase..PubBase+PubSpan and panics on full saturation
-// (50000 deterministic slots is far more than any realistic chat-pair
-// count, so saturation here is an indication of either a bug or a
-// hostile workload).
+// The range sits clear of the system DMSG port table (everything
+// <300 plus reserved ports around 80 / 100 / 136). Collisions with
+// the reserved set are walked past so a pair can always Listen.
 package pairing
 
 import (
@@ -37,17 +33,15 @@ import (
 // visor's CXO user-feed registry, which needs to reject overlapping
 // port allocations) can validate against the same numbers.
 const (
-	PubBase uint16 = 10000
-	PubSpan uint16 = 25000
-	SubBase uint16 = 35000
+	PortBase uint16 = 10000
+	PortSpan uint16 = 50000
 )
 
 // ReservedPorts is the set of DMSG ports already bound by visor
 // subsystems. The pair-feed allocator avoids these so a publisher can
-// always Listen and a subscriber's local listen can't shadow a system
-// service. Mirrors pkg/visor/cxo_user_feeds.go reservedDmsgPorts; kept
-// in sync manually because dragging in pkg/visor here would create an
-// import cycle (skychat is invoked by the launcher inside the visor).
+// always Listen. Mirrors pkg/visor/cxo_user_feeds.go reservedDmsgPorts;
+// kept in sync manually because dragging in pkg/visor here would create
+// an import cycle (skychat is invoked by the launcher inside the visor).
 func ReservedPorts() map[uint16]struct{} {
 	return map[uint16]struct{}{
 		skyenv.DmsgCtrlPort:                  {},
@@ -65,63 +59,36 @@ func ReservedPorts() map[uint16]struct{} {
 	}
 }
 
-// PairPorts is the pair of DMSG ports a single side of a chat pair
-// uses. Both Alice and Bob compute the same PairPorts struct from the
-// same (alice_pk, bob_pk) input.
-type PairPorts struct {
-	Publisher  uint16
-	Subscriber uint16
-}
-
-// ComputePairPorts returns the deterministic publisher + subscriber
-// ports for the pair (a, b). Symmetric: ComputePairPorts(a, b) ==
-// ComputePairPorts(b, a). The caller must already have decided that
-// the pair should exist; ComputePairPorts has no side effects.
+// ComputePairPort returns the deterministic DMSG port for the chat
+// pair (a, b). Symmetric: ComputePairPort(a, b) == ComputePairPort(b, a).
 //
-// Returns an error only when every port slot in PubBase..PubBase+PubSpan
-// is also in ReservedPorts (impossible with the current static
-// reserved table, but checked so future expansions of that table fail
-// loudly rather than infinite-loop).
-func ComputePairPorts(a, b cipher.PubKey) (PairPorts, error) {
-	pub, err := publisherPort(a, b, ReservedPorts())
-	if err != nil {
-		return PairPorts{}, err
-	}
-	return PairPorts{
-		Publisher:  pub,
-		Subscriber: pub + PubSpan,
-	}, nil
+// Returns an error only when every port slot in the span is also in
+// ReservedPorts (impossible with the current static table, but
+// checked so future expansions of that table fail loudly rather than
+// infinite-loop).
+func ComputePairPort(a, b cipher.PubKey) (uint16, error) {
+	return pairPort(a, b, ReservedPorts())
 }
 
-// publisherPort hashes the (min, max) of (a, b) and walks forward
-// past any reserved-port collision to the next free slot. Exported
-// for tests via ComputePairPorts; kept internal here so the
-// reserved-port table is the single configuration knob.
-func publisherPort(a, b cipher.PubKey, reserved map[uint16]struct{}) (uint16, error) {
+// pairPort hashes the (min, max) of (a, b) and walks forward past any
+// reserved-port collision to the next free slot. Both ends do the
+// same walk so the result stays symmetric.
+func pairPort(a, b cipher.PubKey, reserved map[uint16]struct{}) (uint16, error) {
 	lo, hi := orderedPair(a, b)
 	h := sha256.New()
 	h.Write(lo[:]) //nolint:errcheck
 	h.Write(hi[:]) //nolint:errcheck
 	sum := h.Sum(nil)
-	// Use the first 4 bytes of the hash; mod into the publisher span.
 	raw := binary.BigEndian.Uint32(sum[:4])
-	candidate := PubBase + uint16(raw%uint32(PubSpan))
+	candidate := PortBase + uint16(raw%uint32(PortSpan))
 
-	// Walk forward through the publisher span until we find a non-
-	// reserved slot. Both ends must do the same walk for the result
-	// to stay symmetric.
-	for offset := uint16(0); offset < PubSpan; offset++ {
-		port := PubBase + ((candidate-PubBase)+offset)%PubSpan
+	for offset := uint16(0); offset < PortSpan; offset++ {
+		port := PortBase + ((candidate-PortBase)+offset)%PortSpan
 		if _, isReserved := reserved[port]; !isReserved {
-			// Also avoid the corresponding subscriber slot if it's
-			// reserved — keeps Pair.Open simple by guaranteeing both
-			// slots are free.
-			if _, subReserved := reserved[port+PubSpan]; !subReserved {
-				return port, nil
-			}
+			return port, nil
 		}
 	}
-	return 0, fmt.Errorf("pairing: no free publisher port in [%d, %d)", PubBase, PubBase+PubSpan)
+	return 0, fmt.Errorf("pairing: no free port in [%d, %d)", PortBase, PortBase+PortSpan)
 }
 
 // orderedPair returns (a, b) sorted byte-lexicographically so the

--- a/cmd/apps/skychat/pairing/ports_test.go
+++ b/cmd/apps/skychat/pairing/ports_test.go
@@ -6,89 +6,72 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 )
 
-func TestComputePairPortsSymmetric(t *testing.T) {
+func TestComputePairPortSymmetric(t *testing.T) {
 	a, _ := cipher.GenerateKeyPair()
 	b, _ := cipher.GenerateKeyPair()
 
-	ab, err := ComputePairPorts(a, b)
+	ab, err := ComputePairPort(a, b)
 	if err != nil {
 		t.Fatalf("a,b: %v", err)
 	}
-	ba, err := ComputePairPorts(b, a)
+	ba, err := ComputePairPort(b, a)
 	if err != nil {
 		t.Fatalf("b,a: %v", err)
 	}
 	if ab != ba {
-		t.Fatalf("ports must be symmetric: ab=%+v ba=%+v", ab, ba)
+		t.Fatalf("ports must be symmetric: ab=%d ba=%d", ab, ba)
 	}
 }
 
-func TestComputePairPortsInRange(t *testing.T) {
+func TestComputePairPortInRange(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		a, _ := cipher.GenerateKeyPair()
 		b, _ := cipher.GenerateKeyPair()
-		pp, err := ComputePairPorts(a, b)
+		port, err := ComputePairPort(a, b)
 		if err != nil {
 			t.Fatalf("iter %d: %v", i, err)
 		}
-		if pp.Publisher < PubBase || pp.Publisher >= PubBase+PubSpan {
-			t.Errorf("iter %d: publisher port %d out of [%d, %d)", i, pp.Publisher, PubBase, PubBase+PubSpan)
-		}
-		if pp.Subscriber < SubBase || pp.Subscriber >= SubBase+PubSpan {
-			t.Errorf("iter %d: subscriber port %d out of [%d, %d)", i, pp.Subscriber, SubBase, SubBase+PubSpan)
-		}
-		if pp.Subscriber-pp.Publisher != PubSpan {
-			t.Errorf("iter %d: subscriber should be publisher+%d, got publisher=%d sub=%d", i, PubSpan, pp.Publisher, pp.Subscriber)
+		if port < PortBase || port >= PortBase+PortSpan {
+			t.Errorf("iter %d: port %d out of [%d, %d)", i, port, PortBase, PortBase+PortSpan)
 		}
 	}
 }
 
-func TestComputePairPortsAvoidsReserved(t *testing.T) {
+func TestComputePairPortAvoidsReserved(t *testing.T) {
 	// Synthesize a reserved set that includes the deterministic slot
-	// for a given pair, and verify publisherPort walks past it.
+	// for a given pair, and verify pairPort walks past it.
 	a, _ := cipher.GenerateKeyPair()
 	b, _ := cipher.GenerateKeyPair()
 
-	// First, find what the natural deterministic port would be.
-	natural, err := publisherPort(a, b, map[uint16]struct{}{})
+	natural, err := pairPort(a, b, map[uint16]struct{}{})
 	if err != nil {
 		t.Fatalf("baseline: %v", err)
 	}
-	// Now reserve that exact slot and re-compute.
 	reserved := map[uint16]struct{}{natural: {}}
-	walked, err := publisherPort(a, b, reserved)
+	walked, err := pairPort(a, b, reserved)
 	if err != nil {
 		t.Fatalf("with collision: %v", err)
 	}
 	if walked == natural {
 		t.Fatalf("expected walk past reserved port %d, still got %d", natural, walked)
 	}
-	// walked should be the next non-reserved slot in the span.
-	if walked < PubBase || walked >= PubBase+PubSpan {
-		t.Errorf("walked port %d out of pub range", walked)
+	if walked < PortBase || walked >= PortBase+PortSpan {
+		t.Errorf("walked port %d out of pair range", walked)
 	}
 }
 
-func TestComputePairPortsAvoidsRealReservedTable(t *testing.T) {
-	// Cross-check that no random pair lands on a port from the real
-	// reserved table. With 50 random pairs and 12 reserved ports out
-	// of 50000 slots, the probability of a hit is ~1.2% per pair, so
-	// across 50 iterations we expect >40% chance of at least one
-	// collision IF the avoidance code didn't work — running the test
-	// repeatedly with avoidance on should never report one.
+func TestComputePairPortAvoidsRealReservedTable(t *testing.T) {
+	// Sanity-check that random pairs don't land on a real reserved port.
 	reserved := ReservedPorts()
 	for i := 0; i < 200; i++ {
 		a, _ := cipher.GenerateKeyPair()
 		b, _ := cipher.GenerateKeyPair()
-		pp, err := ComputePairPorts(a, b)
+		port, err := ComputePairPort(a, b)
 		if err != nil {
 			t.Fatalf("iter %d: %v", i, err)
 		}
-		if _, hit := reserved[pp.Publisher]; hit {
-			t.Errorf("iter %d: publisher port %d landed on reserved", i, pp.Publisher)
-		}
-		if _, hit := reserved[pp.Subscriber]; hit {
-			t.Errorf("iter %d: subscriber port %d landed on reserved", i, pp.Subscriber)
+		if _, hit := reserved[port]; hit {
+			t.Errorf("iter %d: port %d landed on reserved", i, port)
 		}
 	}
 }

--- a/cmd/apps/skychat/pairing/store.go
+++ b/cmd/apps/skychat/pairing/store.go
@@ -49,22 +49,14 @@ type Record struct {
 	// PeerPK is the partner visor's public key.
 	PeerPK cipher.PubKey `json:"peer_pk"`
 
-	// MyPort is the DMSG port my outbox publisher listens on.
-	// Equal to the deterministic ComputePairPorts(myPK, peerPK).Publisher.
+	// Port is the DMSG port both sides use for this pair. Equal to
+	// ComputePairPort(myPK, peerPK). Each side's CXO node listens
+	// on this port and hosts both publisher (own feed) and
+	// subscriber (peer's feed) roles.
+	//
 	// Persisted (rather than recomputed every time) so a future
 	// reserved-port table change doesn't silently shift live pairs.
-	MyPort uint16 `json:"my_port"`
-
-	// PeerPort is the DMSG port the peer's outbox publisher listens on.
-	// Same value as MyPort under the current scheme — both ends share
-	// the deterministic publisher port — but stored separately so the
-	// schema can accommodate a future asymmetric variant without a
-	// migration.
-	PeerPort uint16 `json:"peer_port"`
-
-	// SubscriberPort is where my CXO subscriber's node binds its own
-	// listener. ComputePairPorts(myPK, peerPK).Subscriber.
-	SubscriberPort uint16 `json:"subscriber_port"`
+	Port uint16 `json:"port"`
 
 	Status        Status    `json:"status"`
 	EstablishedAt time.Time `json:"established_at"`

--- a/cmd/apps/skychat/pairing/store_test.go
+++ b/cmd/apps/skychat/pairing/store_test.go
@@ -27,12 +27,10 @@ func sampleRecord(t *testing.T) Record {
 	t.Helper()
 	pk, _ := cipher.GenerateKeyPair()
 	return Record{
-		PeerPK:         pk,
-		MyPort:         12345,
-		PeerPort:       12345,
-		SubscriberPort: 37345,
-		Status:         StatusPending,
-		EstablishedAt:  time.Now().UTC().Truncate(time.Millisecond),
+		PeerPK:        pk,
+		Port:          12345,
+		Status:        StatusPending,
+		EstablishedAt: time.Now().UTC().Truncate(time.Millisecond),
 	}
 }
 
@@ -47,7 +45,7 @@ func TestStorePutGet(t *testing.T) {
 	if err != nil || !ok {
 		t.Fatalf("Get: ok=%v err=%v", ok, err)
 	}
-	if got.PeerPK != r.PeerPK || got.MyPort != r.MyPort || got.Status != r.Status {
+	if got.PeerPK != r.PeerPK || got.Port != r.Port || got.Status != r.Status {
 		t.Errorf("roundtrip mismatch: got %+v want %+v", got, r)
 	}
 }
@@ -115,8 +113,8 @@ func TestStoreSetStatus(t *testing.T) {
 		t.Errorf("status = %s, want active", got.Status)
 	}
 	// Other fields preserved.
-	if got.MyPort != r.MyPort {
-		t.Errorf("MyPort changed: got %d want %d", got.MyPort, r.MyPort)
+	if got.Port != r.Port {
+		t.Errorf("Port changed: got %d want %d", got.Port, r.Port)
 	}
 }
 

--- a/cmd/skywire-cli/commands/visor/pair.go
+++ b/cmd/skywire-cli/commands/visor/pair.go
@@ -1,0 +1,207 @@
+// Package clivisor cmd/skywire-cli/commands/visor/pair.go
+//
+// `skywire cli visor pair` — drive the visor's chat-pair feed
+// manager from the CLI. Handy for testing the pairing pipeline
+// without running the skychat app, and for scripted setups where
+// pairs are bootstrapped from config (e.g. seed-pair lists in
+// integration tests).
+//
+// Each subcommand wraps one Visor.Pair* RPC method:
+//
+//	pair add <peer-pk>          → PairAdd
+//	pair ls                     → PairList
+//	pair rm <peer-pk>           → PairRemove
+//	pair send <peer-pk> <text>  → PairSend
+//	pair poll [--since <RFC3339>] → PairPoll
+package clivisor
+
+import (
+	"fmt"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+var pairPollSince string
+
+func init() {
+	pairPollCmd.Flags().StringVar(&pairPollSince, "since", "",
+		"only report messages with TS strictly after this RFC3339 timestamp; empty drains the full window")
+	pairCmd.AddCommand(pairAddCmd)
+	pairCmd.AddCommand(pairLsCmd)
+	pairCmd.AddCommand(pairRmCmd)
+	pairCmd.AddCommand(pairSendCmd)
+	pairCmd.AddCommand(pairPollCmd)
+	RootCmd.AddCommand(pairCmd)
+}
+
+var pairCmd = &cobra.Command{
+	Use:   "pair",
+	Short: "Manage chat-pair feeds",
+	Long: `Drive the visor's chat-pair feed manager.
+
+Each pair is a per-partner CXO feed with an allowlist of exactly the
+partner's public key. Both ends must call ` + "`pair add`" + ` with the
+other's PK before messages flow.
+
+Without a subcommand this prints the active pair list.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		listPairs(cmd)
+	},
+}
+
+var pairAddCmd = &cobra.Command{
+	Use:   "add <peer-pk>",
+	Short: "Register a chat pair with peer-pk",
+	Long: `Open a chat-pair publisher (allowlist=[peer-pk]) and a subscriber
+to the peer's matching publisher. The peer must call ` + "`pair add`" + ` with
+this visor's PK on its side for the connection to actually flow.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		peer := internal.ParsePK(cmd.Flags(), "peer-pk", args[0])
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.PairAdd(peer); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("PairAdd: %w", err))
+		}
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"peer_pk": peer.Hex(), "added": true},
+			fmt.Sprintf("Pair with %s registered\n", peer.Hex()))
+	},
+}
+
+var pairLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List chat pairs",
+	Run: func(cmd *cobra.Command, _ []string) {
+		listPairs(cmd)
+	},
+}
+
+var pairRmCmd = &cobra.Command{
+	Use:   "rm <peer-pk>",
+	Short: "Tear down a chat pair",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		peer := internal.ParsePK(cmd.Flags(), "peer-pk", args[0])
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.PairRemove(peer); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("PairRemove: %w", err))
+		}
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"peer_pk": peer.Hex(), "removed": true},
+			fmt.Sprintf("Pair with %s removed\n", peer.Hex()))
+	},
+}
+
+var pairSendCmd = &cobra.Command{
+	Use:   "send <peer-pk> <text>",
+	Short: "Publish a message into the pair feed",
+	Long: `Send one chat message via the per-pair CXO feed. The peer's
+subscriber will see it on the next CXO publish-batch cycle.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		peer := internal.ParsePK(cmd.Flags(), "peer-pk", args[0])
+		text := args[1]
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if err := rpcClient.PairSend(peer, text); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("PairSend: %w", err))
+		}
+		internal.PrintOutput(cmd.Flags(),
+			map[string]any{"peer_pk": peer.Hex(), "sent": true},
+			fmt.Sprintf("Sent to %s: %s\n", peer.Hex(), text))
+	},
+}
+
+var pairPollCmd = &cobra.Command{
+	Use:   "poll",
+	Short: "Drain inbound pair messages",
+	Long: `Pull every inbound pair message buffered on the visor with TS
+strictly after --since (or the full inbox window when --since is empty).
+
+The visor keeps a bounded ring (1024 messages by default); poll often
+enough that it doesn't roll over between reads.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		var since time.Time
+		if pairPollSince != "" {
+			t, err := time.Parse(time.RFC3339, pairPollSince)
+			if err != nil {
+				internal.PrintFatalError(cmd.Flags(),
+					fmt.Errorf("--since: %w (expected RFC3339)", err))
+			}
+			since = t
+		}
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		msgs, err := rpcClient.PairPoll(since)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("PairPoll: %w", err))
+		}
+		var buf strings.Builder
+		w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "TIMESTAMP\tPEER\tTEXT") //nolint:errcheck,gosec
+		for _, m := range msgs {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", //nolint:errcheck,gosec
+				m.TS.UTC().Format(time.RFC3339Nano), m.PeerPK.Hex()[:16]+"...", m.Text)
+		}
+		w.Flush() //nolint:errcheck,gosec
+		internal.PrintOutput(cmd.Flags(), msgs, buf.String())
+	},
+}
+
+// listPairs renders the current pair set, called by both the bare
+// `pair` command and the explicit `pair ls`.
+func listPairs(cmd *cobra.Command) {
+	rpcClient, err := clirpc.Client(cmd.Flags())
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), err)
+	}
+	pairs, err := rpcClient.PairList()
+	if err != nil {
+		internal.PrintFatalError(cmd.Flags(), fmt.Errorf("PairList: %w", err))
+	}
+	if len(pairs) == 0 {
+		internal.PrintOutput(cmd.Flags(), pairs, "No pairs registered.\n")
+		return
+	}
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "PEER\tSTATUS\tPORT\tESTABLISHED\tLAST MSG") //nolint:errcheck,gosec
+	for _, p := range pairs {
+		last := "-"
+		if !p.LastMessageAt.IsZero() {
+			last = p.LastMessageAt.UTC().Format(time.RFC3339)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", //nolint:errcheck,gosec
+			truncatePK(p.PeerPK),
+			p.Status, p.Port,
+			p.EstablishedAt.UTC().Format(time.RFC3339),
+			last)
+	}
+	w.Flush() //nolint:errcheck,gosec
+	internal.PrintOutput(cmd.Flags(), pairs, buf.String())
+}
+
+func truncatePK(pk cipher.PubKey) string {
+	s := pk.Hex()
+	if len(s) > 16 {
+		return s[:16] + "..."
+	}
+	return s
+}

--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -110,9 +110,15 @@ func (c *Conn) run() {
 	c.n.removeConn(c)
 
 	// Remove from transport cache and close the underlying connection.
+	// IsTCP() distinguishes TCP from UDP, but DMSG connections also
+	// have IsTCP()==false and don't have a UDP transport. Nil-check
+	// each so a DMSG-only node (NewWithDMSG path: TCP/UDP listeners
+	// disabled) doesn't panic when its conns close.
 	if c.IsTCP() {
-		c.n.tcp.closeConn(c.Address()) //nolint:errcheck,gosec
-	} else {
+		if c.n.tcp != nil {
+			c.n.tcp.closeConn(c.Address()) //nolint:errcheck,gosec
+		}
+	} else if c.n.udp != nil {
 		c.n.udp.closeConn(c.Address()) //nolint:errcheck,gosec
 	}
 

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -129,6 +129,13 @@ type PubConfig struct {
 // owns the node — Close releases both.
 func NewWithDMSG(dmsgC *dmsg.Client, sk cipher.SecKey, conf PubConfig) (*Publisher, error) {
 	cfg := node.NewConfig()
+	// Bind the CXO node's identity to the publisher's keypair so the
+	// node's handshake-advertised PK matches the feed PK. Otherwise
+	// the CXO node generates a random keypair and remote peers see a
+	// different PK than they expect from the feed metadata — which
+	// breaks any subscriber-allowlist that uses the feed PK as the
+	// gating identity (the per-pair-feed pattern relies on this).
+	cfg.SecKey = skycipher.SecKey(sk)
 	cfg.Config = skyobject.NewConfig()
 	cfg.Config.InMemoryDB = conf.InMemoryDB
 	if conf.DataDir != "" {
@@ -230,6 +237,16 @@ func New(cxoNode *node.Node, sk cipher.SecKey, conf Config) (*Publisher, error) 
 // this PK.
 func (p *Publisher) Feed() cipher.PubKey {
 	return p.pk
+}
+
+// Node returns the underlying CXO node. Exposed so callers can
+// attach a Subscriber to the same node via NewSubscriberOnNode —
+// the per-pair-feed pattern uses one node per pair side, listening
+// on the deterministic pair port, hosting both the publisher's own
+// feed and a subscriber to the peer's feed. Mutating the returned
+// node directly is unsupported; treat it as read-only state.
+func (p *Publisher) Node() *node.Node {
+	return p.cxoNode
 }
 
 // SetAllowlist atomically replaces the subscriber allowlist. nil

--- a/pkg/cxo/treestore/subscriber.go
+++ b/pkg/cxo/treestore/subscriber.go
@@ -50,8 +50,9 @@ type UpdateCallback func(changes []UpdateEvent)
 type Subscriber struct {
 	log *logging.Logger
 
-	cxoNode *node.Node
-	feedPK  cipher.PubKey
+	cxoNode  *node.Node
+	ownsNode bool // when true, Close releases the node; false = caller owns
+	feedPK   cipher.PubKey
 
 	mu       sync.RWMutex
 	cache    map[string][]byte
@@ -96,6 +97,13 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 	if conf.DataDir != "" {
 		cfg.Config.DataDir = conf.DataDir
 	}
+	// We're DMSG-only — disable the CXO node's default TCP/UDP/RPC
+	// listeners (mirrors NewWithDMSG). Hardcoded ports otherwise
+	// mean two Subscribers in the same process collide on bind, which
+	// is the common case for per-pair-feed callers.
+	cfg.TCP.Listen = ""
+	cfg.UDP.Listen = ""
+	cfg.RPC = ""
 
 	cxoNode, err := node.NewNode(cfg)
 	if err != nil {
@@ -113,14 +121,50 @@ func NewSubscriber(dmsgC *dmsg.Client, feedPK cipher.PubKey, conf SubConfig) (*S
 	}
 
 	s := &Subscriber{
-		log:     conf.Logger,
-		cxoNode: cxoNode,
-		feedPK:  feedPK,
-		cache:   make(map[string][]byte),
+		log:      conf.Logger,
+		cxoNode:  cxoNode,
+		ownsNode: true,
+		feedPK:   feedPK,
+		cache:    make(map[string][]byte),
 	}
 
 	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
 		s.handleRootFilled(r)
+	}
+	return s, nil
+}
+
+// NewSubscriberOnNode attaches a Subscriber to an existing CXO node.
+// Caller retains ownership of the node — the Subscriber's Close does
+// NOT release it.
+//
+// Use case: per-pair feeds where one CXO node hosts both a publisher
+// (owning its own feed) AND a subscriber (to the peer's feed). Two
+// separate nodes don't work there because both would Listen on the
+// same deterministic pair port and collide.
+//
+// The OnRootFilled callback is set on the node's config — the existing
+// callback is preserved if the new subscription's feed PK doesn't
+// match the incoming Root, so multiple subscribers can coexist on the
+// same node by chaining handlers. Today only single-subscriber-per-node
+// is exercised; chaining is a future extension.
+func NewSubscriberOnNode(cxoNode *node.Node, feedPK cipher.PubKey, conf SubConfig) (*Subscriber, error) {
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("cxo-treestore-sub")
+	}
+	s := &Subscriber{
+		log:      conf.Logger,
+		cxoNode:  cxoNode,
+		ownsNode: false,
+		feedPK:   feedPK,
+		cache:    make(map[string][]byte),
+	}
+	prev := cxoNode.Config().OnRootFilled
+	cxoNode.Config().OnRootFilled = func(n *node.Node, r *registry.Root) {
+		s.handleRootFilled(r)
+		if prev != nil {
+			prev(n, r)
+		}
 	}
 	return s, nil
 }
@@ -212,7 +256,9 @@ func (s *Subscriber) OnUpdate(cb UpdateCallback) {
 	s.mu.Unlock()
 }
 
-// Close stops the subscriber and releases the embedded CXO node.
+// Close stops the subscriber. When the subscriber owns its CXO node
+// (the NewSubscriber path), the node is also released; in
+// NewSubscriberOnNode mode the caller retains ownership.
 // Idempotent.
 func (s *Subscriber) Close() error {
 	s.closeMu.Lock()
@@ -221,7 +267,9 @@ func (s *Subscriber) Close() error {
 		return s.closeErr
 	}
 	s.closed = true
-	s.closeErr = s.cxoNode.Close()
+	if s.ownsNode {
+		s.closeErr = s.cxoNode.Close()
+	}
 	return s.closeErr
 }
 

--- a/pkg/visor/cxo_user_feeds.go
+++ b/pkg/visor/cxo_user_feeds.go
@@ -88,13 +88,11 @@ func (v *Visor) RegisterCXOFeed(name string, dmsgPort uint16, description string
 		return fmt.Errorf("cxo feed: dmsg port %d reserved for %s", dmsgPort, used)
 	}
 	// Reject ports inside the chat-pair allocator's deterministic
-	// range. A user feed at a pair-publisher port would shadow some
-	// pair's outbox; at a pair-subscriber port it would collide with
-	// some subscriber's local listener. Both are silent, hard-to-
-	// debug failures for the affected pair, so reject up front.
-	if dmsgPort >= pairing.PubBase && dmsgPort < pairing.SubBase+pairing.PubSpan {
+	// range. A user feed there would shadow some pair's CXO node,
+	// causing silent, hard-to-debug failures for the affected pair.
+	if dmsgPort >= pairing.PortBase && dmsgPort < pairing.PortBase+pairing.PortSpan {
 		return fmt.Errorf("cxo feed: dmsg port %d reserved for chat-pair feeds (range [%d, %d))",
-			dmsgPort, pairing.PubBase, pairing.SubBase+pairing.PubSpan)
+			dmsgPort, pairing.PortBase, pairing.PortBase+pairing.PortSpan)
 	}
 	if v.dmsgC == nil {
 		return errors.New("cxo feed: dmsg client not available")

--- a/pkg/visor/pairing.go
+++ b/pkg/visor/pairing.go
@@ -24,13 +24,11 @@ import (
 // PairInfo is the public summary of a chat pair, returned by PairList
 // and used as the poll cursor for PairPoll.
 type PairInfo struct {
-	PeerPK         cipher.PubKey  `json:"peer_pk"`
-	Status         pairing.Status `json:"status"`
-	MyPort         uint16         `json:"my_port"`
-	PeerPort       uint16         `json:"peer_port"`
-	SubscriberPort uint16         `json:"subscriber_port"`
-	EstablishedAt  time.Time      `json:"established_at"`
-	LastMessageAt  time.Time      `json:"last_message_at,omitempty"`
+	PeerPK        cipher.PubKey  `json:"peer_pk"`
+	Status        pairing.Status `json:"status"`
+	Port          uint16         `json:"port"`
+	EstablishedAt time.Time      `json:"established_at"`
+	LastMessageAt time.Time      `json:"last_message_at,omitempty"`
 }
 
 // PairMessage is one inbound message delivered through the visor's
@@ -95,13 +93,11 @@ func (v *Visor) PairList() ([]PairInfo, error) {
 	out := make([]PairInfo, 0, len(records))
 	for _, r := range records {
 		out = append(out, PairInfo{
-			PeerPK:         r.PeerPK,
-			Status:         r.Status,
-			MyPort:         r.MyPort,
-			PeerPort:       r.PeerPort,
-			SubscriberPort: r.SubscriberPort,
-			EstablishedAt:  r.EstablishedAt,
-			LastMessageAt:  r.LastMessageAt,
+			PeerPK:        r.PeerPK,
+			Status:        r.Status,
+			Port:          r.Port,
+			EstablishedAt: r.EstablishedAt,
+			LastMessageAt: r.LastMessageAt,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {


### PR DESCRIPTION
## Summary

PR-4 of the skychat-on-CXO sequence. Adds CLI surface for the visor's
chat-pair feed manager (#2380) and an end-to-end integration test that
proves the full pipeline works against a real DMSG mesh.

Writing the integration test surfaced four architecture issues from
PR-2/PR-3 that this PR fixes — see the commit for details. None of
them shipped to a real consumer yet, so no migration concerns.

## CLI surface

\`\`\`
cli visor pair                   # status (list)
cli visor pair add <peer-pk>     # register a pair
cli visor pair ls                # explicit list
cli visor pair rm <peer-pk>      # tear down
cli visor pair send <peer-pk> <text>
cli visor pair poll [--since RFC3339]
\`\`\`

Useful for testing the pipeline without skychat HTTP (which lands in
a later PR), and for scripted integration setups.

## Architecture cleanup

1. **One CXO node per pair side, not two.** Originally PR-2 had
   separate publisher and subscriber nodes per pair on different
   DMSG ports. That doesn't work because \`DMSGFactory\` uses one port
   for both listen and dial — Bob's subscriber dialing at his own
   subscriber port goes nowhere because Alice listens at the
   publisher port. Switched to one CXO node per pair side, listening
   on the deterministic pair port, hosting both publisher (own feed)
   and subscriber (peer's feed) by feed PK. Both sides use the same
   port number — pair port is symmetric.

2. **CXO node identity must match the feed PK.** \`node.Config.SecKey\`
   was unset, so \`NewNode\` generated a random keypair and the
   handshake-advertised \`PeerID()\` didn't match the visor PK that
   the subscriber-allowlist was checking against. \`NewWithDMSG\` now
   binds \`cfg.SecKey\` to the publisher's secret key.

3. **DMSG-only nodes panicked on conn close** because \`conn.run\`'s
   cleanup dispatched to \`udp.closeConn\` for non-TCP conns, but
   \`NewWithDMSG\` disables UDP. Added a nil-check.

4. **\`NewSubscriberOnNode\`** attaches a Subscriber to an existing
   CXO node (caller retains ownership; Close doesn't release the
   node). Lets one CXO node host both publisher and subscriber.

5. **Subscriber config also disables TCP/UDP/RPC listeners** —
   multiple subscribers in one process were colliding on hardcoded
   \`:8870\` / \`:8871\`. Mirrors what \`Publisher.NewWithDMSG\` already does.

## API simplification

\`PairPorts\` struct collapsed to a single \`ComputePairPort\` returning
\`uint16\`; \`SubscriberPort\` / \`PeerPort\` / \`MyPort\` fields collapsed
to a single \`Port\`. The Record schema is simpler as a result.

## Integration test

\`cmd/apps/skychat/pairing/integration_test.go\`:

- Spins up a 1-server / 2-client dmsg mesh via \`dmsgtest\`
- Wires two \`pairing.Manager\`s with shared PK/SK pairs (mirrors visor)
- Both ends \`Add\` each other's PK
- A → B and B → A messages, verified in the inbound handlers

Skipped under \`-short\` because the in-process DMSG mesh + CXO node
startup add a few seconds. Locally stable across 5 consecutive runs.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/cxo/... ./pkg/visor/... ./cmd/apps/skychat/...\` passes
- [x] Integration test stable: 5 consecutive runs all pass
- [x] \`golangci-lint\` clean across touched packages
- [x] \`cli visor pair --help\` renders correctly

## What's next

- **PR-5**: skychat HTTP/handshake — \`POST /pair\`, SSE integration,
  \`pair-invite\` / \`pair-ack\` over the legacy direct path.
- **PR-6**: UI (add-contact dialog, contact list, picker).
- **PR-7**: ECDH body encryption.
- **PR-8**: default-on, legacy mode behind a flag for CI.