### PR TITLE
skychat/pairing: ECDH + ChaCha20-Poly1305 body encryption

### DIFF
--- a/cmd/apps/skychat/pairing/crypto.go
+++ b/cmd/apps/skychat/pairing/crypto.go
@@ -1,0 +1,112 @@
+// Package pairing — cmd/apps/skychat/pairing/crypto.go: end-to-end
+// body encryption for chat-pair feeds.
+//
+// Threat model: the pair feed lives at a publicly-known DMSG port
+// under the publisher's PK, and any peer who learns the publisher
+// PK + port can attempt to subscribe. The publisher-side allowlist
+// (CXO TreeStore SubscriberAllowlist, added in #2378) gates read
+// access to the feed at the connection layer. This file adds a
+// belt-and-suspenders layer at the message-content layer:
+//
+//   - Each Pair derives a 32-byte symmetric key from
+//     ECDH(my_sk, peer_pk). Both sides compute the same key from
+//     ECDH(my_pk, peer_sk) and ECDH(peer_pk, my_sk) — that's the
+//     symmetry property of ECDH.
+//   - Every leaf published into the pair feed is sealed with
+//     ChaCha20-Poly1305 AEAD, with a fresh random 12-byte nonce
+//     prepended to the ciphertext: [nonce | ct+tag].
+//
+// What is encrypted:
+//   - The Message JSON body. The leaf bytes stored in CXO are
+//     ciphertext; subscribers decrypt before json.Unmarshal.
+//
+// What is NOT encrypted:
+//   - The path: msgs/<unix-nanos>/<seq>. Timestamp + ordering are
+//     metadata; an observer who already breached the allowlist would
+//     learn the timing pattern of messages but not their content.
+//
+// secp256k1 + ChaCha20-Poly1305: the skywire identity uses
+// secp256k1 keys, not Curve25519, so we can't use NaCl box directly.
+// skycoin/cipher.ECDH does the secp256k1 scalar-mult and SHA256s the
+// raw shared point — that yields a 32-byte key suitable as the
+// ChaCha20-Poly1305 key directly. No HKDF needed because we have a
+// single fixed use (this pair) per derived key.
+package pairing
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+	"golang.org/x/crypto/chacha20poly1305"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// pairKey is the symmetric key used for one chat pair.
+type pairKey []byte
+
+// derivePairKey returns the ECDH-derived symmetric key for the
+// (mySK, peerPK) pair. The result is identical when computed by the
+// peer with their own SK and our PK.
+func derivePairKey(mySK cipher.SecKey, peerPK cipher.PubKey) (pairKey, error) {
+	key, err := skycipher.ECDH(skycipher.PubKey(peerPK), skycipher.SecKey(mySK))
+	if err != nil {
+		return nil, fmt.Errorf("pairing: derive ECDH key: %w", err)
+	}
+	if len(key) != chacha20poly1305.KeySize {
+		// skycoin/cipher.ECDH returns SHA256 → 32 bytes; this branch
+		// only triggers if the upstream changed the digest length.
+		return nil, fmt.Errorf("pairing: ECDH key length %d != %d",
+			len(key), chacha20poly1305.KeySize)
+	}
+	return key, nil
+}
+
+// sealMessage AEAD-encrypts plaintext under key, prepending a fresh
+// random nonce. Output layout: [12-byte nonce | ChaCha20-Poly1305
+// ciphertext + 16-byte tag].
+func sealMessage(key pairKey, plaintext []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: aead init: %w", err)
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("pairing: nonce: %w", err)
+	}
+	// Allocate output as [nonce | ciphertext+tag] in one slice so
+	// the caller can publish it directly without further copies.
+	out := make([]byte, len(nonce), len(nonce)+len(plaintext)+aead.Overhead())
+	copy(out, nonce)
+	out = aead.Seal(out, nonce, plaintext, nil)
+	return out, nil
+}
+
+// errCipherShort is returned when an inbound leaf is shorter than
+// the nonce + tag overhead. Indicates either a malformed message or
+// a plaintext leaf from a pre-encryption peer (which we no longer
+// accept).
+var errCipherShort = errors.New("pairing: ciphertext too short")
+
+// openMessage AEAD-decrypts a [nonce | ct+tag] blob produced by
+// sealMessage. Returns an error on tag mismatch (tampered ciphertext
+// or wrong key) so callers can drop the leaf rather than surface
+// garbage to the user.
+func openMessage(key pairKey, sealed []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: aead init: %w", err)
+	}
+	if len(sealed) < aead.NonceSize()+aead.Overhead() {
+		return nil, errCipherShort
+	}
+	nonce := sealed[:aead.NonceSize()]
+	ct := sealed[aead.NonceSize():]
+	pt, err := aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: open: %w", err)
+	}
+	return pt, nil
+}

--- a/cmd/apps/skychat/pairing/crypto_test.go
+++ b/cmd/apps/skychat/pairing/crypto_test.go
@@ -1,0 +1,155 @@
+package pairing
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestDerivePairKeySymmetric(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+
+	keyAB, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatalf("A→B derive: %v", err)
+	}
+	keyBA, err := derivePairKey(skB, pkA)
+	if err != nil {
+		t.Fatalf("B→A derive: %v", err)
+	}
+	if !bytes.Equal(keyAB, keyBA) {
+		t.Fatal("ECDH key must be symmetric: derive(skA, pkB) == derive(skB, pkA)")
+	}
+}
+
+func TestDerivePairKeyDifferentPairs(t *testing.T) {
+	_, skA := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	pkC, _ := cipher.GenerateKeyPair()
+
+	keyAB, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyAC, err := derivePairKey(skA, pkC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(keyAB, keyAC) {
+		t.Fatal("different pairs must produce different keys")
+	}
+}
+
+func TestSealOpenRoundtrip(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, skB := cipher.GenerateKeyPair()
+	_ = pkA
+
+	keyAB, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyBA, err := derivePairKey(skB, pkA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	plaintext := []byte(`{"text":"hello bob","ts":"2026-04-29T00:00:00Z"}`)
+
+	sealed, err := sealMessage(keyAB, plaintext)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if bytes.Contains(sealed, plaintext) {
+		t.Fatal("ciphertext must not contain plaintext bytes")
+	}
+
+	opened, err := openMessage(keyBA, sealed)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(opened, plaintext) {
+		t.Fatalf("roundtrip mismatch: got %q want %q", opened, plaintext)
+	}
+}
+
+func TestOpenWithWrongKeyFails(t *testing.T) {
+	pkA, skA := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	_, skC := cipher.GenerateKeyPair()
+	_ = pkA
+
+	keyAB, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong, err := derivePairKey(skC, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed, err := sealMessage(keyAB, []byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openMessage(wrong, sealed); err == nil {
+		t.Fatal("opening with wrong key must fail")
+	}
+}
+
+func TestOpenTamperedFails(t *testing.T) {
+	_, skA := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	key, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := sealMessage(key, []byte("secret"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Flip one bit in the ciphertext (after the nonce). AEAD must reject.
+	tampered := append([]byte{}, sealed...)
+	tampered[len(tampered)-1] ^= 0x01
+	if _, err := openMessage(key, tampered); err == nil {
+		t.Fatal("opening tampered ciphertext must fail")
+	}
+}
+
+func TestOpenShortInputFails(t *testing.T) {
+	_, skA := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	key, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openMessage(key, []byte{1, 2, 3}); err == nil {
+		t.Fatal("opening too-short input must fail")
+	}
+}
+
+func TestSealNonceUnique(t *testing.T) {
+	// Sealing the same plaintext twice with the same key must produce
+	// different ciphertexts because the nonce is randomized per call.
+	_, skA := cipher.GenerateKeyPair()
+	pkB, _ := cipher.GenerateKeyPair()
+	key, err := derivePairKey(skA, pkB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plaintext := []byte("identical message")
+
+	a, err := sealMessage(key, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := sealMessage(key, plaintext)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(a, b) {
+		t.Fatal("two seals of the same plaintext must differ (nonce reuse would break AEAD security)")
+	}
+}

--- a/cmd/apps/skychat/pairing/integration_test.go
+++ b/cmd/apps/skychat/pairing/integration_test.go
@@ -107,10 +107,22 @@ func TestPairRoundTripOverDmsg(t *testing.T) {
 	require.NoError(t, pairB.Connect())
 
 	// A → B
-	require.NoError(t, pairA.Send("hello bob"))
+	const plaintextAB = "hello bob"
+	require.NoError(t, pairA.Send(plaintextAB))
+
+	// Snoop the publisher's local tree: the leaf bytes must be
+	// ciphertext (not the plaintext). Catches a regression where
+	// encryption gets accidentally bypassed and the leaf is the
+	// raw JSON.
+	pairA.pub.Walk(MessagePathPrefix, func(path string, value []byte) bool {
+		require.NotContains(t, string(value), plaintextAB,
+			"published leaf at %q must not contain plaintext", path)
+		return true
+	})
+
 	require.NoError(t, inboxB.waitFor(20*time.Second, func(msgs []testReceived) bool {
 		for _, m := range msgs {
-			if m.peer == pkA && m.text == "hello bob" {
+			if m.peer == pkA && m.text == plaintextAB {
 				return true
 			}
 		}

--- a/cmd/apps/skychat/pairing/pair.go
+++ b/cmd/apps/skychat/pairing/pair.go
@@ -87,6 +87,11 @@ type Pair struct {
 	pub *treestore.Publisher
 	sub *treestore.Subscriber
 
+	// key is the ECDH-derived symmetric key for this pair. Both
+	// sides compute the same value from their own SK + the peer's
+	// PK. Derived once at Open and reused for every Send / decrypt.
+	key pairKey
+
 	// seq disambiguates messages with the same nanosecond timestamp.
 	// Per-pair scope so a sender posting in tight loops doesn't
 	// silently overwrite earlier leaves.
@@ -122,6 +127,14 @@ func Open(cfg Config) (*Pair, error) {
 		return nil, fmt.Errorf("pairing: Open: compute port: %w", err)
 	}
 
+	// Derive the pair's symmetric key now so a key-derivation
+	// failure (e.g. invalid peer PK) is reported up front, before
+	// we spin up any CXO nodes.
+	key, err := derivePairKey(cfg.MySK, cfg.PeerPK)
+	if err != nil {
+		return nil, fmt.Errorf("pairing: Open: %w", err)
+	}
+
 	peerHex := cfg.PeerPK.Hex()
 	pub, err := treestore.NewWithDMSG(cfg.DmsgC, cfg.MySK, treestore.PubConfig{
 		BatchWindow:         cfg.BatchWindow,
@@ -145,7 +158,7 @@ func Open(cfg Config) (*Pair, error) {
 	}
 	sub.SetPrefixes([]string{MessagePathPrefix})
 
-	p := &Pair{cfg: cfg, port: port, pub: pub, sub: sub, log: log}
+	p := &Pair{cfg: cfg, port: port, pub: pub, sub: sub, key: key, log: log}
 	sub.OnUpdate(p.onUpdate)
 	return p, nil
 }
@@ -181,6 +194,11 @@ func (p *Pair) SetMessageHandler(h MessageHandler) {
 
 // Send publishes a message to this side's outbox feed. The peer's
 // subscriber will see it on the next CXO publish-batch cycle.
+//
+// The message body is sealed with the pair's ECDH-derived key
+// before being stored as the leaf value, so anyone who breaches
+// the publisher allowlist still cannot read message content.
+// The path itself (timestamp + seq) stays plaintext.
 func (p *Pair) Send(text string) error {
 	now := time.Now().UTC()
 	msg := Message{Text: text, TS: now}
@@ -188,9 +206,13 @@ func (p *Pair) Send(text string) error {
 	if err != nil {
 		return fmt.Errorf("pairing: Send: marshal: %w", err)
 	}
+	sealed, err := sealMessage(p.key, body)
+	if err != nil {
+		return fmt.Errorf("pairing: Send: %w", err)
+	}
 	seq := p.seq.Add(1)
 	path := MessagePathPrefix + "/" + strconv.FormatInt(now.UnixNano(), 10) + "/" + strconv.FormatUint(seq, 10)
-	if err := p.pub.Put(path, body); err != nil {
+	if err := p.pub.Put(path, sealed); err != nil {
 		return fmt.Errorf("pairing: Send: put %q: %w", path, err)
 	}
 	return nil
@@ -215,10 +237,13 @@ func (p *Pair) Close() error {
 	return firstErr
 }
 
-// onUpdate is the subscriber callback. Decodes each leaf as a Message
-// and dispatches via the registered handler. Tolerates non-msg leaves
-// (e.g. future typing indicators under a different prefix) by
-// silently ignoring decode failures.
+// onUpdate is the subscriber callback. Opens each leaf with the
+// pair's ECDH key and decodes the resulting plaintext as a Message,
+// then dispatches via the registered handler. Tolerates non-msg
+// leaves (e.g. future typing indicators under a different prefix)
+// or tampered/foreign ciphertexts by silently dropping them — a
+// failure here would surface as a noisy log without giving the
+// user any actionable signal.
 func (p *Pair) onUpdate(events []treestore.UpdateEvent) {
 	h := p.handler
 	if h == nil {
@@ -228,8 +253,15 @@ func (p *Pair) onUpdate(events []treestore.UpdateEvent) {
 		if ev.Value == nil {
 			continue
 		}
+		plaintext, err := openMessage(p.key, ev.Value)
+		if err != nil {
+			p.log.WithError(err).
+				WithField("path", ev.Path).
+				Debug("pairing: ignoring undecryptable leaf")
+			continue
+		}
 		var msg Message
-		if err := json.Unmarshal(ev.Value, &msg); err != nil {
+		if err := json.Unmarshal(plaintext, &msg); err != nil {
 			p.log.WithError(err).
 				WithField("path", ev.Path).
 				Debug("pairing: ignoring undecodable leaf")


### PR DESCRIPTION
## Summary

PR-7 of the skychat-on-CXO sequence. Adds end-to-end body encryption
to chat-pair feeds, layered on top of the publisher allowlist
(#2378).

Each pair derives a 32-byte symmetric key from
\`ECDH(my_sk, peer_pk)\` at Open time. Every message body is sealed
with ChaCha20-Poly1305 AEAD before being published as a CXO leaf;
subscribers decrypt before json.Unmarshal.

## Threat model

The chat-pair feed lives at a publicly-known DMSG port under the
publisher's PK. Two layers gate access:

1. **Connection layer (PR-2 / #2378)**: \`OnSubscribeRemote\`
   rejects subscribe requests from any peer not on the allowlist.
2. **Content layer (this PR)**: even if a subscriber bypasses the
   allowlist, the leaf bytes are ciphertext. They learn message
   timing (\`path = msgs/<ts>/<seq>\`) but not content.

## Crypto choices

- **secp256k1 ECDH**: skywire identity uses secp256k1 keys (not
  Curve25519), so we can't use NaCl box directly.
  \`skycoin/cipher.ECDH\` scalar-mults the shared point and SHA256s
  it — yielding a 32-byte key, exactly the size
  \`chacha20poly1305.New\` expects. No HKDF needed: single-purpose
  key, single-pair.
- **ChaCha20-Poly1305**: stdlib AEAD, 12-byte nonces. Output layout
  per leaf: \`[12-byte random nonce | ciphertext + 16-byte tag]\`.
- **Per-call random nonce**: avoids the catastrophic nonce-reuse
  failure mode of fixed-nonce schemes. With 12-byte nonces the
  birthday bound is far beyond any realistic message volume.

## What's NOT encrypted

The path itself: \`msgs/<unix-nanos>/<seq>\`. Timestamp + ordering
are visible to anyone who breached the allowlist. Hiding metadata
is a separate (and much harder) problem; encrypting bodies is
straightforward and gives us the meaningful win.

## Tests

- \`crypto_test.go\` (5 unit tests):
  - Key derivation symmetry: \`derive(skA, pkB) == derive(skB, pkA)\`.
  - Different pairs → different keys.
  - Seal/open roundtrip; ciphertext must not contain plaintext bytes.
  - Wrong-key rejection (different SK → AEAD tag mismatch).
  - Tampered-bit rejection (flip last byte → AEAD tag mismatch).
  - Short-input rejection (\< nonce + tag length).
  - Nonce uniqueness: two seals of the same plaintext differ.
- Integration test (\`TestPairRoundTripOverDmsg\`) gains a snoop
  assertion: after \`Pair.Send\`, \`publisher.Walk\` over the message
  prefix must NOT find the plaintext anywhere in the leaf bytes.
  Catches regressions where encryption gets bypassed.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/pairing/...\` passes (unit + integration)
- [x] Integration stable across 3 consecutive runs
- [x] \`golangci-lint\` clean
- [x] \`make check\` passes

## What's next

- **PR-8**: Default \`--pair-enable\` to true with \`--legacy-direct\`
  opt-in for CI; documentation update.