### PR TITLE
skychat: fan SSE messages out to all clients (fix self-send drop)

### DIFF
--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -123,9 +123,10 @@ func pendingList() []pendingInvite {
 	return out
 }
 
-// notifyInviteSSE pushes a structured envelope onto clientCh so the
-// browser hears about new invites in real time. Drops if clientCh is
-// full so a slow SSE consumer doesn't block the handshake handler.
+// notifyInviteSSE broadcasts a structured envelope to every connected
+// SSE client so the browser hears about new invites in real time.
+// The hub drops to per-client buffers internally if any consumer is
+// slow.
 func notifyInviteSSE(peerPK cipher.PubKey, kind string) {
 	envelope := map[string]string{
 		"channel": "pair-invite",
@@ -137,10 +138,7 @@ func notifyInviteSSE(peerPK cipher.PubKey, kind string) {
 	if err != nil {
 		return
 	}
-	select {
-	case clientCh <- string(body):
-	default:
-	}
+	hub.broadcast(string(body))
 }
 
 // connectPairRPC dials the local visor's RPC and stores the client
@@ -164,11 +162,12 @@ func connectPairRPC() {
 // startPairPoller bridges visor.PairPoll into the existing SSE
 // pipeline. Polls the visor at pairPollInterval, marshals each
 // message into the same JSON shape the SSE handler emits, and
-// pushes onto clientCh.
+// broadcasts via the hub.
 //
-// Drops if clientCh is full so a slow SSE client doesn't block the
-// poller. The visor's bounded inbox already protects against
-// unbounded growth of buffered messages.
+// The hub drops per-client when their buffer is full so a slow
+// SSE consumer doesn't block the poller. The visor's bounded
+// inbox already protects against unbounded growth of buffered
+// messages.
 func startPairPoller(parent context.Context) {
 	if !pairEnable || pairRPC == nil {
 		return
@@ -207,10 +206,7 @@ func startPairPoller(parent context.Context) {
 					appLog("Pairing: marshal SSE message: %v", err)
 					continue
 				}
-				select {
-				case clientCh <- string(body):
-				default:
-				}
+				hub.broadcast(string(body))
 			}
 		}
 	}()

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -42,8 +42,8 @@ var (
 	addr      string
 	appCl     *app.Client
 	appLog    func(format string, args ...interface{}) // App logger function
-	clientCh  chan string
-	conns     map[cipher.PubKey]net.Conn // Chat connections
+	hub       *sseHub                                  // SSE broadcast registry; see sse.go-like helpers below
+	conns     map[cipher.PubKey]net.Conn               // Chat connections
 	connsMu   sync.Mutex
 	appPort   uint16
 	useSkynet bool
@@ -68,6 +68,60 @@ var (
 
 //go:embed static
 var embededFiles embed.FS
+
+// sseSubscriberBufSize is the per-client outbound message buffer
+// depth. A slow SSE client (or a stalled browser tab) drops messages
+// once its buffer is full rather than blocking the producer; missed
+// messages are recoverable from history (when persistence is on) or
+// just dropped (when off).
+const sseSubscriberBufSize = 64
+
+// sseHub fans messages out to every connected SSE client. The
+// previous implementation used a single unbuffered channel, which
+// meant exactly ONE consumer received each message — when more than
+// one tab was open, or a stale handler was leaked, every other tab
+// silently lost messages. The hub registers a per-client channel on
+// connect and broadcasts to all of them on each message.
+type sseHub struct {
+	mu      sync.Mutex
+	clients map[chan string]struct{}
+}
+
+func newSSEHub() *sseHub {
+	return &sseHub{clients: make(map[chan string]struct{})}
+}
+
+// subscribe registers a fresh client channel and returns it plus an
+// unsubscribe func the caller MUST invoke on shutdown. The channel
+// is buffered so a producer never blocks on a slow consumer.
+func (h *sseHub) subscribe() (<-chan string, func()) {
+	ch := make(chan string, sseSubscriberBufSize)
+	h.mu.Lock()
+	h.clients[ch] = struct{}{}
+	h.mu.Unlock()
+	return ch, func() {
+		h.mu.Lock()
+		if _, ok := h.clients[ch]; ok {
+			delete(h.clients, ch)
+			close(ch)
+		}
+		h.mu.Unlock()
+	}
+}
+
+// broadcast sends msg to every connected client. Drops to clients
+// whose buffer is full — bounded fan-out keeps a single stalled
+// client from holding back the whole stream.
+func (h *sseHub) broadcast(msg string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for ch := range h.clients {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
 
 func init() {
 	launcher.RegisterApp("skychat", RunSkychat)
@@ -180,8 +234,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 		}
 	}
 
-	clientCh = make(chan string)
-	defer close(clientCh)
+	hub = newSSEHub()
 
 	port := appCl.Config().RoutingPort
 	if appPort != 0 {
@@ -349,12 +402,7 @@ func handleConn(conn net.Conn) {
 		if err != nil {
 			appLog("Failed to marshal json: %v", err)
 		}
-		select {
-		case clientCh <- string(clientMsg):
-			appCl.Log().Debugf("Received and sent to ui: %s", clientMsg)
-		default:
-			appCl.Log().Debugf("Received and trashed: %s", clientMsg)
-		}
+		hub.broadcast(string(clientMsg))
 	}
 }
 
@@ -465,6 +513,9 @@ func sseHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Transfer-Encoding", "chunked")
 
+	ch, unsubscribe := hub.subscribe()
+	defer unsubscribe()
+
 	// Seed the new SSE client with recent history if persistence is enabled.
 	if historyStore != nil && persistSeedCount > 0 {
 		recent, err := historyStore.ListRecent(persistSeedCount)
@@ -491,14 +542,18 @@ func sseHandler(w http.ResponseWriter, req *http.Request) {
 
 	for {
 		select {
-		case msg, ok := <-clientCh:
+		case msg, ok := <-ch:
 			if !ok {
 				return
 			}
-			_, err := fmt.Fprintf(w, "data: %s\n\n", msg)
-			if err == nil {
-				f.Flush()
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", msg); err != nil {
+				// Client gone (write to a closed conn) — exit so the
+				// hub deregisters this subscriber and stops buffering
+				// messages it can't deliver.
+				appCl.Log().Debugf("SSE write failed, dropping subscriber: %v", err)
+				return
 			}
+			f.Flush()
 
 		case <-req.Context().Done():
 			appCl.Log().Debug("SSE connection was closed.")


### PR DESCRIPTION
## Summary

Skychat's \`/sse\` handler shared a single unbuffered \`clientCh\` across
every connected SSE client. With more than one consumer (e.g. the
user's browser tab plus any diagnostic \`curl -N /sse\`, or just a
leaked stale handler from a prior reload), each broadcast was
delivered to exactly **one** randomly-selected consumer — the rest
silently lost the message.

This was the root cause of the "self-send doesn't work" report.
Self-send is the easiest way to hit the bug because:
- The user keeps the skychat tab open while testing,
- Any stale browser tab / earlier reload often leaves a parked
  goroutine on \`clientCh\`,
- The sender goroutine and the SSE consumer goroutine race at the
  channel — Go's runtime picks a winner each time.

The dmsg-vs-skynet asymmetry I observed was the same race surfacing
slightly differently because of timing variance between the two
network paths' first message-arrival.

## Fix

Replace the single channel with \`sseHub\`, a registry of per-client
buffered channels:

\`\`\`go
type sseHub struct {
    mu      sync.Mutex
    clients map[chan string]struct{}
}
\`\`\`

- \`hub.subscribe()\` registers a fresh \`make(chan string, 64)\` and
  returns it plus an unsubscribe func the caller defers.
- \`hub.broadcast(msg)\` iterates the registry and does a
  non-blocking send to each subscriber. A wedged tab drops messages
  to its own buffer; the rest of the stream keeps flowing.

Senders updated:
- \`handleConn\` (legacy DM path)
- \`notifyInviteSSE\` (pair-invite control envelopes)
- pair poll loop (CXO inbound message bridge)

Receiver (\`sseHandler\`):
- Subscribes on entry, defers unsubscribe.
- Exits on \`Fprintf\` error too — without this, a dead client whose
  ctx isn't yet canceled would keep draining its buffer forever.

## Reproduction (verified before/after)

Setup: skychat running, browser tab open, plus \`curl -N /sse\` in
another shell.

Before fix: about half of self-sends silently dropped, randomly
distributed between the two consumers.

After fix: every consumer receives every message.

\`\`\`
=== fix-dmsg-1 ===
HTTP 200, 0.340s
=== fix-dmsg-2 ===
HTTP 200, 0.001s
=== fix-skynet-1 ===
HTTP 200, 0.001s

=== SSE captured (curl) ===
data: {"message":"fix-dmsg-1",...}
data: {"message":"fix-dmsg-2",...}
data: {"message":"fix-skynet-1",...}
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./cmd/apps/skychat/...\` passes
- [x] \`golangci-lint\` clean
- [x] \`make check\` clean
- [x] Self-send manual repro: 3 consecutive messages (dmsg, dmsg, skynet) all delivered to a curl-SSE client while the browser is also connected