### PR TITLE
skychat: consent-based pair-invite flow with accept/decline UI

### DIFF
--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -13,14 +13,17 @@
 // Handshake flow (Alice initiates with Bob):
 //
 //  1. Alice's UI: POST /pair {peer_pk: bob}
-//  2. Skychat: visor.PairAdd(bob); send {type:"pair-invite", from_pk:alice}
-//     to Bob via legacy direct dial.
-//  3. Bob's skychat handleConn: recognizes pair-invite, calls
-//     visor.PairAdd(alice) on his side; replies {type:"pair-ack",
-//     from_pk:bob} on the same legacy connection.
-//  4. Alice's skychat handleConn: recognizes pair-ack — both sides
-//     now have publishers up; CXO subscribers connect on the next
-//     publish-batch cycle.
+//  2. Alice's skychat: visor.PairAdd(bob) (status pending);
+//     send {type:"pair-invite"} to Bob via legacy direct dial.
+//  3. Bob's skychat handleConn: stores invite in pending set,
+//     pushes a channel="pair-invite" SSE event so the UI shows
+//     accept/decline buttons. NO automatic PairAdd on Bob's side.
+//  4. Bob accepts via UI → POST /pair/invites/<alice>/accept:
+//     visor.PairAdd(alice) + visor.PairMarkActive(alice); send
+//     {type:"pair-ack"} to alice. (Decline path sends
+//     {type:"pair-decline"} and drops the pending entry.)
+//  5. Alice's skychat handleConn: pair-ack → visor.PairMarkActive(bob);
+//     pair-decline → visor.PairRemove(bob). Both sides now in sync.
 //
 // Legacy plain-text DMs continue to work alongside the structured
 // envelope: handleConn first tries to JSON-decode each frame; on
@@ -36,6 +39,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/skycoin/skywire/pkg/app/appnet"
@@ -67,9 +71,77 @@ type pairMsg struct {
 }
 
 const (
-	pairTypeInvite = "pair-invite"
-	pairTypeAck    = "pair-ack"
+	pairTypeInvite  = "pair-invite"
+	pairTypeAck     = "pair-ack"
+	pairTypeDecline = "pair-decline"
 )
+
+// pendingInvite is one inbound pair-invite that the user hasn't yet
+// acted on. Stored in skychat memory only; lost on restart (a peer
+// can re-invite if the connection is re-established).
+type pendingInvite struct {
+	PeerPK     cipher.PubKey `json:"peer_pk"`
+	ReceivedAt time.Time     `json:"received_at"`
+}
+
+var (
+	pendingInvitesMu sync.Mutex
+	pendingInvites   = map[cipher.PubKey]pendingInvite{}
+)
+
+// pendingPut records a fresh invite. Idempotent — re-invites from the
+// same peer just bump the timestamp.
+func pendingPut(peerPK cipher.PubKey) {
+	pendingInvitesMu.Lock()
+	defer pendingInvitesMu.Unlock()
+	pendingInvites[peerPK] = pendingInvite{PeerPK: peerPK, ReceivedAt: time.Now().UTC()}
+}
+
+// pendingDelete drops a pending invite (called on accept/decline).
+func pendingDelete(peerPK cipher.PubKey) {
+	pendingInvitesMu.Lock()
+	delete(pendingInvites, peerPK)
+	pendingInvitesMu.Unlock()
+}
+
+// pendingHas reports whether peerPK has an outstanding invite.
+func pendingHas(peerPK cipher.PubKey) bool {
+	pendingInvitesMu.Lock()
+	_, ok := pendingInvites[peerPK]
+	pendingInvitesMu.Unlock()
+	return ok
+}
+
+// pendingList returns a snapshot copy of the pending set.
+func pendingList() []pendingInvite {
+	pendingInvitesMu.Lock()
+	defer pendingInvitesMu.Unlock()
+	out := make([]pendingInvite, 0, len(pendingInvites))
+	for _, inv := range pendingInvites {
+		out = append(out, inv)
+	}
+	return out
+}
+
+// notifyInviteSSE pushes a structured envelope onto clientCh so the
+// browser hears about new invites in real time. Drops if clientCh is
+// full so a slow SSE consumer doesn't block the handshake handler.
+func notifyInviteSSE(peerPK cipher.PubKey, kind string) {
+	envelope := map[string]string{
+		"channel": "pair-invite",
+		"event":   kind, // "received" | "accepted" | "declined"
+		"peer":    peerPK.Hex(),
+		"ts":      time.Now().UTC().Format(time.RFC3339Nano),
+	}
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return
+	}
+	select {
+	case clientCh <- string(body):
+	default:
+	}
+}
 
 // connectPairRPC dials the local visor's RPC and stores the client
 // in pairRPC. Best-effort — a failure logs and disables pairing for
@@ -154,12 +226,102 @@ func stopPairPoller() {
 
 // registerPairHTTPHandlers wires the /pair endpoints onto mux.
 // No-op when --pair-enable is false.
+//
+// Pattern precedence: net/http picks the longest matching prefix, so
+// /pair/invites and /pair/invites/ shadow /pair/ for the invite
+// subtree. This lets the invite handlers be cleanly separate from
+// the per-pair item handler without parsing the path twice.
 func registerPairHTTPHandlers(ctx context.Context) {
 	if !pairEnable {
 		return
 	}
 	http.HandleFunc("/pair", pairRootHandler(ctx))
+	http.HandleFunc("/pair/invites", pairInvitesListHandler())
+	http.HandleFunc("/pair/invites/", pairInvitesItemHandler(ctx))
 	http.HandleFunc("/pair/", pairItemHandler(ctx))
+}
+
+// pairInvitesListHandler serves GET /pair/invites — current pending
+// invites.
+func pairInvitesListHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if pairRPC == nil {
+			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(pendingList()) //nolint:errcheck
+	}
+}
+
+// pairInvitesItemHandler serves POST /pair/invites/<pk>/accept and
+// POST /pair/invites/<pk>/decline.
+func pairInvitesItemHandler(ctx context.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if pairRPC == nil {
+			http.Error(w, "pairing disabled (visor RPC unavailable)", http.StatusServiceUnavailable)
+			return
+		}
+		// Path: /pair/invites/<pk>/<action>
+		rest := strings.TrimPrefix(r.URL.Path, "/pair/invites/")
+		segments := strings.SplitN(rest, "/", 2)
+		if len(segments) != 2 || segments[0] == "" || segments[1] == "" {
+			http.Error(w, "expected /pair/invites/<pk>/{accept,decline}", http.StatusBadRequest)
+			return
+		}
+		peer, err := parsePK(segments[0])
+		if err != nil {
+			http.Error(w, "invalid peer-pk: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		if !pendingHas(peer) {
+			http.Error(w, "no pending invite from this peer", http.StatusNotFound)
+			return
+		}
+
+		switch segments[1] {
+		case "accept":
+			// Create the local pair (status starts at pending; the
+			// initiator's PairMarkActive on receiving our ack will
+			// flip them, but on this side we'd want active too).
+			if err := pairRPC.PairAdd(peer); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			// Mark our own side active immediately — the user
+			// just consented, so there's no further confirmation
+			// needed.
+			if err := pairRPC.PairMarkActive(peer); err != nil {
+				appLog("Pairing: PairMarkActive after accept failed: %v", err)
+			}
+			pendingDelete(peer)
+			// Best-effort ack to the initiator. If the legacy
+			// connection has dropped, the pair record is still
+			// good and the initiator can converge on next contact.
+			if err := sendPairControl(ctx, peer, pairTypeAck); err != nil {
+				appLog("Pairing: pair-ack to %s failed: %v", peer.Hex()[:8], err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		case "decline":
+			pendingDelete(peer)
+			if err := sendPairControl(ctx, peer, pairTypeDecline); err != nil {
+				appLog("Pairing: pair-decline to %s failed: %v", peer.Hex()[:8], err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+
+		default:
+			http.Error(w, "expected /pair/invites/<pk>/{accept,decline}", http.StatusBadRequest)
+		}
+	}
 }
 
 // pairRootHandler serves POST /pair (add) and GET /pair (list).
@@ -287,20 +449,33 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 	case pairTypeInvite:
 		// The from_pk in the envelope is informational — we use the
 		// legacy connection's RemoteAddr.PubKey as the authoritative
-		// identity. Either way they should match.
-		appLog("Pairing: pair-invite from %s", peerPK.Hex()[:8])
-		if err := pairRPC.PairAdd(peerPK); err != nil {
-			appLog("Pairing: PairAdd from invite failed: %v", err)
-			return true
-		}
-		// Best-effort ack.
-		if err := sendPairControlOnExistingConn(peerPK, pairTypeAck); err != nil {
-			appLog("Pairing: pair-ack to %s failed: %v", peerPK.Hex()[:8], err)
-		}
+		// identity. The pair is NOT created here: the invite is
+		// stored as pending and surfaced to the UI, which calls
+		// /pair/invites/<pk>/accept when the user consents.
+		appLog("Pairing: pair-invite from %s (pending user consent)", peerPK.Hex()[:8])
+		pendingPut(peerPK)
+		notifyInviteSSE(peerPK, "received")
 		return true
 
 	case pairTypeAck:
-		appLog("Pairing: pair-ack from %s — both sides paired", peerPK.Hex()[:8])
+		// Initiator side: the peer accepted our invite. Promote the
+		// pending pair record to active so the UI shows it as
+		// confirmed.
+		appLog("Pairing: pair-ack from %s — peer accepted", peerPK.Hex()[:8])
+		if err := pairRPC.PairMarkActive(peerPK); err != nil {
+			appLog("Pairing: PairMarkActive after ack failed: %v", err)
+		}
+		notifyInviteSSE(peerPK, "accepted")
+		return true
+
+	case pairTypeDecline:
+		// Initiator side: the peer declined our invite. Drop the
+		// pending pair record so it doesn't sit in pending forever.
+		appLog("Pairing: pair-decline from %s — peer declined", peerPK.Hex()[:8])
+		if err := pairRPC.PairRemove(peerPK); err != nil {
+			appLog("Pairing: PairRemove after decline failed: %v", err)
+		}
+		notifyInviteSSE(peerPK, "declined")
 		return true
 	}
 	_ = ctx
@@ -317,24 +492,6 @@ func sendPairControl(ctx context.Context, peerPK cipher.PubKey, msgType string) 
 		return err
 	}
 	conn, err := dialOrReusePeerConn(ctx, peerPK)
-	if err != nil {
-		return err
-	}
-	_, err = conn.Write(body)
-	return err
-}
-
-// sendPairControlOnExistingConn writes a pair-control message on an
-// already-open conns[peerPK] entry, used from handleConn where we
-// already have the connection live.
-func sendPairControlOnExistingConn(peerPK cipher.PubKey, msgType string) error {
-	connsMu.Lock()
-	conn, ok := conns[peerPK]
-	connsMu.Unlock()
-	if !ok {
-		return errors.New("pairing: no live connection to peer")
-	}
-	body, err := json.Marshal(pairMsg{Type: msgType})
 	if err != nil {
 		return err
 	}

--- a/cmd/apps/skychat/commands/static/index.html
+++ b/cmd/apps/skychat/commands/static/index.html
@@ -252,6 +252,79 @@
       border-left: 2px solid var(--accent-orange);
     }
 
+    /* Pending invites — distinct section above the recipient list. */
+    .invites-section {
+      border-bottom: 1px solid var(--border-color);
+    }
+
+    .invites-section.hidden {
+      display: none;
+    }
+
+    .invites-header {
+      padding: 10px 16px 6px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--accent-orange);
+    }
+
+    .invite-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-top: 1px solid var(--border-color);
+    }
+
+    .invite-pk {
+      flex: 1;
+      min-width: 0;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 12px;
+      color: var(--text-primary);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .invite-actions {
+      display: flex;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+
+    .invite-btn {
+      background: transparent;
+      border: 1px solid var(--border-color);
+      color: var(--text-secondary);
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    .invite-btn.accept {
+      border-color: var(--accent-green);
+      color: var(--accent-green);
+    }
+
+    .invite-btn.accept:hover {
+      background: var(--accent-green);
+      color: white;
+    }
+
+    .invite-btn.decline {
+      border-color: var(--accent-red);
+      color: var(--accent-red);
+    }
+
+    .invite-btn.decline:hover {
+      background: var(--accent-red);
+      color: white;
+    }
+
     /* Chat Area */
     .chat-container {
       flex: 1;
@@ -684,6 +757,10 @@
         <button type="submit" class="btn btn-icon" title="Add contact">+</button>
       </form>
     </div>
+    <div id="invitesSection" class="invites-section hidden">
+      <div class="invites-header">Pending Pair Invites</div>
+      <div id="invitesList"></div>
+    </div>
     <ul id="recipients" class="recipient-list"></ul>
   </aside>
 
@@ -751,6 +828,7 @@
         this.connected = false;
         this.pairedSet = new Set();
         this.pairAvailable = false;
+        this.pendingInvites = new Set();
 
         this.loadData();
         this.recipients.forEach(r => this._addRecipient(r));
@@ -854,6 +932,12 @@
 
         source.onmessage = (msg) => {
           const data = JSON.parse(msg.data);
+          // Pair-invite control envelope — handle separately so it
+          // doesn't get rendered as a chat message.
+          if (data.channel === 'pair-invite') {
+            this.handlePairInviteSSE(data);
+            return;
+          }
           const message = {
             ts: new Date(),
             from: this.processPk(data.sender),
@@ -1012,6 +1096,7 @@
       syncPairedFromVisor() {
         this.pairedSet = new Set();
         this.pairAvailable = false;
+        this.pendingInvites = new Set();
         fetch('/pair')
           .then(res => {
             if (res.status === 404 || res.status === 503) {
@@ -1035,11 +1120,119 @@
               }
             });
             this.refreshPairControls();
+            // Now seed any pending invites the visor was holding when
+            // we connected. SSE keeps this in sync after the initial
+            // load.
+            this.syncPendingInvites();
           })
           .catch(e => {
             // Pairing endpoint not reachable — fall back to legacy UI.
             console.debug('skychat pair sync skipped:', e.message);
           });
+      }
+
+      // syncPendingInvites refreshes the pending-invite list from the
+      // skychat backend.
+      syncPendingInvites() {
+        if (!this.pairAvailable) return;
+        fetch('/pair/invites')
+          .then(res => res.ok ? res.json() : [])
+          .then(invites => {
+            this.pendingInvites = new Set();
+            (invites || []).forEach(inv => {
+              if (inv && inv.peer_pk) {
+                this.pendingInvites.add(this.processPk(inv.peer_pk));
+              }
+            });
+            this.renderInvites();
+          })
+          .catch(e => console.debug('invite sync skipped:', e.message));
+      }
+
+      // renderInvites updates the sidebar pending-invites section.
+      renderInvites() {
+        const section = document.getElementById('invitesSection');
+        const list = document.getElementById('invitesList');
+        if (!this.pendingInvites || this.pendingInvites.size === 0) {
+          section.classList.add('hidden');
+          list.innerHTML = '';
+          return;
+        }
+        section.classList.remove('hidden');
+        list.innerHTML = '';
+        this.pendingInvites.forEach(pk => {
+          const shortPk = pk.substring(0, 8) + '...' + pk.substring(pk.length - 8);
+          const item = document.createElement('div');
+          item.className = 'invite-item';
+          item.innerHTML = `
+            <div class="invite-pk" title="${pk}">${shortPk}</div>
+            <div class="invite-actions">
+              <button class="invite-btn accept" onclick="app.acceptInvite('${pk}')" title="Accept pair invite">✓</button>
+              <button class="invite-btn decline" onclick="app.declineInvite('${pk}')" title="Decline pair invite">✕</button>
+            </div>`;
+          list.appendChild(item);
+        });
+      }
+
+      acceptInvite(pk) {
+        fetch(`/pair/invites/${pk}/accept`, { method: 'POST' })
+          .then(res => {
+            if (res.ok) {
+              this.pendingInvites.delete(pk);
+              this.pairedSet.add(pk);
+              if (!this.recipients.includes(pk)) {
+                this._addRecipient(pk);
+              } else {
+                this._updatePairBadge(pk, true);
+              }
+              this.renderInvites();
+              this.refreshPairControls();
+              this.showToast('Invite accepted.');
+            } else {
+              res.text().then(t => this.showToast(`Accept failed: ${t}`, 'error'));
+            }
+          })
+          .catch(e => this.showToast(e.message, 'error'));
+      }
+
+      declineInvite(pk) {
+        fetch(`/pair/invites/${pk}/decline`, { method: 'POST' })
+          .then(res => {
+            if (res.ok) {
+              this.pendingInvites.delete(pk);
+              this.renderInvites();
+              this.showToast('Invite declined.');
+            } else {
+              res.text().then(t => this.showToast(`Decline failed: ${t}`, 'error'));
+            }
+          })
+          .catch(e => this.showToast(e.message, 'error'));
+      }
+
+      // handlePairInviteSSE reacts to channel="pair-invite" envelopes.
+      // event="received" → add to pending; "accepted" → mark our
+      // initiated pair active; "declined" → drop our pending pair.
+      handlePairInviteSSE(data) {
+        const peer = this.processPk(data.peer);
+        if (data.event === 'received') {
+          this.pendingInvites.add(peer);
+          this.renderInvites();
+          this.showToast(`Pair invite from ${peer.substring(0,8)}...`);
+        } else if (data.event === 'accepted') {
+          this.pairedSet.add(peer);
+          if (!this.recipients.includes(peer)) {
+            this._addRecipient(peer);
+          } else {
+            this._updatePairBadge(peer, true);
+          }
+          this.refreshPairControls();
+          this.showToast(`Pair confirmed with ${peer.substring(0,8)}...`);
+        } else if (data.event === 'declined') {
+          this.pairedSet.delete(peer);
+          this._updatePairBadge(peer, false);
+          this.refreshPairControls();
+          this.showToast(`Pair declined by ${peer.substring(0,8)}...`, 'error');
+        }
       }
 
       updateUnreadBadges() {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -201,6 +201,7 @@ type API interface {
 	PairAdd(peerPK cipher.PubKey) error
 	PairList() ([]PairInfo, error)
 	PairRemove(peerPK cipher.PubKey) error
+	PairMarkActive(peerPK cipher.PubKey) error
 	PairSend(peerPK cipher.PubKey, text string) error
 	PairPoll(since time.Time) ([]PairMessage, error)
 

--- a/pkg/visor/pairing.go
+++ b/pkg/visor/pairing.go
@@ -117,6 +117,22 @@ func (v *Visor) PairRemove(peerPK cipher.PubKey) error {
 	return mgr.Remove(peerPK)
 }
 
+// PairMarkActive transitions a previously-added pair from
+// pending → active. Called by the initiator's skychat when the
+// peer's pair-ack arrives, signaling that both sides have
+// publishers up and the user-visible status should reflect a
+// confirmed pair.
+//
+// No-op if the record is already active. Returns an error when
+// pairing is disabled or no record exists for peerPK.
+func (v *Visor) PairMarkActive(peerPK cipher.PubKey) error {
+	mgr := v.pairManager()
+	if mgr == nil {
+		return ErrPairingDisabled
+	}
+	return mgr.MarkActive(peerPK)
+}
+
 // PairSend publishes one message to peerPK's pair feed. Returns
 // ErrNotFound if peerPK isn't a registered pair.
 func (v *Visor) PairSend(peerPK cipher.PubKey, text string) error {

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1082,6 +1082,11 @@ func (rc *rpcClient) PairRemove(peerPK cipher.PubKey) error {
 	return rc.Call("PairRemove", &peerPK, &struct{}{})
 }
 
+// PairMarkActive implements API.
+func (rc *rpcClient) PairMarkActive(peerPK cipher.PubKey) error {
+	return rc.Call("PairMarkActive", &peerPK, &struct{}{})
+}
+
 // PairSend implements API.
 func (rc *rpcClient) PairSend(peerPK cipher.PubKey, text string) error {
 	return rc.Call("PairSend", &PairSendRequest{PeerPK: peerPK, Text: text}, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1091,6 +1091,9 @@ func (mc *mockRPCClient) PairList() ([]PairInfo, error) { return nil, nil }
 // PairRemove implements API.
 func (mc *mockRPCClient) PairRemove(_ cipher.PubKey) error { return nil }
 
+// PairMarkActive implements API.
+func (mc *mockRPCClient) PairMarkActive(_ cipher.PubKey) error { return nil }
+
 // PairSend implements API.
 func (mc *mockRPCClient) PairSend(_ cipher.PubKey, _ string) error { return nil }
 

--- a/pkg/visor/rpc_pairing.go
+++ b/pkg/visor/rpc_pairing.go
@@ -60,6 +60,15 @@ func (r *RPC) PairRemove(peerPK *cipher.PubKey, _ *struct{}) (err error) {
 	return r.visor.PairRemove(*peerPK)
 }
 
+// PairMarkActive promotes a pending pair to active.
+func (r *RPC) PairMarkActive(peerPK *cipher.PubKey, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "PairMarkActive", peerPK)(nil, &err)
+	if peerPK == nil {
+		return fmt.Errorf("nil request")
+	}
+	return r.visor.PairMarkActive(*peerPK)
+}
+
 // PairSend publishes one message into the pair feed.
 func (r *RPC) PairSend(req *PairSendRequest, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "PairSend", req)(nil, &err)


### PR DESCRIPTION
## Summary

PR-8 of the skychat-on-CXO sequence. Replaces the auto-accept
handshake from PR-5 with a proper consent-based flow: receiving a
pair-invite no longer automatically attaches the peer; the invite
is held pending until the user explicitly clicks Accept or Decline.

This was the precondition for being able to flip \`--pair-enable\`
to default-on in a future PR — without consent, anyone who knows
your visor PK could pair-invite and auto-attach.

## State machine

\`\`\`
Alice                                 Bob
─────                                 ───
POST /pair {bob_pk}
  visor.PairAdd(bob)  [pending]
  send pair-invite ──────────────►   handleConn pair-invite:
                                       pendingPut(alice)
                                       SSE channel=pair-invite (received)
                                       UI shows accept/decline

                                     User clicks Accept:
                                       POST /pair/invites/alice/accept
                                       visor.PairAdd(alice) [pending]
                                       visor.PairMarkActive(alice) [active]
                                       pendingDelete(alice)
                                     ◄───── send pair-ack
handleConn pair-ack:
  visor.PairMarkActive(bob) [active]
  SSE channel=pair-invite (accepted)

(Or, on Decline:
                                     ◄───── send pair-decline
handleConn pair-decline:
  visor.PairRemove(bob)
  SSE channel=pair-invite (declined))
\`\`\`

## What's added

**Visor RPC** (\`pkg/visor/{api,pairing,rpc_pairing,rpc_client,rpc_client_mock}.go\`):
- \`PairMarkActive(peerPK)\` exposes the existing \`pairing.Manager.MarkActive\`
  so the initiator's pending record can transition to active when
  the peer's pair-ack arrives.

**Skychat backend** (\`cmd/apps/skychat/commands/pairing.go\`):
- In-memory \`pendingInvites\` store with mutex (lost on restart; OK
  for MVP — peers can re-invite).
- \`handleConn\` dispatches:
  - \`pair-invite\` → \`pendingPut\` + SSE notify (no auto-PairAdd)
  - \`pair-ack\` → \`PairMarkActive\` on initiator
  - \`pair-decline\` (new type) → \`PairRemove\` on initiator
- New HTTP endpoints:
  - \`GET /pair/invites\` — list pending
  - \`POST /pair/invites/<pk>/accept\` — \`PairAdd\` + \`PairMarkActive\`,
    drop pending, send pair-ack
  - \`POST /pair/invites/<pk>/decline\` — drop pending, send pair-decline
- \`notifyInviteSSE\` pushes \`channel="pair-invite"\` envelopes with
  \`event ∈ {received, accepted, declined}\` so the UI updates without
  polling.

**Skychat UI** (\`cmd/apps/skychat/commands/static/index.html\`):
- New "Pending Pair Invites" section above the recipient list,
  with per-invite ✓ / ✕ buttons in the accent-green / accent-red
  palette.
- SSE handler dispatches \`channel="pair-invite"\` envelopes to a
  new \`handlePairInviteSSE\` method that updates the pending set,
  the paired set, and the recipient list.
- Startup sync: \`syncPendingInvites()\` seeds the UI from
  \`/pair/invites\` on reload.

## Backwards compatibility

- All new behavior still gated behind \`--pair-enable\`. CI tests
  using the legacy plain-text DM path are unaffected.
- The HTTP \`POST /pair {peer_pk}\` endpoint behavior is unchanged
  on the initiator side (still creates pending pair + sends invite).
  The change is on the responder side: invites no longer auto-accept.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint\` clean
- [x] \`make check\` clean
- [x] JS parses cleanly
- [x] Unit + integration tests pass (\`go test ./cmd/apps/skychat/... ./pkg/visor/...\`)
- [ ] Manual browser smoke (alice initiates, bob's UI shows invite,
      bob accepts, both sides see paired state, bob declines, alice
      sees pair removed)

## What's next

- **PR-9 (originally PR-8)**: documentation pass — \`docs/skychat_pairing.md\`
  with the design, the threat model + transport-stack metadata note,
  the consent-based handshake, and the full HTTP / SSE schema.