### PR TITLE
fix: STCPR re-register body retry; let dmsg-only visors register SUDPH

### DIFF
--- a/cmd/svc/address-resolver/commands/root.go
+++ b/cmd/svc/address-resolver/commands/root.go
@@ -39,6 +39,7 @@ const (
 var (
 	addr            string
 	udpAddr         string
+	publicUDPAddr   string
 	metricsAddr     string
 	redisURL        string
 	redisPoolSize   int
@@ -120,6 +121,7 @@ GET /security/nonces/{pk}
 func init() {
 	RootCmd.Flags().StringVarP(&addr, "addr", "a", ":9093", "address to bind to\n\r")
 	RootCmd.Flags().StringVar(&udpAddr, "udp-addr", ":30178", "UDP address to bind to for SUDPH\n\r")
+	RootCmd.Flags().StringVar(&publicUDPAddr, "public-udp-address", "", "externally-reachable host:port advertised in /health for SUDPH (e.g. ar.example.com:30178)\n\rrequired for visors that reach this AR over dmsghttp; without it those visors cannot register SUDPH")
 	RootCmd.Flags().StringVarP(&metricsAddr, "metrics", "m", "", "address to bind metrics API to")
 	RootCmd.Flags().StringVar(&pprofAddr, "pprof", "", "address to bind pprof debug server (e.g. localhost:6060)")
 	RootCmd.Flags().StringVar(&redisURL, "redis", "redis://localhost:6379", "connections string for a redis store\n\r")
@@ -252,7 +254,7 @@ Example:
 		}
 
 		enableMetrics := metricsAddr != ""
-		arAPI := api.New(logger, transportStore, nonceStore, enableMetrics, m, dmsgAddr)
+		arAPI := api.New(logger, transportStore, nonceStore, enableMetrics, m, dmsgAddr, publicUDPAddr)
 
 		udpListener, err := kcp.Listen(udpAddr)
 		if err != nil {

--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -67,6 +67,13 @@ type API struct {
 
 	dmsgAddr    string
 	DmsgServers []string
+
+	// publicUDPAddr is the externally-reachable host:port of the AR's
+	// SUDPH UDP listener. Empty when the operator hasn't configured one.
+	// Visors that reach this AR over dmsghttp use the value advertised in
+	// /health to dial SUDPH; without it those visors cannot register
+	// SUDPH at all (no host part to UDP-resolve from a dmsg:// PK URL).
+	publicUDPAddr string
 }
 
 // HealthCheckResponse is struct of /health endpoint
@@ -76,6 +83,11 @@ type HealthCheckResponse struct {
 	StartedAt   time.Time       `json:"started_at"`
 	DmsgAddr    string          `json:"dmsg_address,omitempty"`
 	DmsgServers []string        `json:"dmsg_servers,omitempty"`
+	// UDPAddr is the externally-reachable host:port of this AR's SUDPH
+	// listener. Visors that connect over dmsghttp use this value to
+	// register SUDPH — without it the dmsg-only URL has no IP to dial.
+	// Omitted when the operator did not configure --public-udp-address.
+	UDPAddr string `json:"udp_address,omitempty"`
 }
 
 // ArData has all the visors that have registered with sudph or stcpr transport
@@ -89,9 +101,12 @@ type Error struct {
 	Error string `json:"error"`
 }
 
-// New creates a new api.
+// New creates a new api. publicUDPAddr is the externally-reachable
+// host:port of the AR's SUDPH UDP listener (e.g. "ar.example.com:30178");
+// pass empty when not configured — clients that reach the AR over
+// dmsghttp will then have no way to register SUDPH.
 func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
-	enableMetrics bool, m armetrics.Metrics, dmsgAddr string) *API {
+	enableMetrics bool, m armetrics.Metrics, dmsgAddr, publicUDPAddr string) *API {
 	api := &API{
 		log:                         log,
 		store:                       s,
@@ -102,6 +117,7 @@ func New(log *logging.Logger, s store.Store, nonceStore httpauth.NonceStore,
 		closeC:                      make(chan struct{}),
 		dmsgAddr:                    dmsgAddr,
 		DmsgServers:                 []string{},
+		publicUDPAddr:               publicUDPAddr,
 	}
 
 	r := chi.NewRouter()
@@ -342,6 +358,7 @@ func (a *API) health(w http.ResponseWriter, r *http.Request) {
 		StartedAt:   a.startedAt,
 		DmsgAddr:    a.dmsgAddr,
 		DmsgServers: a.DmsgServers,
+		UDPAddr:     a.publicUDPAddr,
 	})
 }
 

--- a/pkg/dmsg/dmsghttp/http_transport.go
+++ b/pkg/dmsg/dmsghttp/http_transport.go
@@ -119,6 +119,16 @@ func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		ps.discard()
 		t.untrack(ps)
+		// req.Write on the dead pooled stream consumed req.Body. Without
+		// rewinding it the fresh-dial attempt below would send 0 body
+		// bytes against the original ContentLength, producing
+		// "http: ContentLength=N with Body length 0". Mirror
+		// net/http.Transport's retry behavior: rewind via GetBody when
+		// available. POSTs created with http.NewRequest(*bytes.Buffer
+		// |*bytes.Reader|*strings.Reader) get GetBody set automatically.
+		if err := rewindBody(req); err != nil {
+			return nil, err
+		}
 		// fall through to fresh dial
 	}
 
@@ -135,6 +145,24 @@ func (t *HTTPTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 	return resp, nil
+}
+
+// rewindBody resets req.Body to a fresh reader using req.GetBody, so a
+// retry can re-read the body after a failed write attempt. Returns an
+// error only if GetBody is set but produces an error; if GetBody is nil
+// (e.g. body is nil/NoBody or non-rewindable) the request is left
+// unchanged and the retry sends no body — which is fine for the only
+// requests that hit this path with no GetBody (auth nonce GETs etc).
+func rewindBody(req *http.Request) error {
+	if req.GetBody == nil {
+		return nil
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return err
+	}
+	req.Body = body
+	return nil
 }
 
 // do writes req to ps and reads back the response. The response body

--- a/pkg/dmsg/dmsghttp/http_transport_test.go
+++ b/pkg/dmsg/dmsghttp/http_transport_test.go
@@ -2,8 +2,10 @@
 package dmsghttp
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -18,6 +20,41 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 )
+
+// TestRewindBody pins the helper that the pooled-stream-failed retry
+// path relies on. http.NewRequest auto-sets req.GetBody for *bytes.Buffer
+// payloads (the form used by httpauth/AR clients), so a drained body
+// can be reset before the fresh-dial retry. The bug this guards against
+// is the AR re-registration warning "ContentLength=N with Body length 0":
+// the first req.Write to a stale pooled stream consumed the body, and
+// the retry sent zero bytes against the original ContentLength.
+func TestRewindBody(t *testing.T) {
+	t.Run("rewinds_drained_body", func(t *testing.T) {
+		const payload = `{"port":"30178","addresses":["10.0.0.1"]}`
+		req, err := http.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString(payload))
+		require.NoError(t, err)
+		require.Equal(t, int64(len(payload)), req.ContentLength)
+
+		// Simulate req.Write consuming the body on a doomed pooled stream.
+		_, err = io.Copy(io.Discard, req.Body)
+		require.NoError(t, err)
+
+		require.NoError(t, rewindBody(req))
+
+		got, err := io.ReadAll(req.Body)
+		require.NoError(t, err)
+		assert.Equal(t, payload, string(got))
+		assert.Equal(t, int64(len(payload)), req.ContentLength,
+			"ContentLength must stay matched to the rewound body")
+	})
+
+	t.Run("nil_get_body_is_noop", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+		require.NoError(t, err)
+		assert.Nil(t, req.GetBody)
+		assert.NoError(t, rewindBody(req))
+	})
+}
 
 func TestHTTPTransport_RoundTrip(t *testing.T) {
 	logging.SetLevel(logrus.WarnLevel)

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -90,6 +90,7 @@ type httpClient struct {
 	pk             cipher.PubKey
 	sk             cipher.SecKey
 	remoteHTTPAddr string
+	remoteHTTPURL  *url.URL
 	remoteUDPAddr  string
 	sudphConn      net.PacketConn
 	sudphArConn    net.Conn
@@ -106,15 +107,25 @@ type httpClient struct {
 // * SW-Public: The specified public key.
 // * SW-Nonce:  The nonce for that public key.
 // * SW-Sig:    The signature of the payload + the nonce.
+//
+// When remoteAddr uses the dmsg:// scheme the URL host is a public key,
+// not an IP, so it cannot be UDP-resolved for SUDPH. In that case the
+// UDP target is left empty here and resolved from the AR's /health
+// (udp_address field) once the auth client is ready. ARs that don't
+// publish udp_address simply leave SUDPH unavailable to dmsg-only
+// callers — the same behavior as before this change.
 func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC *http.Client, clientPublicIP string, log *logging.Logger, mLog *logging.MasterLogger) (APIClient, error) {
 	remoteURL, err := url.Parse(remoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("parse URL: %w", err)
 	}
 
-	remoteUDP := remoteURL.Host
-	if _, _, err := net.SplitHostPort(remoteUDP); err != nil {
-		remoteUDP = net.JoinHostPort(remoteUDP, defaultUDPPort)
+	var remoteUDP string
+	if remoteURL.Scheme != "dmsg" {
+		remoteUDP = remoteURL.Host
+		if _, _, err := net.SplitHostPort(remoteUDP); err != nil {
+			remoteUDP = net.JoinHostPort(remoteUDP, defaultUDPPort)
+		}
 	}
 
 	client := &httpClient{
@@ -123,6 +134,7 @@ func NewHTTP(remoteAddr string, pk cipher.PubKey, sk cipher.SecKey, httpC *http.
 		pk:             pk,
 		sk:             sk,
 		remoteHTTPAddr: remoteAddr,
+		remoteHTTPURL:  remoteURL,
 		remoteUDPAddr:  remoteUDP,
 		clientPublicIP: clientPublicIP,
 		ready:          make(chan struct{}),
@@ -156,10 +168,69 @@ func (c *httpClient) initHTTPClient(httpC *http.Client) {
 		}
 	}
 
+	c.httpClient = httpAuthClient
+
+	// dmsg:// URL has no IP for SUDPH — pull AR's public UDP address
+	// from /health (set by --public-udp-address on the server). Best
+	// effort: a missing or unparseable value just leaves SUDPH unavailable
+	// for this AR, which is the pre-fix behavior.
+	if c.remoteHTTPURL != nil && c.remoteHTTPURL.Scheme == "dmsg" {
+		if udpAddr := c.fetchPublicUDPAddr(httpC); udpAddr != "" {
+			c.remoteUDPAddr = udpAddr
+			c.log.Debugf("Resolved AR UDP address via /health: %q", udpAddr)
+		} else {
+			c.log.Info("AR /health did not advertise udp_address; SUDPH unavailable for this AR")
+		}
+	}
+
 	c.log.Debug("Connected to address resolver. STCPR/SUDPH services are available.")
 
-	c.httpClient = httpAuthClient
 	close(c.ready)
+}
+
+// fetchPublicUDPAddr does a single unauthenticated GET /health using
+// the underlying HTTP client (which carries the dmsghttp transport)
+// and returns the udp_address advertised by the AR. Returns "" on any
+// failure — the caller treats that as "SUDPH not available via this AR".
+func (c *httpClient) fetchPublicUDPAddr(httpC *http.Client) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.remoteHTTPAddr+"/health", nil)
+	if err != nil {
+		c.log.WithError(err).Debug("Failed to build /health request for udp_address lookup")
+		return ""
+	}
+	resp, err := httpC.Do(req)
+	if err != nil {
+		c.log.WithError(err).Debug("Failed to GET /health for udp_address lookup")
+		return ""
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			c.log.WithError(cerr).Debug("Failed to close /health response body")
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		c.log.Debugf("/health returned status %d for udp_address lookup", resp.StatusCode)
+		return ""
+	}
+	var body struct {
+		UDPAddr string `json:"udp_address"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		c.log.WithError(err).Debug("Failed to decode /health for udp_address lookup")
+		return ""
+	}
+	udpAddr := strings.TrimSpace(body.UDPAddr)
+	if udpAddr == "" {
+		return ""
+	}
+	if _, _, err := net.SplitHostPort(udpAddr); err != nil {
+		// Allow "host" without port; default to AR's well-known SUDPH port.
+		udpAddr = net.JoinHostPort(udpAddr, defaultUDPPort)
+	}
+	return udpAddr
 }
 
 // Get performs a new GET request.
@@ -382,6 +453,11 @@ func (c *httpClient) BindSUDPH(filter *pfilter.PacketFilter, hs Handshake) (<-ch
 // for AR's record of our public address and for any remote visors that
 // already received our (PK, port) tuple via Resolve.
 func (c *httpClient) connectSUDPH(filter *pfilter.PacketFilter, hs Handshake) (net.Conn, LocalAddresses, error) {
+	if c.remoteUDPAddr == "" {
+		// dmsg-only AR with no udp_address in /health. Surface a clear
+		// reason so the visor log isn't a confusing UDP-resolve error.
+		return nil, LocalAddresses{}, errors.New("AR has no UDP address (dmsg-only AR did not advertise udp_address in /health); SUDPH unavailable")
+	}
 	rAddr, err := net.ResolveUDPAddr("udp", c.remoteUDPAddr)
 	if err != nil {
 		return nil, LocalAddresses{}, err

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -86,6 +86,17 @@ func (c *sudphClient) listen() (net.Listener, error) {
 	c.log.Debug("Binding")
 	addrCh, err := c.ar.BindSUDPH(c.filter, c.makeBindHandshake())
 	if err != nil {
+		// BindSUDPH may fail when the AR has no UDP target (dmsg-only AR
+		// without a published udp_address). Release the listener so we
+		// don't leak the UDP port — keeping it open after a failed bind
+		// served no purpose and made later restarts noisier on shared
+		// hosts.
+		if closeErr := packetListener.Close(); closeErr != nil {
+			c.log.WithError(closeErr).Warn("Failed to close UDP listener after BindSUDPH error")
+		}
+		c.packetListener = nil
+		c.filter = nil
+		c.sudphVisorsConn = nil
 		return nil, err
 	}
 

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -18,7 +18,6 @@ import (
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsgcurl"
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
@@ -255,13 +254,12 @@ func (v *Visor) retryStunOnTransientFail(log *logging.Logger) {
 }
 
 func initSudphClient(ctx context.Context, v *Visor, log *logging.Logger) error {
-	var serviceURL dmsgcurl.URL
-	_ = serviceURL.Fill(v.conf.Transport.AddressResolver) //nolint:errcheck
-	// don't start sudph if we are connection to AR via dmsghttp
-	if serviceURL.Scheme == "dmsg" {
-		log.Info("SUDPH transport wont be available under dmsghttp")
-		return nil
-	}
+	// Previously this short-circuited when AR was reached via dmsg
+	// because the dmsg URL host is a PK with no IP for SUDPH. The AR
+	// client now learns AR's public UDP address from /health
+	// (udp_address); when that field is missing, BindSUDPH returns a
+	// clear error and SUDPH simply stays unavailable for this AR. No
+	// reason to hard-skip up front.
 	if v.stun.client != nil {
 		switch v.stun.client.NATType {
 		case stun.NATSymmetric, stun.NATSymmetricUDPFirewall:


### PR DESCRIPTION
## Summary

Two address-resolver-related bugs that compound for visors reaching the AR over dmsghttp.

### 1. STCPR re-registration body retry (`pkg/dmsg/dmsghttp`)

When the pooled dmsg stream was closed by the peer between requests, `RoundTrip`'s first `req.Write` consumed `req.Body`, then the fresh-dial fallback sent zero bytes against the original `Content-Length`. Visible in production as repeated:

```
WARN [stcpr]: STCPR re-registration retry 1/3 failed
  error="Post \"dmsg://<AR-PK>:80/bind/stcpr\":
         http: ContentLength=63 with Body length 0"
```

Fixed by mirroring `net/http.Transport`'s retry behavior — `req.GetBody()` rebuilds the body before the second attempt. `http.NewRequest` auto-sets `GetBody` for `*bytes.Buffer` / `*bytes.Reader` / `*strings.Reader` payloads, which covers every caller in this tree.

### 2. SUDPH was unreachable for dmsg-only visors (server + client + visor init)

A visor whose `address_resolver` is a `dmsg://` URL has no IP to UDP-dial for SUDPH, so `initSudphClient` short-circuited (`SUDPH transport wont be available under dmsghttp`) and no SUDPH entry was ever registered. On the production AR this showed up as ~1k STCPR entries vs. ~150 SUDPH — every dmsghttp-only visor silently locked out.

- **Server**: new `--public-udp-address` flag on `skywire svc ar`; advertised as `udp_address` in `/health`. Default empty, so existing deployments are unchanged until they opt in.
- **Client**: when AR is reached over `dmsg://`, the AR client fetches `/health` once during init and uses `udp_address` as the SUDPH UDP target. Best-effort — if the AR doesn't advertise it, `BindSUDPH` returns a clear error instead of an opaque UDP-resolve failure.
- **Visor init**: hard `dmsg`→skip-SUDPH gate in `initSudphClient` removed; SUDPH now follows the same code path regardless of AR scheme.
- **Bonus**: `sudphClient.listen` now closes the UDP listener it opened when `BindSUDPH` errors out — previously leaked.

Backward compatible: ARs that don't set `--public-udp-address` simply omit `udp_address` from `/health` and visors fall through cleanly with `"AR /health did not advertise udp_address; SUDPH unavailable for this AR"`.

### Deployment note

The SUDPH fix is end-to-end only once the production AR is restarted with `--public-udp-address <host:port>` (e.g. `ar.skywire.skycoin.com:30178`). Until then, dmsg-only visors will continue to fall back to STCPR — same outcome as today, just with a clearer log line.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on all touched packages
- [x] New unit test `TestRewindBody` pins the dmsghttp helper
- [x] `go test ./pkg/dmsg/dmsghttp/... ./pkg/transport/network/... ./pkg/visor/... ./pkg/address-resolver/... ./cmd/svc/address-resolver/...` — all pass (the pre-existing `TestRedis` NOAUTH failure reproduces on clean `upstream/develop` and is unrelated)
- [ ] Roll out updated AR with `--public-udp-address` set; confirm dmsghttp visors begin appearing in `/transports` `sudph` list
- [ ] Confirm STCPR re-registration warnings stop on a visor with the patched dmsghttp transport