### PR TITLE
log/cli: stop truncating public keys

### DIFF
--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -303,14 +303,14 @@ func pairInvitesItemHandler(ctx context.Context) http.HandlerFunc {
 			// connection has dropped, the pair record is still
 			// good and the initiator can converge on next contact.
 			if err := sendPairControl(ctx, peer, pairTypeAck); err != nil {
-				appLog("Pairing: pair-ack to %s failed: %v", peer.Hex()[:8], err)
+				appLog("Pairing: pair-ack to %s failed: %v", peer.Hex(), err)
 			}
 			w.WriteHeader(http.StatusNoContent)
 
 		case "decline":
 			pendingDelete(peer)
 			if err := sendPairControl(ctx, peer, pairTypeDecline); err != nil {
-				appLog("Pairing: pair-decline to %s failed: %v", peer.Hex()[:8], err)
+				appLog("Pairing: pair-decline to %s failed: %v", peer.Hex(), err)
 			}
 			w.WriteHeader(http.StatusNoContent)
 
@@ -359,7 +359,7 @@ func pairRootHandler(ctx context.Context) http.HandlerFunc {
 			// can converge later with each calling PairAdd manually.
 			if err := sendPairControl(ctx, peer, pairTypeInvite); err != nil {
 				appLog("Pairing: pair-invite to %s failed: %v (record kept; peer can converge later)",
-					peer.Hex()[:8], err)
+					peer.Hex(), err)
 			}
 			w.WriteHeader(http.StatusNoContent)
 
@@ -448,7 +448,7 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 		// identity. The pair is NOT created here: the invite is
 		// stored as pending and surfaced to the UI, which calls
 		// /pair/invites/<pk>/accept when the user consents.
-		appLog("Pairing: pair-invite from %s (pending user consent)", peerPK.Hex()[:8])
+		appLog("Pairing: pair-invite from %s (pending user consent)", peerPK.Hex())
 		pendingPut(peerPK)
 		notifyInviteSSE(peerPK, "received")
 		return true
@@ -457,7 +457,7 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 		// Initiator side: the peer accepted our invite. Promote the
 		// pending pair record to active so the UI shows it as
 		// confirmed.
-		appLog("Pairing: pair-ack from %s — peer accepted", peerPK.Hex()[:8])
+		appLog("Pairing: pair-ack from %s — peer accepted", peerPK.Hex())
 		if err := pairRPC.PairMarkActive(peerPK); err != nil {
 			appLog("Pairing: PairMarkActive after ack failed: %v", err)
 		}
@@ -467,7 +467,7 @@ func handlePairControlFrame(ctx context.Context, peerPK cipher.PubKey, raw []byt
 	case pairTypeDecline:
 		// Initiator side: the peer declined our invite. Drop the
 		// pending pair record so it doesn't sit in pending forever.
-		appLog("Pairing: pair-decline from %s — peer declined", peerPK.Hex()[:8])
+		appLog("Pairing: pair-decline from %s — peer declined", peerPK.Hex())
 		if err := pairRPC.PairRemove(peerPK); err != nil {
 			appLog("Pairing: PairRemove after decline failed: %v", err)
 		}

--- a/cmd/apps/skychat/pairing/manager.go
+++ b/cmd/apps/skychat/pairing/manager.go
@@ -210,7 +210,7 @@ func (m *Manager) Resume() (resumed int, err error) {
 		p, openErr := m.openPair(rec.PeerPK)
 		if openErr != nil {
 			m.log.WithError(openErr).
-				WithField("peer", rec.PeerPK.Hex()[:8]).
+				WithField("peer", rec.PeerPK.Hex()).
 				Warn("pairing: Resume: skip pair")
 			continue
 		}

--- a/cmd/apps/skynet-client/commands/skynet-client.go
+++ b/cmd/apps/skynet-client/commands/skynet-client.go
@@ -108,7 +108,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 	}
 
 	appCl.Log().Infof("Connecting to %s:%d, forwarding to localhost:%d",
-		remotePK.Hex()[:16], remotePort, localPort)
+		remotePK.Hex(), remotePort, localPort)
 
 	// Set routing port if specified
 	if appPort != 0 {
@@ -126,7 +126,7 @@ func RunSkynetClient(ctx context.Context, args []string) error {
 		Port:   routing.Port(skyenv.SkyForwardingServerPort),
 	}
 
-	appCl.Log().Infof("Dialing %s on port %d", remotePK.Hex()[:16], skyenv.SkyForwardingServerPort)
+	appCl.Log().Infof("Dialing %s on port %d", remotePK.Hex(), skyenv.SkyForwardingServerPort)
 
 	conn, err := appCl.Dial(connApp)
 	if err != nil {

--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -390,7 +390,7 @@ var RootCmd = &cobra.Command{
 						return
 					}
 					dhtNodeRef.Store(dhtNode)
-					dhtLog.WithField("id", dhtNode.ID().String()[:16]).
+					dhtLog.WithField("id", dhtNode.ID().String()).
 						WithField("bootstrap_peers", len(bootstrapPKs)).
 						Info("DHT full node started on port 100")
 

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -1139,7 +1139,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 						fmt.Printf("[RPC] Reconnection failed: %v\n", err)
 						result.Error = fmt.Sprintf("RPC reconnection failed: %v", err)
 						results[i] = result
-						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 						continue
 					}
 					rpcClient = newClient
@@ -1167,7 +1167,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 					if reconnErr != nil {
 						result.Error = fmt.Sprintf("configure failed (reconnect failed): %v", err)
 						results[i] = result
-						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 						continue
 					}
 					rpcClient = newClient
@@ -1177,7 +1177,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				if err != nil {
 					result.Error = fmt.Sprintf("configure failed: %v", err)
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1193,7 +1193,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 					if reconnErr != nil {
 						result.Error = fmt.Sprintf("start failed (reconnect failed): %v", err)
 						results[i] = result
-						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+						fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 						continue
 					}
 					rpcClient = newClient
@@ -1203,7 +1203,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				if err != nil {
 					result.Error = fmt.Sprintf("start failed: %v", err)
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1262,7 +1262,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 
 				if result.Error != "" {
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1276,7 +1276,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 					}
 					result.Error = errMsg
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1289,7 +1289,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				if err != nil {
 					result.Error = fmt.Sprintf("SOCKS5 dialer: %v", err)
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1304,7 +1304,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				if err != nil {
 					result.Error = fmt.Sprintf("HTTP: %v", err)
 					results[i] = result
-					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String()[:8], result.Error)
+					fmt.Printf("[%d/%d] FAIL %s - %s\n", i+1, total, pxy.pk.String(), result.Error)
 					continue
 				}
 
@@ -1344,9 +1344,9 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 					if result.Bandwidth > 0 {
 						bwStr = fmt.Sprintf(" %.0fkbps", result.Bandwidth)
 					}
-					fmt.Printf("[%d/%d] OK %s - %.0fms%s%s%s\n", i+1, total, pxy.pk.String()[:8], result.Latency, locStr, ipStr, bwStr)
+					fmt.Printf("[%d/%d] OK %s - %.0fms%s%s%s\n", i+1, total, pxy.pk.String(), result.Latency, locStr, ipStr, bwStr)
 				} else {
-					fmt.Printf("[%d/%d] FAIL %s - HTTP %d\n", i+1, total, pxy.pk.String()[:8], resp.StatusCode)
+					fmt.Printf("[%d/%d] FAIL %s - HTTP %d\n", i+1, total, pxy.pk.String(), resp.StatusCode)
 				}
 			}
 
@@ -1558,9 +1558,9 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 							if result.Bandwidth > 0 {
 								bwStr = fmt.Sprintf(" %.1fkbps", result.Bandwidth)
 							}
-							fmt.Printf("[%d/%d] OK %s%s - %.0fms%s%s%s\n", current, total, pxy.pk.String()[:8], verStr, result.Latency, locStr, ipStr, bwStr)
+							fmt.Printf("[%d/%d] OK %s%s - %.0fms%s%s%s\n", current, total, pxy.pk.String(), verStr, result.Latency, locStr, ipStr, bwStr)
 						} else {
-							fmt.Printf("[%d/%d] FAIL %s%s - %s\n", current, total, pxy.pk.String()[:8], verStr, result.Error)
+							fmt.Printf("[%d/%d] FAIL %s%s - %s\n", current, total, pxy.pk.String(), verStr, result.Error)
 						}
 					}
 				}(i, p)

--- a/cmd/skywire-cli/commands/rg/rg.go
+++ b/cmd/skywire-cli/commands/rg/rg.go
@@ -60,7 +60,7 @@ var listCmd = &cobra.Command{
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "APP\tREMOTE\tPORTS\tLATENCY\tTX\tRX\tUP\tDOWN\tROUTES\tMUX") //nolint:errcheck,gosec
 		for _, r := range routes {
-			remote := r.Route.RemotePK.String()[:8] + ".."
+			remote := r.Route.RemotePK.String() + ".."
 			ports := fmt.Sprintf("%d:%d", r.Route.LocalPort, r.Route.RemotePort)
 			latency := "-"
 			if r.Route.Latency > 0 {
@@ -82,7 +82,7 @@ var listCmd = &cobra.Command{
 			// Show transport details for mux routes
 			if nRoutes > 1 {
 				for _, tp := range r.Route.Transports {
-					tpID := tp.ID.String()[:8] + ".."
+					tpID := tp.ID.String() + ".."
 					lat := "-"
 					if tp.Latency > 0 {
 						lat = fmt.Sprintf("%.0fms", tp.Latency)

--- a/cmd/skywire-cli/commands/skynet/curl.go
+++ b/cmd/skywire-cli/commands/skynet/curl.go
@@ -62,7 +62,7 @@ Examples:
 			body = []byte(curlData)
 		}
 
-		fmt.Fprintf(os.Stderr, "Dialing %s:%d%s...\n", target.pk.String()[:8], target.port, target.path)
+		fmt.Fprintf(os.Stderr, "Dialing %s:%d%s...\n", target.pk.String(), target.port, target.path)
 
 		resp, err := rpcClient.SkynetHTTP(visor.SkynetHTTPRequest{
 			PK:     target.pk,

--- a/cmd/skywire-cli/commands/tp/tp-add-edge.go
+++ b/cmd/skywire-cli/commands/tp/tp-add-edge.go
@@ -69,7 +69,7 @@ connected to (e.g., connecting to all edges of a well-connected hub).`,
 		}
 
 		if len(entries) == 0 {
-			fmt.Printf("No transports found for %s\n", targetPK.String()[:8])
+			fmt.Printf("No transports found for %s\n", targetPK.String())
 			return
 		}
 
@@ -84,7 +84,7 @@ connected to (e.g., connecting to all edges of a well-connected hub).`,
 		}
 
 		if len(edgePKs) == 0 {
-			fmt.Printf("No edge keys found for %s (excluding self)\n", targetPK.String()[:8])
+			fmt.Printf("No edge keys found for %s (excluding self)\n", targetPK.String())
 			return
 		}
 
@@ -95,7 +95,7 @@ connected to (e.g., connecting to all edges of a well-connected hub).`,
 		}
 
 		if edgeVerbose {
-			fmt.Printf("Found %d edges for %s, attempting to connect...\n", len(pksToConnect), targetPK.String()[:8])
+			fmt.Printf("Found %d edges for %s, attempting to connect...\n", len(pksToConnect), targetPK.String())
 		}
 
 		// Process in parallel batches
@@ -135,9 +135,9 @@ connected to (e.g., connecting to all edges of a well-connected hub).`,
 
 				if edgeVerbose {
 					if res.success {
-						fmt.Printf("✓ %s (%s)\n", edgePK.String()[:8], res.tpType)
+						fmt.Printf("✓ %s (%s)\n", edgePK.String(), res.tpType)
 					} else {
-						fmt.Printf("✗ %s: %v\n", edgePK.String()[:8], res.err)
+						fmt.Printf("✗ %s: %v\n", edgePK.String(), res.err)
 					}
 				}
 			}(i, pk)
@@ -152,6 +152,6 @@ connected to (e.g., connecting to all edges of a well-connected hub).`,
 				successCount++
 			}
 		}
-		fmt.Printf("\nConnected to %d/%d edges of %s\n", successCount, len(pksToConnect), targetPK.String()[:8])
+		fmt.Printf("\nConnected to %d/%d edges of %s\n", successCount, len(pksToConnect), targetPK.String())
 	},
 }

--- a/cmd/skywire-cli/commands/tp/tp-add.go
+++ b/cmd/skywire-cli/commands/tp/tp-add.go
@@ -156,7 +156,7 @@ var addTpCmd = &cobra.Command{
 
 				for i, pk := range pks {
 					if !isJSON {
-						fmt.Printf("[%d/%d] Requesting transport on %s to %s via TPS...\n", i+1, len(pks), targetPK.String()[:16]+"...", pk.String()[:16]+"...")
+						fmt.Printf("[%d/%d] Requesting transport on %s to %s via TPS...\n", i+1, len(pks), targetPK.String(), pk.String())
 					}
 
 					var tpResp *visor.TPSTransportResponse
@@ -166,7 +166,7 @@ var addTpCmd = &cobra.Command{
 						// Use embedded TPS only - if it fails, don't try external nodes
 						tpResp, tpErr = rpcClient.TPSAddTransport(targetPK, pk, tpType)
 						if tpErr == nil && !isJSON {
-							logger.Infof("Established %v transport on %s to %s via embedded TPS", tpType, targetPK.String()[:16], pk.String()[:16])
+							logger.Infof("Established %v transport on %s to %s via embedded TPS", tpType, targetPK.String(), pk.String())
 						}
 					} else {
 						// Embedded TPS not running - use external TPS nodes
@@ -190,13 +190,13 @@ var addTpCmd = &cobra.Command{
 						// Try each TPS node (already sorted by health, healthy first)
 						for _, tpsPK := range tpsNodes {
 							if !isJSON {
-								logger.Debugf("Trying TPS node %s", tpsPK.String()[:16])
+								logger.Debugf("Trying TPS node %s", tpsPK.String())
 							}
 
 							// Health check
 							if err := rpcClient.TPSExternalHealthCheck(tpsPK); err != nil {
 								if !isJSON {
-									logger.WithError(err).Debugf("TPS %s health check failed", tpsPK.String()[:16])
+									logger.WithError(err).Debugf("TPS %s health check failed", tpsPK.String())
 								}
 								continue
 							}
@@ -205,19 +205,19 @@ var addTpCmd = &cobra.Command{
 							tpResp, tpErr = rpcClient.TPSExternalAddTransport(tpsPK, targetPK, pk, tpType)
 							if tpErr == nil {
 								if !isJSON {
-									logger.Infof("Established %v transport on %s to %s via TPS %s", tpType, targetPK.String()[:16], pk.String()[:16], tpsPK.String()[:16])
+									logger.Infof("Established %v transport on %s to %s via TPS %s", tpType, targetPK.String(), pk.String(), tpsPK.String())
 								}
 								break
 							}
 							if !isJSON {
-								logger.WithError(tpErr).Debugf("TPS %s failed to add transport", tpsPK.String()[:16])
+								logger.WithError(tpErr).Debugf("TPS %s failed to add transport", tpsPK.String())
 							}
 						}
 					}
 
 					if tpErr != nil {
 						if !isJSON {
-							logger.WithError(tpErr).Errorf("Failed to establish transport on %s to %s", targetPK.String()[:16], pk.String()[:16])
+							logger.WithError(tpErr).Errorf("Failed to establish transport on %s to %s", targetPK.String(), pk.String())
 						}
 						failCount++
 						continue
@@ -233,7 +233,7 @@ var addTpCmd = &cobra.Command{
 				totalFail += failCount
 
 				if len(pks) > 1 && !isJSON {
-					fmt.Printf("Visor %s: %d/%d transports established\n", targetPK.String()[:16], successCount, len(pks))
+					fmt.Printf("Visor %s: %d/%d transports established\n", targetPK.String(), successCount, len(pks))
 				}
 			}
 
@@ -267,7 +267,7 @@ var addTpCmd = &cobra.Command{
 
 		for i, pk := range pks {
 			if len(pks) > 1 && !isJSON {
-				fmt.Printf("[%d/%d] Adding transport to %s...\n", i+1, len(pks), pk.String()[:16]+"...")
+				fmt.Printf("[%d/%d] Adding transport to %s...\n", i+1, len(pks), pk.String())
 			}
 
 			// Probe dmsg port 136 to check if route setup can reach the
@@ -278,7 +278,7 @@ var addTpCmd = &cobra.Command{
 				reachable, probeErr := rpcClient.DmsgProbe(pk, 136)
 				if probeErr == nil && !reachable {
 					if !isJSON {
-						logger.Warnf("Skipping %s: not reachable on dmsg port 136 (route setup will fail)", pk.String()[:16])
+						logger.Warnf("Skipping %s: not reachable on dmsg port 136 (route setup will fail)", pk.String())
 					}
 					failCount++
 					continue

--- a/cmd/skywire-cli/commands/tp/tp-rm.go
+++ b/cmd/skywire-cli/commands/tp/tp-rm.go
@@ -71,10 +71,10 @@ var rmTpCmd = &cobra.Command{
 					if err := rpcClient.TPSRemoveTransport(targetPK, tID); err != nil {
 						failCount++
 						errors = append(errors, fmt.Sprintf("%s: %v", tpIDStr, err))
-						logger.WithError(err).Warnf("Failed to remove transport %s on %s", tpIDStr, targetPK.String()[:16])
+						logger.WithError(err).Warnf("Failed to remove transport %s on %s", tpIDStr, targetPK.String())
 					} else {
 						successCount++
-						logger.Infof("Removed transport %s on %s", tpIDStr, targetPK.String()[:16])
+						logger.Infof("Removed transport %s on %s", tpIDStr, targetPK.String())
 					}
 				}
 

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -159,21 +159,21 @@ var tpCmd = &cobra.Command{
 
 					// Try each TPS node (already sorted by health, healthy first)
 					for _, tpsPK := range tpsNodes {
-						logger.Debugf("Trying TPS node %s for target %s", tpsPK.String()[:16], targetPK.String()[:16])
+						logger.Debugf("Trying TPS node %s for target %s", tpsPK.String(), targetPK.String())
 
 						// Health check
 						if err := rpcClient.TPSExternalHealthCheck(tpsPK); err != nil {
-							logger.WithError(err).Debugf("TPS %s health check failed", tpsPK.String()[:16])
+							logger.WithError(err).Debugf("TPS %s health check failed", tpsPK.String())
 							continue
 						}
 
 						// Try to get transports via this TPS
 						tpsTransports, tpErr = rpcClient.TPSExternalGetTransports(tpsPK, targetPK)
 						if tpErr == nil {
-							logger.Debugf("Got transports from %s via TPS %s", targetPK.String()[:16], tpsPK.String()[:16])
+							logger.Debugf("Got transports from %s via TPS %s", targetPK.String(), tpsPK.String())
 							break
 						}
-						logger.WithError(tpErr).Debugf("TPS %s failed to get transports for %s", tpsPK.String()[:16], targetPK.String()[:16])
+						logger.WithError(tpErr).Debugf("TPS %s failed to get transports for %s", tpsPK.String(), targetPK.String())
 					}
 				}
 

--- a/cmd/skywire-cli/commands/visor/hvtui.go
+++ b/cmd/skywire-cli/commands/visor/hvtui.go
@@ -197,13 +197,13 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						setStatus("register fwd port failed: " + err.Error())
 						return
 					}
-					setStatus(fmt.Sprintf("forwarded port %d registered on %s", port, targetPK.String()[:8]))
+					setStatus(fmt.Sprintf("forwarded port %d registered on %s", port, targetPK.String()))
 					refresh()
 				}()
 			})
 			form.AddButton("Cancel", closeModal)
 			form.SetBorder(true).
-				SetTitle(" Register forwarded port on " + targetPK.String()[:8] + " ").
+				SetTitle(" Register forwarded port on " + targetPK.String() + " ").
 				SetTitleAlign(tview.AlignLeft)
 			showModal(form, 80, 24)
 		}
@@ -230,7 +230,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 			})
 			form.AddButton("Cancel", closeModal)
 			form.SetBorder(true).
-				SetTitle(" Add transport on " + targetPK.String()[:8] + " ").
+				SetTitle(" Add transport on " + targetPK.String() + " ").
 				SetTitleAlign(tview.AlignLeft)
 			showModal(form, 80, 11)
 		}
@@ -259,7 +259,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 					stColor = tcell.ColorAqua
 				}
 				if e.ProxiedVia != nil {
-					st = "via " + e.ProxiedVia.String()[:8]
+					st = "via " + e.ProxiedVia.String()
 					stColor = tcell.ColorYellow
 				}
 				if e.Error != "" {
@@ -452,7 +452,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 					if !ok {
 						return nil
 					}
-					showInputModal("Set min_hops on "+v.PK.String()[:8], "min_hops", "0", func(s string) {
+					showInputModal("Set min_hops on "+v.PK.String(), "min_hops", "0", func(s string) {
 						n, err := strconv.ParseUint(s, 10, 16)
 						if err != nil {
 							setStatus(fmt.Sprintf("min_hops: invalid number: %s", err))
@@ -463,7 +463,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 								setStatus("set min_hops failed: " + err.Error())
 								return
 							}
-							setStatus(fmt.Sprintf("set min_hops=%d on %s", n, v.PK.String()[:8]))
+							setStatus(fmt.Sprintf("set min_hops=%d on %s", n, v.PK.String()))
 							refresh()
 						}()
 					})
@@ -473,13 +473,13 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 					if !ok {
 						return nil
 					}
-					showInputModal("Set reward address on "+v.PK.String()[:8], "address", v.RewardAddress, func(s string) {
+					showInputModal("Set reward address on "+v.PK.String(), "address", v.RewardAddress, func(s string) {
 						go func() {
 							if _, err := rpcClient.HVSetRewardAddress(v.PK, s); err != nil {
 								setStatus("set reward failed: " + err.Error())
 								return
 							}
-							setStatus("reward address set on " + v.PK.String()[:8])
+							setStatus("reward address set on " + v.PK.String())
 							refresh()
 						}()
 					})
@@ -506,7 +506,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							labels[i] = fmt.Sprintf("[%-7s] %-22s port:%d", state, a.Name, a.Port)
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("Toggle app on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Toggle app on "+v.PK.String(), labels, func(idx int) {
 								a := apps[idx]
 								go func() {
 									var aerr error
@@ -519,7 +519,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 										setStatus(a.Name + ": " + aerr.Error())
 										return
 									}
-									setStatus("toggled " + a.Name + " on " + v.PK.String()[:8])
+									setStatus("toggled " + a.Name + " on " + v.PK.String())
 									refresh()
 								}()
 							})
@@ -549,14 +549,14 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							labels[i] = fmt.Sprintf("%-22s port:%d", a.Name, a.Port)
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("Stop app on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Stop app on "+v.PK.String(), labels, func(idx int) {
 								name := running[idx].Name
 								go func() {
 									if err := rpcClient.HVStopApp(v.PK, name); err != nil {
 										setStatus("stop " + name + " failed: " + err.Error())
 										return
 									}
-									setStatus("stopped " + name + " on " + v.PK.String()[:8])
+									setStatus("stopped " + name + " on " + v.PK.String())
 									refresh()
 								}()
 							})
@@ -578,13 +578,13 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						tps := sum.Overview.Transports
 						labels := make([]string, len(tps))
 						for i, tp := range tps {
-							short := tp.ID.String()[:8] + ".."
-							labels[i] = fmt.Sprintf("%s  %-6s  %s..  %s", short, strings.ToUpper(string(tp.Type)), tp.Remote.String()[:8], tp.Label)
+							short := tp.ID.String() + ".."
+							labels[i] = fmt.Sprintf("%s  %-6s  %s..  %s", short, strings.ToUpper(string(tp.Type)), tp.Remote.String(), tp.Label)
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("Delete transport on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Delete transport on "+v.PK.String(), labels, func(idx int) {
 								tp := tps[idx]
-								short := tp.ID.String()[:8] + ".."
+								short := tp.ID.String() + ".."
 								showConfirmModal("Confirm",
 									fmt.Sprintf("Delete transport %s (%s) ?", short, tp.Type),
 									func() {
@@ -593,7 +593,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 												setStatus("rm transport failed: " + err.Error())
 												return
 											}
-											setStatus("transport " + short + " removed on " + v.PK.String()[:8])
+											setStatus("transport " + short + " removed on " + v.PK.String())
 											refresh()
 										}()
 									})
@@ -616,7 +616,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						rgs := sum.RouteGroups
 						if len(rgs) == 0 {
 							app.QueueUpdateDraw(func() {
-								showInputModal("Delete rule by ID on "+v.PK.String()[:8],
+								showInputModal("Delete rule by ID on "+v.PK.String(),
 									"route ID", "", func(s string) {
 										n, err := strconv.ParseUint(s, 10, 32)
 										if err != nil {
@@ -639,11 +639,11 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						for i, rg := range rgs {
 							labels[i] = fmt.Sprintf("fwd=%d csm=%d  %s..:%d → %s..:%d",
 								rg.FwdRuleID, rg.ConsumeRuleID,
-								rg.Desc.SrcPK.String()[:8], rg.Desc.SrcPort,
-								rg.Desc.DstPK.String()[:8], rg.Desc.DstPort)
+								rg.Desc.SrcPK.String(), rg.Desc.SrcPort,
+								rg.Desc.DstPK.String(), rg.Desc.DstPort)
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("Delete route group on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Delete route group on "+v.PK.String(), labels, func(idx int) {
 								rg := rgs[idx]
 								showConfirmModal("Confirm",
 									fmt.Sprintf("Delete fwd rule %d and consume rule %d ?", rg.FwdRuleID, rg.ConsumeRuleID),
@@ -677,7 +677,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 								return
 							}
 							setStatus(fmt.Sprintf("transport %s.. (%s) added on %s",
-								res.ID.String()[:8], tpType, v.PK.String()[:8]))
+								res.ID.String(), tpType, v.PK.String()))
 							refresh()
 						}()
 					})
@@ -698,14 +698,14 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						newVal := !current
 						app.QueueUpdateDraw(func() {
 							showConfirmModal("Toggle public_autoconnect",
-								fmt.Sprintf("Currently %v on %s. Set to %v?", current, v.PK.String()[:8], newVal),
+								fmt.Sprintf("Currently %v on %s. Set to %v?", current, v.PK.String(), newVal),
 								func() {
 									go func() {
 										if err := rpcClient.HVSetPublicAutoconnect(v.PK, newVal); err != nil {
 											setStatus("set autoconnect failed: " + err.Error())
 											return
 										}
-										setStatus(fmt.Sprintf("public_autoconnect=%v on %s", newVal, v.PK.String()[:8]))
+										setStatus(fmt.Sprintf("public_autoconnect=%v on %s", newVal, v.PK.String()))
 										refresh()
 									}()
 								})
@@ -717,7 +717,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 					if !ok {
 						return nil
 					}
-					showInputModal("Set mux_routes on "+v.PK.String()[:8], "mux_routes (0 or 1 = single)", "1", func(s string) {
+					showInputModal("Set mux_routes on "+v.PK.String(), "mux_routes (0 or 1 = single)", "1", func(s string) {
 						n, err := strconv.Atoi(s)
 						if err != nil || n < 0 {
 							setStatus("mux_routes: invalid number")
@@ -728,7 +728,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 								setStatus("set mux_routes failed: " + err.Error())
 								return
 							}
-							setStatus(fmt.Sprintf("mux_routes=%d on %s", n, v.PK.String()[:8]))
+							setStatus(fmt.Sprintf("mux_routes=%d on %s", n, v.PK.String()))
 							refresh()
 						}()
 					})
@@ -739,7 +739,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						return nil
 					}
 					m := tview.NewModal().
-						SetText(fmt.Sprintf("Local route calculation on %s\n(vs route-finder service)", v.PK.String()[:8])).
+						SetText(fmt.Sprintf("Local route calculation on %s\n(vs route-finder service)", v.PK.String())).
 						AddButtons([]string{"Enable", "Disable", "Cancel"}).
 						SetDoneFunc(func(_ int, label string) {
 							closeModal()
@@ -752,7 +752,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 									setStatus("set calculate_routes failed: " + err.Error())
 									return
 								}
-								setStatus(fmt.Sprintf("calculate_routes=%v on %s", enable, v.PK.String()[:8]))
+								setStatus(fmt.Sprintf("calculate_routes=%v on %s", enable, v.PK.String()))
 								refresh()
 							}()
 						})
@@ -765,14 +765,14 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						return nil
 					}
 					showConfirmModal("Reload visor",
-						fmt.Sprintf("Reload visor %s without restarting?", v.PK.String()[:8]),
+						fmt.Sprintf("Reload visor %s without restarting?", v.PK.String()),
 						func() {
 							go func() {
 								if err := rpcClient.HVReload(v.PK); err != nil {
 									setStatus("reload failed: " + err.Error())
 									return
 								}
-								setStatus("reload triggered on " + v.PK.String()[:8])
+								setStatus("reload triggered on " + v.PK.String())
 								refresh()
 							}()
 						})
@@ -783,14 +783,14 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						return nil
 					}
 					showConfirmModal("Shutdown visor",
-						fmt.Sprintf("SHUTDOWN visor %s? It will stop responding.", v.PK.String()[:8]),
+						fmt.Sprintf("SHUTDOWN visor %s? It will stop responding.", v.PK.String()),
 						func() {
 							go func() {
 								if err := rpcClient.HVShutdown(v.PK); err != nil {
 									setStatus("shutdown failed: " + err.Error())
 									return
 								}
-								setStatus("shutdown sent to " + v.PK.String()[:8])
+								setStatus("shutdown sent to " + v.PK.String())
 								refresh()
 							}()
 						})
@@ -808,7 +808,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							return
 						}
 						var sb strings.Builder
-						sb.WriteString(fmt.Sprintf("[yellow]Service health for %s[white]\n\n", v.PK.String()[:16]))
+						sb.WriteString(fmt.Sprintf("[yellow]Service health for %s[white]\n\n", v.PK.String()))
 						sb.WriteString(fmt.Sprintf("  %-22s %-9s %-7s %-12s %s\n", "SERVICE", "STATUS", "TP", "LATENCY", "VERSION"))
 						sb.WriteString("  ────────────────────────────────────────────────────────────────────────\n")
 						for _, e := range entries {
@@ -853,7 +853,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						return nil
 					}
 					showConfirmModal("DMSG connect-all",
-						fmt.Sprintf("Trigger DMSG connect-all on %s?", v.PK.String()[:8]),
+						fmt.Sprintf("Trigger DMSG connect-all on %s?", v.PK.String()),
 						func() {
 							go func() {
 								res, err := rpcClient.HVDmsgConnectAll(v.PK)
@@ -862,7 +862,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 									return
 								}
 								setStatus(fmt.Sprintf("connect-all on %s: total=%d already=%d new=%d failed=%d",
-									v.PK.String()[:8], res.Total, res.AlreadyConnected, res.NewlyConnected, len(res.Failed)))
+									v.PK.String(), res.Total, res.AlreadyConnected, res.NewlyConnected, len(res.Failed)))
 								refresh()
 							}()
 						})
@@ -872,7 +872,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 					if !ok {
 						return nil
 					}
-					showInputModal("Set DMSG sessions_count on "+v.PK.String()[:8], "sessions_count (0 = all)", "0", func(s string) {
+					showInputModal("Set DMSG sessions_count on "+v.PK.String(), "sessions_count (0 = all)", "0", func(s string) {
 						n, err := strconv.Atoi(s)
 						if err != nil || n < 0 {
 							setStatus("sessions_count: invalid number")
@@ -885,7 +885,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 								return
 							}
 							setStatus(fmt.Sprintf("sessions_count=%d on %s (total=%d already=%d new=%d fail=%d)",
-								n, v.PK.String()[:8], res.Total, res.AlreadyConnected, res.NewlyConnected, len(res.Failed)))
+								n, v.PK.String(), res.Total, res.AlreadyConnected, res.NewlyConnected, len(res.Failed)))
 							refresh()
 						}()
 					})
@@ -908,7 +908,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							labels[i] = a.Name
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("App logs on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("App logs on "+v.PK.String(), labels, func(idx int) {
 								name := apps[idx].Name
 								go func() {
 									setStatus("Loading logs for " + name + "...")
@@ -967,7 +967,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							labels[i] = fmt.Sprintf("[autostart=%-3s] %s", as, a.Name)
 						}
 						app.QueueUpdateDraw(func() {
-							showListModal("Toggle autostart on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Toggle autostart on "+v.PK.String(), labels, func(idx int) {
 								a := apps[idx]
 								newVal := !a.AutoStart
 								go func() {
@@ -975,7 +975,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 										setStatus("set autostart failed: " + err.Error())
 										return
 									}
-									setStatus(fmt.Sprintf("%s autostart=%v on %s", a.Name, newVal, v.PK.String()[:8]))
+									setStatus(fmt.Sprintf("%s autostart=%v on %s", a.Name, newVal, v.PK.String()))
 									refresh()
 								}()
 							})
@@ -1021,7 +1021,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 						}
 						labels = append(labels, "[set upstream]", "[close]")
 						app.QueueUpdateDraw(func() {
-							showListModal("Resolving proxies on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Resolving proxies on "+v.PK.String(), labels, func(idx int) {
 								if idx >= len(active) {
 									if labels[idx] == "[set upstream]" {
 										app.QueueUpdateDraw(func() {
@@ -1099,7 +1099,7 @@ Select a visor to see detailed info. Press 'r' to refresh, 'q' to quit.`,
 							"[close]",
 						)
 						app.QueueUpdateDraw(func() {
-							showListModal("Ports on "+v.PK.String()[:8], labels, func(idx int) {
+							showListModal("Ports on "+v.PK.String(), labels, func(idx int) {
 								n := len(tcpPorts) + len(fwdPorts)
 								if idx < n {
 									return // selecting a row is read-only for now

--- a/cmd/skywire-cli/commands/visor/pair.go
+++ b/cmd/skywire-cli/commands/visor/pair.go
@@ -25,7 +25,6 @@ import (
 
 	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
-	"github.com/skycoin/skywire/pkg/cipher"
 )
 
 var pairPollSince string
@@ -158,7 +157,7 @@ enough that it doesn't roll over between reads.`,
 		fmt.Fprintln(w, "TIMESTAMP\tPEER\tTEXT") //nolint:errcheck,gosec
 		for _, m := range msgs {
 			fmt.Fprintf(w, "%s\t%s\t%s\n", //nolint:errcheck,gosec
-				m.TS.UTC().Format(time.RFC3339Nano), m.PeerPK.Hex()[:16]+"...", m.Text)
+				m.TS.UTC().Format(time.RFC3339Nano), m.PeerPK.Hex(), m.Text)
 		}
 		w.Flush() //nolint:errcheck,gosec
 		internal.PrintOutput(cmd.Flags(), msgs, buf.String())
@@ -189,19 +188,11 @@ func listPairs(cmd *cobra.Command) {
 			last = p.LastMessageAt.UTC().Format(time.RFC3339)
 		}
 		fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n", //nolint:errcheck,gosec
-			truncatePK(p.PeerPK),
+			p.PeerPK.Hex(),
 			p.Status, p.Port,
 			p.EstablishedAt.UTC().Format(time.RFC3339),
 			last)
 	}
 	w.Flush() //nolint:errcheck,gosec
 	internal.PrintOutput(cmd.Flags(), pairs, buf.String())
-}
-
-func truncatePK(pk cipher.PubKey) string {
-	s := pk.Hex()
-	if len(s) > 16 {
-		return s[:16] + "..."
-	}
-	return s
 }

--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -1773,12 +1773,11 @@ func (env *TestEnv) ExecJSONWithTimeout(cmd string, output interface{}, timeout 
 	return err
 }
 
-// truncatePK safely truncates a public key string for logging
+// truncatePK is a no-op identity left in place for compatibility with
+// existing call sites in this test file; PKs are emitted in full so
+// integration-test diagnostic logs stay greppable.
 func truncatePK(pk string) string {
-	if len(pk) < 16 {
-		return pk
-	}
-	return pk[:16] + "..."
+	return pk
 }
 
 // truncateID safely truncates an ID string for logging

--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -276,7 +276,7 @@ func (c *Conn) sendLastRoot(pk cipher.PubKey) {
 	}
 
 	c.n.Printf("[WARN] [%s] sendLastRoot %s: %v (activeHead=%d)",
-		c.String(), pk.Hex()[:7], err, activeHead)
+		c.String(), pk.Hex(), err, activeHead)
 
 }
 
@@ -666,7 +666,7 @@ func (c *Conn) handle(seq uint32, m msg.Msg) (err error) {
 func (c *Conn) handleSub(seq uint32, sub *msg.Sub) (_ error) {
 
 	c.n.Debugf(MsgReceivePin, "[%s] handleSub %s",
-		c.String(), sub.Feed.Hex()[:7])
+		c.String(), sub.Feed.Hex())
 
 	// don't allow blank
 
@@ -712,7 +712,7 @@ func (c *Conn) handleSub(seq uint32, sub *msg.Sub) (_ error) {
 func (c *Conn) handleUnsub(seq uint32, unsub *msg.Unsub) (err error) { //nolint:unparam
 
 	c.n.Debugf(MsgReceivePin, "[%s] handleUnsub %s",
-		c.String(), unsub.Feed.Hex()[:7])
+		c.String(), unsub.Feed.Hex())
 
 	if unsub.Feed == (cipher.PubKey{}) {
 		return errors.New("invalid request Unsub blank feed") // fatal
@@ -743,7 +743,7 @@ func (c *Conn) handleRqList(seq uint32, rq *msg.RqList) (_ error) { //nolint:unp
 func (c *Conn) handleRoot(root *msg.Root) (_ error) {
 
 	c.n.Debugf(MsgReceivePin, "[%s] handleRoot %s/%d/%d",
-		c.String(), root.Feed.Hex()[:7], root.Nonce, root.Seq)
+		c.String(), root.Feed.Hex(), root.Nonce, root.Seq)
 
 	// check seq first (avoid verify-signature for old unwanted Root objects)
 
@@ -836,7 +836,7 @@ func (c *Conn) handleRqObject(seq uint32, rq *msg.RqObject) {
 func (c *Conn) handleRqPreview(seq uint32, rqp *msg.RqPreview) (_ error) {
 
 	c.n.Debugf(MsgReceivePin, "[%s] handleRqPreview %s", c.String(),
-		rqp.Feed.Hex()[:7])
+		rqp.Feed.Hex())
 
 	var r, err = c.n.c.LastRoot(rqp.Feed, c.n.c.ActiveHead(rqp.Feed))
 
@@ -861,7 +861,7 @@ func (c *Conn) handleRqPreview(seq uint32, rqp *msg.RqPreview) (_ error) {
 func (c *Conn) handleRqPeers(seq uint32, rqp *msg.RqPeers) error {
 
 	c.n.Debugf(MsgReceivePin, "[%s] handleRqPeers %s", c.String(),
-		rqp.Feed.Hex()[:7])
+		rqp.Feed.Hex())
 
 	s, ok := c.n.InSwarm(rqp.Feed)
 	if !ok {
@@ -872,7 +872,7 @@ func (c *Conn) handleRqPeers(seq uint32, rqp *msg.RqPeers) error {
 	peers := s.peersForExchange(c.PeerID())
 
 	c.n.Debugf(PEXPin, "sending info about %d peers of feed %s to peer %s, addr %s",
-		len(peers), rqp.Feed.Hex()[:8], c.PeerID().Hex()[:8], c.Address())
+		len(peers), rqp.Feed.Hex(), c.PeerID().Hex(), c.Address())
 
 	c.sendMsg(c.nextSeq(), seq, &msg.Peers{ //nolint:errcheck,gosec
 		Feed: rqp.Feed,

--- a/pkg/cxo/node/feeds.go
+++ b/pkg/cxo/node/feeds.go
@@ -240,7 +240,7 @@ func (n *nodeFeeds) addFeed(pk cipher.PubKey) (added bool) {
 // (handler)
 func (n *nodeFeeds) handleAddFeed(pk cipher.PubKey) {
 
-	n.n.Debug(FeedPin, "handleAddFeed ", pk.Hex()[:7])
+	n.n.Debug(FeedPin, "handleAddFeed ", pk.Hex())
 
 	var ok bool
 
@@ -275,7 +275,7 @@ func (n *nodeFeeds) delFeed(pk cipher.PubKey) {
 // (handler)
 func (n *nodeFeeds) handleDelFeed(pk cipher.PubKey) {
 
-	n.n.Debug(FeedPin, "handleDelFeed ", pk.Hex()[:7])
+	n.n.Debug(FeedPin, "handleDelFeed ", pk.Hex())
 
 	var nf, ok = n.fs[pk]
 
@@ -303,7 +303,7 @@ func (n *nodeFeeds) addConnFeed(c *Conn, pk cipher.PubKey) {
 // (handler)
 func (n *nodeFeeds) handleAddConnFeed(cf connFeed) {
 
-	n.n.Debugln(FeedPin, "handleAddConnFeed", cf.c.String(), cf.f.Hex()[:7])
+	n.n.Debugln(FeedPin, "handleAddConnFeed", cf.c.String(), cf.f.Hex())
 
 	// if the cf.f is blank the this connection is new
 
@@ -337,7 +337,7 @@ func (n *nodeFeeds) delConnFeed(c *Conn, pk cipher.PubKey) {
 // (handler)
 func (n *nodeFeeds) handleDelConnFeed(cf connFeed) {
 
-	n.n.Debugln(FeedPin, "handleDelConnFeed", cf.c.String(), cf.f.Hex()[:7])
+	n.n.Debugln(FeedPin, "handleDelConnFeed", cf.c.String(), cf.f.Hex())
 
 	var nf, ok = n.fs[cf.f]
 

--- a/pkg/cxo/node/swarm.go
+++ b/pkg/cxo/node/swarm.go
@@ -226,7 +226,7 @@ func (s *Swarm) requestPeers() {
 
 		go func(c *Conn) {
 			s.node.Debugf(PEXPin, "requesting peers for feed %s, peer %s, addr %s",
-				s.feed.Hex()[:8], c.PeerID().Hex()[:8], c.Address())
+				s.feed.Hex(), c.PeerID().Hex(), c.Address())
 
 			defer wg.Done()
 
@@ -237,7 +237,7 @@ func (s *Swarm) requestPeers() {
 			resp, err := c.sendRequest(req)
 			if err != nil {
 				s.node.Errorf(err, "failed to send request for feed %s, peer %s, addr %s",
-					s.feed.Hex()[:8], c.PeerID().Hex()[:8], c.Address())
+					s.feed.Hex(), c.PeerID().Hex(), c.Address())
 				// Could track retry count per peer for backoff.
 				return
 			}
@@ -262,7 +262,7 @@ func (s *Swarm) requestPeers() {
 
 			if err != nil {
 				s.node.Errorf(err, "failed to request peers for feed %s, peer %s, addr %s",
-					s.feed.Hex()[:8], c.PeerID().Hex()[:8], c.Address())
+					s.feed.Hex(), c.PeerID().Hex(), c.Address())
 			}
 		}(conns[i])
 	}
@@ -283,11 +283,11 @@ func (s *Swarm) addPeers(peers []msg.PeerInfo) {
 	defer s.mu.Unlock()
 
 	s.node.Debugf(PEXPin, "adding %d peers for feed %s",
-		len(peers), s.feed.Hex()[:8])
+		len(peers), s.feed.Hex())
 
 	if s.cfg.MaxPeers > 0 && s.cfg.MaxPeers <= uint64(len(s.peers)) {
 		s.node.Debugf(PEXPin, "feed %s already have maximum number of peers",
-			s.feed.Hex()[:8])
+			s.feed.Hex())
 		return
 	}
 
@@ -299,7 +299,7 @@ func (s *Swarm) addPeers(peers []msg.PeerInfo) {
 		}
 		if err := s.validatePeer(pi.PubKey, pi.TCPAddr, pi.UDPAddr); err != nil {
 			s.node.Errorf(err, "failed to add peer %s for feed %s",
-				pi.PubKey.Hex()[:8], s.feed.Hex()[:8])
+				pi.PubKey.Hex(), s.feed.Hex())
 			continue
 		}
 		validPeers = append(validPeers, pi)
@@ -314,7 +314,7 @@ func (s *Swarm) addPeers(peers []msg.PeerInfo) {
 		rcap := s.cfg.MaxPeers - uint64(len(s.peers))
 		if uint64(len(peers)) > rcap {
 			s.node.Debugf(PEXPin, "capping number of peers to be added for feed %s to %d",
-				s.feed.Hex()[:8], rcap)
+				s.feed.Hex(), rcap)
 			peers = peers[:rcap]
 		}
 	}
@@ -325,18 +325,18 @@ func (s *Swarm) addPeers(peers []msg.PeerInfo) {
 		if ok {
 			// Existing peer — update last seen time and metadata
 			s.node.Debugf(PEXPin, "updating last seen time of peer %s for feed %s",
-				pi.PubKey.Hex()[:8], s.feed.Hex()[:8])
+				pi.PubKey.Hex(), s.feed.Hex())
 			p.seen()
 
 			if updated := p.update(pi); updated {
 				s.node.Debugf(PEXPin, "updating info about peer %s for feed %s",
-					pi.PubKey.Hex()[:8], s.feed.Hex()[:8])
+					pi.PubKey.Hex(), s.feed.Hex())
 				s.onPeerUpdated(p)
 			}
 		} else {
 			// New peer — add it
 			s.node.Debugf(PEXPin, "adding new peer %s for feed %s",
-				pi.PubKey.Hex()[:8], s.feed.Hex()[:8])
+				pi.PubKey.Hex(), s.feed.Hex())
 			p = msgToPeer(pi)
 			s.onPeerAdded(p)
 		}
@@ -368,7 +368,7 @@ func (s *Swarm) clearOldPeers() {
 	for _, p := range s.peers {
 		if now.Sub(p.LastSeen) > s.cfg.PeerExpirePeriod {
 			s.node.Debugf(PEXPin, "removing expired peer %s from feed %s",
-				p.PubKey.Hex()[:8], s.feed.Hex()[:8])
+				p.PubKey.Hex(), s.feed.Hex())
 
 			delete(s.peers, p.PubKey)
 			s.onPeerRemoved(p)
@@ -438,7 +438,7 @@ func (s *Swarm) createOutgoingConns(count uint64) {
 
 		go func(p Peer) {
 			s.node.Debugf(PEXPin, "connecting to peer %s, sharing feed %s",
-				p.PubKey.Hex()[:8], s.feed.Hex()[:8])
+				p.PubKey.Hex(), s.feed.Hex())
 
 			defer wg.Done()
 
@@ -450,11 +450,11 @@ func (s *Swarm) createOutgoingConns(count uint64) {
 			conn, err = s.node.TCP().Connect(p.TCPAddr)
 			if err != nil {
 				s.node.Errorf(err, "failed to connect to peer %s, sharing feed %s",
-					p.PubKey.Hex()[:8], s.feed.Hex()[:8])
+					p.PubKey.Hex(), s.feed.Hex())
 			} else {
 				if err = conn.Subscribe(s.feed); err != nil {
 					s.node.Errorf(err, "failed to subscribe for feed %s, shared by peer %s",
-						s.feed.Hex()[:8], p.PubKey.Hex()[:8])
+						s.feed.Hex(), p.PubKey.Hex())
 				}
 			}
 

--- a/pkg/cxo/node/transport_dmsg.go
+++ b/pkg/cxo/node/transport_dmsg.go
@@ -67,7 +67,7 @@ func (d *DMSG) Listen() error {
 // ConnectPK connects to a remote CXO node over DMSG by public key.
 // If a connection already exists, returns the existing one.
 func (d *DMSG) ConnectPK(remotePK cipher.PubKey) (*Conn, error) {
-	d.n.Debugf(NewOutConnPin, "[dmsg:%s] connecting", remotePK.String()[:8])
+	d.n.Debugf(NewOutConnPin, "[dmsg:%s] connecting", remotePK.String())
 
 	// Check if connection already exists
 	if c := d.getConn(remotePK); c != nil {
@@ -83,7 +83,7 @@ func (d *DMSG) ConnectPK(remotePK cipher.PubKey) (*Conn, error) {
 	// Init connection (handshake, etc.)
 	c, err := d.n.initConn(fc, false)
 	if err != nil {
-		d.n.Errorf(err, "[dmsg:%s] failed to connect", remotePK.String()[:8])
+		d.n.Errorf(err, "[dmsg:%s] failed to connect", remotePK.String())
 		if !fc.IsClosed() {
 			fc.Close() //nolint:errcheck,gosec
 		}

--- a/pkg/cxo/skyobject/registry/root.go
+++ b/pkg/cxo/skyobject/registry/root.go
@@ -61,18 +61,18 @@ func (r *Root) Short() string {
 	}
 
 	return fmt.Sprintf("%s/%s/%d",
-		r.Pub.Hex()[:7],
+		r.Pub.Hex(),
 		short,
 		r.Seq)
 }
 
 // String implements fmt.Stringer interface.
 // The String method returns string like pub_key/nonce/seq:hash,
-// where the pub_key and the hash trimmed to first seven symbols
-// (hexadecimal encoding used)
+// where the pub_key is the full hex public key and the hash is
+// trimmed to first seven symbols (hexadecimal encoding used).
 func (r *Root) String() string {
 	return fmt.Sprintf("%s/%d/%d:%s",
-		r.Pub.Hex()[:7],
+		r.Pub.Hex(),
 		r.Nonce,
 		r.Seq,
 		r.Hash.Hex()[:7])

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -166,7 +166,7 @@ func (n *Node) Put(ctx context.Context, value []byte, seq uint64, salt []byte) e
 	var putErrors int
 	for _, p := range closest {
 		if err := n.rpcPutValue(ctx, p, item); err != nil {
-			n.log.WithError(err).WithField("peer", p.PK.String()[:8]).Debug("PutValue failed")
+			n.log.WithError(err).WithField("peer", p.PK.String()).Debug("PutValue failed")
 			putErrors++
 		}
 	}
@@ -258,7 +258,7 @@ func (n *Node) dial(ctx context.Context, pk cipher.PubKey) (io.ReadWriteCloser, 
 	n.noDHTMu.RLock()
 	if t, ok := n.noDHT[pk]; ok && time.Since(t) < dhtNegCacheTTL {
 		n.noDHTMu.RUnlock()
-		return nil, fmt.Errorf("dht: peer %s cached as non-DHT", pk.String()[:8])
+		return nil, fmt.Errorf("dht: peer %s cached as non-DHT", pk.String())
 	}
 	n.noDHTMu.RUnlock()
 
@@ -568,7 +568,7 @@ func (n *Node) bootstrapOnce() int {
 		}
 		p := Peer{ID: NodeIDFromPubKey(pk), PK: pk}
 		if err := n.rpcPing(n.ctx, p); err != nil {
-			n.log.WithError(err).WithField("pk", pk.String()[:8]).Debug("Bootstrap ping failed")
+			n.log.WithError(err).WithField("pk", pk.String()).Debug("Bootstrap ping failed")
 			continue
 		}
 		n.rt.Update(p)

--- a/pkg/dht/disc_adapter.go
+++ b/pkg/dht/disc_adapter.go
@@ -150,11 +150,11 @@ func (d *DiscAdapter) SeedServers(ctx context.Context, pks []cipher.PubKey) {
 	for _, pk := range pks {
 		entry, err := d.Entry(ctx, pk)
 		if err != nil {
-			d.log.WithField("pk", pk.String()[:8]).WithError(err).Debug("Failed to seed server from DHT")
+			d.log.WithField("pk", pk.String()).WithError(err).Debug("Failed to seed server from DHT")
 			continue
 		}
 		if entry.Server != nil {
-			d.log.WithField("pk", pk.String()[:8]).Debug("Seeded DMSG server from DHT")
+			d.log.WithField("pk", pk.String()).Debug("Seeded DMSG server from DHT")
 		}
 	}
 }

--- a/pkg/dht/dmsg_transport.go
+++ b/pkg/dht/dmsg_transport.go
@@ -47,7 +47,7 @@ func (t *DMSGTransport) Dial(ctx context.Context, pk cipher.PubKey) (io.ReadWrit
 		}
 	}
 
-	return nil, fmt.Errorf("dht dmsg dial %s: %w", pk.String()[:8], err)
+	return nil, fmt.Errorf("dht dmsg dial %s: %w", pk.String(), err)
 }
 
 // Listen starts accepting incoming DMSG streams on the DHT port.

--- a/pkg/dht/mock_transport.go
+++ b/pkg/dht/mock_transport.go
@@ -40,7 +40,7 @@ func (t *mockTransport) Dial(ctx context.Context, pk cipher.PubKey) (io.ReadWrit
 	lis, ok := t.net.listeners[pk]
 	t.net.mu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("mock: no listener for %s", pk.String()[:8])
+		return nil, fmt.Errorf("mock: no listener for %s", pk.String())
 	}
 
 	// Create a pair of connected pipes.

--- a/pkg/dht/transport_layer.go
+++ b/pkg/dht/transport_layer.go
@@ -148,7 +148,7 @@ func (tl *TransportLayerDHT) Dial(ctx context.Context, pk cipher.PubKey) (io.Rea
 		}
 	}
 	if targetTp == nil {
-		return nil, fmt.Errorf("dht transport: no transport to %s", pk.String()[:8])
+		return nil, fmt.Errorf("dht transport: no transport to %s", pk.String())
 	}
 
 	streamID := tl.nextStreamID()

--- a/pkg/router/cascade_relay.go
+++ b/pkg/router/cascade_relay.go
@@ -46,7 +46,7 @@ func (rc *RSNRelayCache) Update(rsnPK cipher.PubKey, relayPeers []cipher.PubKey)
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.peers[rsnPK] = relayPeers
-	rc.log.WithField("rsn", rsnPK.String()[:8]).
+	rc.log.WithField("rsn", rsnPK.String()).
 		WithField("relay_peers", len(relayPeers)).
 		Debug("Updated RSN relay peer cache")
 }
@@ -67,7 +67,7 @@ func (rc *RSNRelayCache) FindRelayTransport(
 ) (*transport.ManagedTransport, cipher.PubKey, error) {
 	relayPeers := rc.Get(rsnPK)
 	if len(relayPeers) == 0 {
-		return nil, cipher.PubKey{}, fmt.Errorf("no cached relay peers for RSN %s", rsnPK.String()[:8])
+		return nil, cipher.PubKey{}, fmt.Errorf("no cached relay peers for RSN %s", rsnPK.String())
 	}
 
 	// Check if we directly transport any relay peer.

--- a/pkg/router/wrappers.go
+++ b/pkg/router/wrappers.go
@@ -100,7 +100,7 @@ func (d *setupNodeDialer) Dial(
 		for _, sPK := range setupNodes {
 			// Try direct "setup" transport first.
 			if tp := FindDirectRSNTransport(sPK, d.tm); tp != nil {
-				log.WithField("rsn", sPK.String()[:8]).Debug("Using direct setup transport to RSN")
+				log.WithField("rsn", sPK.String()).Debug("Using direct setup transport to RSN")
 				rules, relayErr := d.dialViaTransport(ctx, log, tp, req)
 				if relayErr == nil {
 					return rules, sPK, nil
@@ -111,8 +111,8 @@ func (d *setupNodeDialer) Dial(
 			// Try relay through a neighbor.
 			tp, relayPK, relayErr := d.relayCache.FindRelayTransport(ctx, sPK, d.tm)
 			if relayErr == nil {
-				log.WithField("rsn", sPK.String()[:8]).
-					WithField("relay", relayPK.String()[:8]).
+				log.WithField("rsn", sPK.String()).
+					WithField("relay", relayPK.String()).
 					Debug("Trying relay to RSN via neighbor")
 				rules, relayErr := d.dialViaTransport(ctx, log, tp, req)
 				if relayErr == nil {
@@ -169,7 +169,7 @@ func (d *setupNodeDialer) dialViaTransport(
 		return routing.EdgeRules{}, fmt.Errorf("setup RPC mux not initialized")
 	}
 
-	log.WithField("remote", tp.Remote().String()[:8]).Debug("Dialing RSN via transport virtual stream")
+	log.WithField("remote", tp.Remote().String()).Debug("Dialing RSN via transport virtual stream")
 
 	stream, err := d.setupRPCMux.DialOnTransport(tp)
 	if err != nil {

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -166,7 +166,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 				}
 
 				done := cfg.Stats.RecordRequest()
-				log.WithField("pk", target.pk.Hex()[:16]+"...").
+				log.WithField("pk", target.pk.Hex()).
 					WithField("port", target.port).
 					Debug("SOCKS5 → skynet direct")
 

--- a/pkg/svcmode/svcmode.go
+++ b/pkg/svcmode/svcmode.go
@@ -368,7 +368,7 @@ func Start(ctx context.Context, cfg Config) (*Handle, error) {
 			dhtLog.WithError(err).Warn("DHT node failed to start")
 		} else {
 			h.DHTNode = dhtNode
-			dhtLog.WithField("id", dhtNode.ID().String()[:16]).
+			dhtLog.WithField("id", dhtNode.ID().String()).
 				WithField("bootstrap_peers", len(bootstrapPKs)).
 				Info("DHT full node started")
 		}

--- a/pkg/transport/managed_transport.go
+++ b/pkg/transport/managed_transport.go
@@ -114,9 +114,9 @@ type LatencyStats struct {
 // NewManagedTransport creates a new ManagedTransport.
 func NewManagedTransport(conf ManagedTransportConfig) *ManagedTransport {
 	aPK, bPK := conf.client.PK(), conf.RemotePK
-	log := logging.MustGetLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()[:6]))
+	log := logging.MustGetLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()))
 	if conf.mlog != nil {
-		log = conf.mlog.PackageLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()[:6]))
+		log = conf.mlog.PackageLogger(fmt.Sprintf("tp:%s", conf.RemotePK.String()))
 	}
 	entry := MakeEntry(aPK, bPK, conf.client.Type(), conf.TransportLabel)
 	logEntry := MakeLogEntry(conf.LS, entry.ID, log)

--- a/pkg/transport/network/addrresolver/client.go
+++ b/pkg/transport/network/addrresolver/client.go
@@ -606,7 +606,7 @@ func (c *httpClient) Resolve(ctx context.Context, tType string, pk cipher.PubKey
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			c.log.Debugf("Retrying resolve for %s (attempt %d/%d) after %v", pk.String()[:8], attempt+1, maxRetries+1, delay)
+			c.log.Debugf("Retrying resolve for %s (attempt %d/%d) after %v", pk.String(), attempt+1, maxRetries+1, delay)
 			select {
 			case <-ctx.Done():
 				return VisorData{}, ctx.Err()
@@ -624,7 +624,7 @@ func (c *httpClient) Resolve(ctx context.Context, tType string, pk cipher.PubKey
 
 		if status == http.StatusTooManyRequests {
 			resp.Body.Close() //nolint:errcheck,gosec
-			c.log.Warnf("Rate limited by address resolver on resolve for %s, retrying...", pk.String()[:8])
+			c.log.Warnf("Rate limited by address resolver on resolve for %s, retrying...", pk.String())
 			continue
 		}
 
@@ -655,7 +655,7 @@ func (c *httpClient) Resolve(ctx context.Context, tType string, pk cipher.PubKey
 		return resolveResp, nil
 	}
 
-	return VisorData{}, fmt.Errorf("resolve for %s failed: rate limited after %d attempts", pk.String()[:8], maxRetries+1)
+	return VisorData{}, fmt.Errorf("resolve for %s failed: rate limited after %d attempts", pk.String(), maxRetries+1)
 }
 
 // Transports query available transports.

--- a/pkg/transport/network/sudph.go
+++ b/pkg/transport/network/sudph.go
@@ -147,7 +147,7 @@ func (c *sudphClient) acceptAddresses(conn net.PacketConn, addrCh <-chan addrres
 			// Same public IP - check cache first, then resolve if needed
 			cached, ok := sameLANCache[addr.PK]
 			if !ok {
-				c.log.Debugf("Remote visor %s shares same public IP, resolving LAN addresses", addr.PK.String()[:8])
+				c.log.Debugf("Remote visor %s shares same public IP, resolving LAN addresses", addr.PK.String())
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				visorData, err := c.ar.Resolve(ctx, string(c.netType), addr.PK)
 				cancel()

--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -34,14 +34,14 @@ func (v *Visor) DialDmsgPing(pk cipher.PubKey) error {
 	preferredServer, err := v.GetPreferredDmsgServer(pk)
 	if err == nil && !preferredServer.Null() {
 		// Use the preferred server
-		v.log.WithField("server", preferredServer.String()[:16]+"...").
-			WithField("remote", pk.String()[:16]+"...").
+		v.log.WithField("server", preferredServer.String()).
+			WithField("remote", pk.String()).
 			Debug("Dialing DMSG ping via preferred server")
 		return v.DialDmsgPingViaServer(pk, preferredServer)
 	}
 
 	// Fall back to default dial (dmsg client will pick a server)
-	v.log.WithField("remote", pk.String()[:16]+"...").
+	v.log.WithField("remote", pk.String()).
 		Debug("Dialing DMSG ping via default server selection")
 
 	conn, err := v.dmsgC.Dial(ctx, dmsg.Addr{PK: pk, Port: skyenv.DmsgPingPort})
@@ -105,7 +105,7 @@ func (v *Visor) DialDmsgRPC(pk cipher.PubKey) (net.Conn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	v.log.WithField("remote", pk.String()[:16]+"...").
+	v.log.WithField("remote", pk.String()).
 		Debug("Dialing remote visor RPC over DMSG")
 
 	// Dial to the gRPC DMSG port on the remote visor
@@ -161,7 +161,7 @@ func (v *Visor) GetPreferredDmsgServer(remotePK cipher.PubKey) (cipher.PubKey, e
 	// ourServers is already sorted by latency (lowest first)
 	for _, server := range ourServers {
 		if remoteServerSet[server.PK] {
-			v.log.WithField("server", server.PK.String()[:16]+"...").
+			v.log.WithField("server", server.PK.String()).
 				WithField("latency", server.Latency).
 				Debug("Selected preferred DMSG server")
 			return server.PK, nil
@@ -210,7 +210,7 @@ func (v *Visor) DmsgPing(conf PingConfig) ([]time.Duration, error) {
 func (v *Visor) DmsgPingViaServer(conf PingConfig, serverPK cipher.PubKey) ([]time.Duration, error) {
 	// Dial the ping connection via the specific server
 	if err := v.DialDmsgPingViaServer(conf.PK, serverPK); err != nil {
-		return nil, fmt.Errorf("dial via server %s: %w", serverPK.String()[:16]+"...", err)
+		return nil, fmt.Errorf("dial via server %s: %w", serverPK.String(), err)
 	}
 
 	// Perform the ping
@@ -222,7 +222,7 @@ func (v *Visor) DmsgPingViaServer(conf PingConfig, serverPK cipher.PubKey) ([]ti
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("ping via server %s: %w", serverPK.String()[:16]+"...", err)
+		return nil, fmt.Errorf("ping via server %s: %w", serverPK.String(), err)
 	}
 
 	return latencies, nil
@@ -500,7 +500,7 @@ func (v *Visor) DmsgBandwidthTest(conf BandwidthTestConfig) (BandwidthResult, er
 func (v *Visor) IsDMSGClientReady() (bool, error) {
 	if v.isDTMReady() {
 		dmsgTracker, ok := v.dmsgTracker.manager.Get(v.conf.PK)
-		if ok && dmsgTracker.ServerPK.Hex()[:5] != "00000" {
+		if ok && dmsgTracker.ServerPK.Hex() != "00000" {
 			return true, nil
 		}
 	}

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -90,7 +90,7 @@ func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 
 	resp, err := v.dhtNode.GetItemsFrom(ctx, targetPK, salt, 0, 0)
 	if err != nil {
-		return 0, fmt.Errorf("sync from %s: %w", targetPK.String()[:8], err)
+		return 0, fmt.Errorf("sync from %s: %w", targetPK.String(), err)
 	}
 
 	stored := 0

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -288,7 +288,7 @@ func (hv *Hypervisor) ServeRPC(ctx context.Context, dmsgPort uint16) error {
 				}); err != nil {
 					hv.logger.WithError(err).Debug("Failed to push LAN DMSG server info to visor")
 				} else {
-					hv.logger.WithField("visor", addr.PK.String()[:16]+"...").
+					hv.logger.WithField("visor", addr.PK.String()).
 						Info("Pushed LAN DMSG server info to visor")
 				}
 			}()

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -117,7 +117,7 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 		log.Info("DHT: transport-layer sync enabled (route ID 0)")
 	}
 
-	log.WithField("id", node.ID().String()[:16]).
+	log.WithField("id", node.ID().String()).
 		WithField("bootstrap_peers", len(bootstrapPKs)).
 		WithField("full_node", fullNode).
 		Info("DHT node started")

--- a/pkg/visor/lan_dmsg_discovery.go
+++ b/pkg/visor/lan_dmsg_discovery.go
@@ -23,7 +23,7 @@ func (v *Visor) discoverLANDmsgServer() {
 	// Try saved LAN servers from config
 	if v.conf.Dmsg != nil && len(v.conf.Dmsg.LANServers) > 0 {
 		for _, entry := range v.conf.Dmsg.LANServers {
-			log.Infof("Trying saved LAN DMSG server: %s @ %s", entry.Static.String()[:16]+"...", entry.Server.Address)
+			log.Infof("Trying saved LAN DMSG server: %s @ %s", entry.Static.String(), entry.Server.Address)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			err := v.dmsgC.EnsureSession(ctx, entry)
 			cancel()
@@ -50,7 +50,7 @@ func (v *Visor) SetLANDmsgServer(info LANDmsgServerInfo) error {
 		return nil
 	}
 
-	log.Infof("Hypervisor pushed LAN DMSG server: PK=%s Address=%s", info.PK.String()[:16]+"...", info.Address)
+	log.Infof("Hypervisor pushed LAN DMSG server: PK=%s Address=%s", info.PK.String(), info.Address)
 
 	lanEntry := &dmsgdisc.Entry{
 		Static: info.PK,
@@ -92,7 +92,7 @@ func (v *Visor) saveLANServerToConfig(info *LANDmsgServerInfo) {
 	}
 
 	v.conf.Dmsg.LANServers = []*dmsgdisc.Entry{entry}
-	log.Infof("Saved LAN DMSG server to config: %s @ %s", info.PK.String()[:16]+"...", info.Address)
+	log.Infof("Saved LAN DMSG server to config: %s @ %s", info.PK.String(), info.Address)
 
 	if err := v.conf.Flush(); err != nil {
 		log.WithError(err).Warn("Failed to persist config with LAN DMSG server")

--- a/pkg/visor/pairing.go
+++ b/pkg/visor/pairing.go
@@ -71,7 +71,7 @@ func (v *Visor) PairAdd(peerPK cipher.PubKey) error {
 		// and Resume on a future restart (or a manual retry) will
 		// pick up the subscriber side once the peer is reachable.
 		v.log.WithError(err).
-			WithField("peer", peerPK.Hex()[:8]).
+			WithField("peer", peerPK.Hex()).
 			Debug("Pairing: subscriber Connect failed; pair record kept")
 	}
 	return nil

--- a/pkg/visor/rpc_hypervisor_proxy.go
+++ b/pkg/visor/rpc_hypervisor_proxy.go
@@ -103,7 +103,7 @@ func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 			case <-done:
 			case <-time.After(10 * time.Second):
 				entry.Error = "timeout"
-				log.WithField("pk", pk.String()[:8]).Warn("HVListVisors: visor query timed out")
+				log.WithField("pk", pk.String()).Warn("HVListVisors: visor query timed out")
 			}
 			results[idx] = entry
 		}(i, e.pk, e.conn.API)
@@ -149,7 +149,7 @@ func (v *Visor) HVListVisors() ([]HVVisorEntry, error) {
 			case sub := <-done:
 				subResults[idx] = sub
 			case <-time.After(10 * time.Second):
-				log.WithField("pk", hyperPK.String()[:8]).Warn("HVListVisors: sub-hypervisor query timed out")
+				log.WithField("pk", hyperPK.String()).Warn("HVListVisors: sub-hypervisor query timed out")
 			}
 		}(i, e.pk, e.conn.API)
 	}
@@ -238,7 +238,7 @@ func (v *Visor) hvDispatch(pk cipher.PubKey) (direct API, sub API, err error) {
 			// Skip this sub-hypervisor; it's slow or in a cycle.
 		}
 	}
-	return nil, nil, fmt.Errorf("visor %s not reachable", pk.String()[:8])
+	return nil, nil, fmt.Errorf("visor %s not reachable", pk.String())
 }
 
 // HVStartApp starts an app on the visor identified by pk.

--- a/pkg/visor/rpc_transport_proxy.go
+++ b/pkg/visor/rpc_transport_proxy.go
@@ -74,7 +74,7 @@ func DialTransportRPC(remotePK cipher.PubKey, tm *transport.Manager, log *loggin
 	stream, err := mux.Dial(remotePK)
 	if err != nil {
 		mux.Close() //nolint:errcheck,gosec
-		return nil, fmt.Errorf("transport rpc: dial %s: %w", remotePK.String()[:8], err)
+		return nil, fmt.Errorf("transport rpc: dial %s: %w", remotePK.String(), err)
 	}
 
 	return rpc.NewClient(stream), nil

--- a/pkg/visor/transport_rpc.go
+++ b/pkg/visor/transport_rpc.go
@@ -76,13 +76,13 @@ func (s *TransportRPCServer) Serve() {
 
 		// Check whitelist.
 		if _, ok := s.whitelist[remotePK]; !ok {
-			s.log.WithField("remote_pk", remotePK.String()[:8]).
+			s.log.WithField("remote_pk", remotePK.String()).
 				Warn("Transport RPC rejected: PK not in whitelist")
 			stream.Close() //nolint:errcheck,gosec
 			continue
 		}
 
-		s.log.WithField("remote_pk", remotePK.String()[:8]).
+		s.log.WithField("remote_pk", remotePK.String()).
 			Debug("Transport RPC connection accepted")
 
 		go func() {


### PR DESCRIPTION
## Summary

Public keys in logs, error messages, and CLI output were being
shortened to 6–16 hex chars in dozens of sites. Truncated PKs are
useless for follow-up work — operators can't grep, can't paste into
another command, can't cross-reference DHT/discovery dumps. The space
saved is negligible; the cost in operability is real.

The example that prompted this change:

\`\`\`
[dht]: PutValue failed error=\"dht: peer 02a97d57 cached as non-DHT\" peer=\"02a97d57\"
\`\`\`

Both the error string and the structured field were 8-char prefixes —
an operator can't tell which peer this was without correlating with
some other log they happened to preserve at full PK.

## Audit

Audited every \`\\.Hex\\(\\)\\[:N\\]\`, \`\\.String\\(\\)\\[:N\\]\`, \`+\"...\"\`
variant, and the \`truncatePK\` helper across \`pkg/\` and \`cmd/\`. Fixed
all PK truncations to emit the full 66-char hex; **kept** object-hash
truncations (under \`pkg/cxo/skyobject/\` + \`pkg/cxo/node/head.go\`)
since those are content-addressed identifiers, not public keys, and
the rule is specific to PKs.

40 files touched across \`pkg/dht\`, \`pkg/transport\`, \`pkg/visor\`,
\`pkg/cxo\`, \`cmd/skywire-cli\`, \`cmd/apps/skychat\`.

## Special cases

- **\`pkg/cxo/skyobject/registry/root.go\`** — \`Root.Short\` / \`Root.String\`
  printed \`r.Pub.Hex()[:7]\` (the publisher's public key, not an
  object hash). Now full PK; the per-object hash component
  (\`r.Hash.Hex()[:7]\`) stays truncated.
- **\`cmd/skywire-cli/commands/visor/pair.go\`** — dropped the
  \`truncatePK\` helper from PR-4; the PEER column in
  \`cli visor pair ls\` now shows the full 66-char PK. Table is wider
  but every value is copy-pasteable.
- **\`internal/integration/env_test.go\`** — the test helper
  \`truncatePK\` is rewritten as identity (kept for call-site
  compatibility) so integration-test diagnostic logs stay greppable.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./pkg/dht/... ./pkg/transport/... ./pkg/cxo/... ./pkg/visor/...\` passes
- [x] \`golangci-lint\` clean against project config
- [x] Final grep confirms zero remaining \`PK.Hex()[:N]\` / \`pk.Hex()[:N]\` / \`Pub.Hex()[:N]\` patterns under \`pkg/\` and \`cmd/\` (excluding test files)