### PR TITLE
perf(dmsgd): keep entry cache populated on SetEntry, not invalidated

### DIFF
--- a/pkg/dmsg/discovery/store/redis.go
+++ b/pkg/dmsg/discovery/store/redis.go
@@ -101,7 +101,17 @@ func (r *redisStore) SetEntry(ctx context.Context, entry *disc.Entry, timeout ti
 		log.WithError(err).Errorf("Failed to set entry in redis")
 		return disc.ErrUnexpected
 	}
-	r.cache.invalidate(entry.Static)
+	// Store the just-written entry in the cache. Previously this was
+	// cache.invalidate, which forced the next reader to round-trip
+	// Redis to refill the slot — pathological for hot PKs (dmsg-servers
+	// repost on every session count change at 5-15 Hz; their entry is
+	// also among the most-queried keys, so each post dropped the next
+	// hundred-or-so reads through to Redis). Since SetEntry has the
+	// canonical post-write value in hand and has just confirmed Redis
+	// accepted it, populating the cache directly is both correct and
+	// drastically more efficient. The cache TTL still bounds staleness
+	// for the case where a Redis-side TTL silently expires the key.
+	r.cache.set(entry.Static, entry)
 
 	if entry.Server != nil {
 		err = r.client.SAdd(ctx, "servers", entry.Static.Hex()).Err()


### PR DESCRIPTION
## Summary

The dmsg-discovery entry cache (`pkg/dmsg/discovery/store/entry_cache.go`) was being invalidated on every `SetEntry`, which is pathological for hot PKs:

- dmsg-server entries are reposted on every session-count change — observed at 5–15 Hz in production (dmsg-server-1's sequence number incremented ~5/sec at the time of profiling).
- The same dmsg-server PKs are among the most-queried entry keys: in a 30s production sample, 100–220 `GET /entry/{pk}` hits per server PK; the top 10 PKs accounted for ~30% of all entry reads.
- After each SetEntry-driven invalidation, the next ~100 reads dropped through to Redis to refill the slot, only for the cycle to repeat seconds later when the server reposted.

`SetEntry` already holds the canonical post-write value (the entry the caller just signed and we just persisted to Redis). Populate the cache with it directly instead of dropping the slot.

The cache TTL (5s) still bounds staleness against the case where a Redis-side TTL silently expires the key. `DelEntry` continues to `invalidate` (entry is gone, not updated). No interface or behavior change for callers.

## Expected impact

dmsg-discovery was seen at ~30% CPU on a 4-core deployment host serving ~545 req/sec, with `secp256k1` signature verification and Redis round-trips dominating the profile. This change collapses read traffic to Redis for hot PKs from "every-write-plus-cache-misses" to "once-per-TTL", which should remove a noticeable chunk of Redis pressure and the corresponding `Syscall6` time. Visor-side query latency for hot PKs improves to a single in-process map lookup.

## Test plan
- [ ] `go test ./pkg/dmsg/discovery/...` passes (verified locally; `TestEntryCache_*` plus `pkg/dmsg/discovery/api`)
- [ ] Manual verification post-deploy: sample `pprof` on dmsg-discovery — `Syscall6` and `redis.cmdable.Get` should drop noticeably; CPU% per dmsg-discovery container should decrease.
- [ ] `redis-cli info commandstats` before/after should show fewer `cmdstat_get` calls relative to `cmdstat_set`.