### PR TITLE
docs(deployment): document dmsg-server DHT/Redis configuration

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -370,9 +370,18 @@ var RootCmd = &cobra.Command{
 					dhtNode := dht.New(dhtCfg, conf.PubKey, conf.SecKey, dhtTP, dhtLog)
 
 					// Set up persistence backend.
+					// Precedence (matches dht.NewBackendFromConfig): RedisAddr →
+					// PersistPath → in-memory. Visors auto-default PersistPath
+					// to <local>/dht.db (see pkg/visor/init_dht.go); the
+					// dmsg-server is environment-dependent (host vs container
+					// vs k8s) so we require it to be set explicitly. Empty
+					// RedisAddr + empty PersistPath = in-memory only, which is
+					// fine for development but loses state on every restart.
 					if conf.RedisAddr != "" {
 						dhtCfg.RedisAddr = conf.RedisAddr
 						dhtCfg.RedisPassword = os.Getenv("REDIS_PASSWORD")
+					} else if conf.PersistPath != "" {
+						dhtCfg.PersistPath = conf.PersistPath
 					}
 					backend, backendErr := dht.NewBackendFromConfig(&dhtCfg)
 					if backendErr != nil {

--- a/docs/deployment/DEPLOYMENT_SYSTEMD.md
+++ b/docs/deployment/DEPLOYMENT_SYSTEMD.md
@@ -2,7 +2,7 @@
 
 This document describes deploying skywire services directly on the host using systemd.
 
-For Docker Compose deployment, see [DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md).
+For Docker Compose deployment, see [DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md). For Kubernetes notes (illustrative — no production K8s deployment exists today), see [KUBERNETES_DEPLOYMENT.md](KUBERNETES_DEPLOYMENT.md).
 
 (original documentation at: https://github.com/skycoin/skywire-deployment)
 

--- a/docs/deployment/DEPLOYMENT_SYSTEMD.md
+++ b/docs/deployment/DEPLOYMENT_SYSTEMD.md
@@ -217,10 +217,13 @@ combined documentation can be found [here](https://github.com/skycoin/skywire/tr
 * [transport-discovery](#transport-discovery)
 * [dmsg-discovery](#dmsg-discovery)
 * [service-discovery](#service-discovery)
+* [dmsg-server](#dmsg-server) — only when `enable_dht: true` (recommended for production)
 
 #### Redis setup
 
 Redis setup simply entails installing redis and starting the service (which may now be called `valkey.service`).
+
+The same Redis instance can back every service above. The DHT full node embedded in dmsg-server uses the `dht:*` keyspace and reads back the `dht:*` entries that transport-discovery, dmsg-discovery, and service-discovery already write — there is no separate DHT-only Redis to configure.
 
 ### Postgres
 * ~[transport-discovery](#transport-discovery)~
@@ -381,6 +384,21 @@ __The port on which the dmsg server is running must be forwarded or otherwise ac
 
 The above "discovery" endpoint should be changed to match the endpoint of the dmsg discovery server referenced in the previous section.
 The default ports are shown.
+
+##### Optional: DHT full node
+
+Production deployments should also set:
+
+```
+	"enable_dht": true,
+	"redis_addr": "127.0.0.1:6379"
+```
+
+With these set, the dmsg-server runs a Kademlia DHT full node on dmsg port 100 alongside its normal relay duties. The DHT is the serving layer for `dht get <pk> <salt>` lookups from visors, and rehydrates from the same Redis used by transport-discovery / dmsg-discovery / service-discovery (which already write `dht:*` mirror keys). The dmsg-servers in the embedded `dmsg.Prod.DmsgServers` list bootstrap-ping each other automatically, so no extra peer config is needed.
+
+Pass the Redis password to the systemd unit via `Environment=REDIS_PASSWORD=…` (see `init/skywire-dmsg.service`). To wire the DHT-to-HTTP discovery pusher (so visor-published DHT entries flow back into the HTTP services), also set `TPD_URL` and `SD_URL` in the unit's environment.
+
+Without `enable_dht`, the dmsg-server still works as a pure relay — visors will rely on HTTP discovery for everything. Without `redis_addr` (but `enable_dht: true`), the DHT runs in-memory only: it works but loses state on restart and won't serve disc-mirror data.
 
 #### Run `dmsg-server`
 

--- a/docs/deployment/DEPLOYMENT_SYSTEMD.md
+++ b/docs/deployment/DEPLOYMENT_SYSTEMD.md
@@ -398,7 +398,20 @@ With these set, the dmsg-server runs a Kademlia DHT full node on dmsg port 100 a
 
 Pass the Redis password to the systemd unit via `Environment=REDIS_PASSWORD=…` (see `init/skywire-dmsg.service`). To wire the DHT-to-HTTP discovery pusher (so visor-published DHT entries flow back into the HTTP services), also set `TPD_URL` and `SD_URL` in the unit's environment.
 
-Without `enable_dht`, the dmsg-server still works as a pure relay — visors will rely on HTTP discovery for everything. Without `redis_addr` (but `enable_dht: true`), the DHT runs in-memory only: it works but loses state on restart and won't serve disc-mirror data.
+###### Persistence options
+
+The DHT backend is selected from the config in this order:
+
+1. **`redis_addr` set** → Redis. Recommended on the host that runs the discovery services' Redis, since the dmsg-server picks up the full disc-mirror dataset on startup.
+2. **`redis_addr` empty, `persist_path` set** → bbolt. The dmsg-server keeps its own DHT state in a single file. Useful for hosts that don't share a Redis with the primary deployment but should still survive restarts. Example:
+   ```
+   "enable_dht": true,
+   "persist_path": "/var/lib/skywire-dmsg/dht.db"
+   ```
+   Make sure the unit's user can write to that path (`StateDirectory=skywire-dmsg` in the systemd unit creates `/var/lib/skywire-dmsg` automatically). State stays local to this dmsg-server — disc-mirror data from the primary's Redis isn't visible here.
+3. **Both empty** → in-memory only. Works, but restarts start cold.
+
+Without `enable_dht`, the dmsg-server is a pure relay and visors fall back to HTTP discovery for everything.
 
 #### Run `dmsg-server`
 

--- a/docs/deployment/DOCKER_DEPLOYMENT.md
+++ b/docs/deployment/DOCKER_DEPLOYMENT.md
@@ -92,7 +92,7 @@ Update the `public_address` and `discovery` fields to match your deployment. Mou
 
 Setting `enable_dht: true` and `redis_addr` in the dmsg-server's `config.json` turns the process into a Kademlia DHT full node on dmsg port 100, in addition to its normal dmsg relay duties. This is the serving layer that makes `dht get <pk> <salt>` from a visor return real data instead of falling through to HTTP discovery.
 
-Example `config.json`:
+Example `config.json` for a dmsg-server colocated with the cluster's Redis (the primary host's compose):
 
 ```json
 {
@@ -110,12 +110,31 @@ Example `config.json`:
 
 For Docker Compose, the dmsg-server stanza must also pass `REDIS_PASSWORD`, `TPD_URL`, and `SD_URL` in its environment, and depend on `redis` and `dmsg-discovery`. The example in `compose.yaml` already does this.
 
-How the DHT serves data:
+How the DHT serves data when Redis is available:
 - `redis_addr` points the DHT full node at the same Redis used by transport-discovery, dmsg-discovery, and service-discovery. Those services already write a Kademlia-shaped mirror of every entry into Redis under `dht:*` keys (see `pkg/dht/mirror_redis.go`); the dmsg-server's DHT node rehydrates from those keys on startup.
 - The dmsg-servers form a bootstrap mesh by dialing each other's DHT port (over dmsg). The bootstrap PK list is built from the embedded `dmsg.Prod.DmsgServers`/`dmsg.Test.DmsgServers` list automatically, so visors and other dmsg-servers find each other without configuration.
 - `TPD_URL` and `SD_URL` enable the DHT-to-discovery pusher: when a visor publishes its own DHT entry directly (e.g. `tp` or `svc` salts), the dmsg-server forwards that write back into the HTTP discoveries so they stay consistent.
 
-Without `enable_dht`, the dmsg-server still works as a relay — visors just rely on HTTP discovery for everything. Without `redis_addr` (but `enable_dht: true`), the DHT runs in-memory only: it works but loses every entry on restart and won't serve the disc-mirror data.
+#### Persistence options for `enable_dht: true`
+
+The DHT backend is selected from the dmsg-server config in this order:
+
+1. **`redis_addr` set** → Redis backend. Recommended for the primary host where the discovery services already write to the same Redis. The dmsg-server gets the full disc-mirror dataset on startup and serves it to visors via Kademlia. Requires `REDIS_PASSWORD` in the container environment.
+2. **`redis_addr` empty, `persist_path` set** → bbolt backend. The dmsg-server keeps its own DHT state in a single file. State persists across restarts but the cluster's disc-mirror data (which lives in the primary Redis) is **not** reachable from this dmsg-server unless visor traffic happens to replicate it via Kademlia. Useful for off-host dmsg-servers that can't reach the primary's Redis but should still survive container restarts.
+3. **Both empty** → in-memory only. Works fine, but every restart starts cold and the disc-mirror dataset is unreachable.
+
+**Important Docker note for option 2 (bbolt):** the bbolt file path must point inside an existing volume mount, otherwise the file lives in the container's writable layer and is destroyed on `docker compose down && up`. The compose stanzas already mount `./dmsg-server/dmsg-server-N/` to `/etc/skywire/dmsg-server`, so the natural path is:
+
+```json
+{
+  "enable_dht": true,
+  "persist_path": "/etc/skywire/dmsg-server/dht.db"
+}
+```
+
+That puts the bbolt file next to `config.json` on the host (`./dmsg-server/dmsg-server-N/dht.db`) and survives container recreation. No additional volume needed.
+
+Without `enable_dht`, the dmsg-server works as a pure relay — visors rely on HTTP discovery for everything.
 
 ### Setup Node Configuration
 

--- a/docs/deployment/DOCKER_DEPLOYMENT.md
+++ b/docs/deployment/DOCKER_DEPLOYMENT.md
@@ -30,7 +30,7 @@ The compose file defines the following services:
 | address-resolver | `svc ar` | 9093 (TCP), 30178 (UDP) | redis, dmsg-discovery | Resolves visor addresses for STCPR/SUDPH transports |
 | conf-service | `svc confbs` | configurable | none | Config bootstrap server for visor configuration |
 | dmsg-discovery | `dmsg disc` | 9090 | redis | DMSG discovery server |
-| dmsg-server | `dmsg server start` | 8080 (internal) | none | DMSG relay server |
+| dmsg-server | `dmsg server start` | 8080 (internal) | redis (if `enable_dht: true`) | DMSG relay server; optional DHT full node on dmsg port 100 |
 | network-monitor | `svc nm` | configurable | most services | Monitors network health and cleans stale entries |
 | route-finder | `svc rf` | 9092 | redis, dmsg-discovery, transport-discovery | Finds routes between visors |
 | service-discovery | `svc sd` | 9098 | redis, dmsg-discovery | Service discovery (VPN servers, etc.) |
@@ -85,6 +85,35 @@ skywire dmsg server config gen -o dmsg-server-config.json
 ```
 
 Update the `public_address` and `discovery` fields to match your deployment. Mount the config directory as a volume in the compose file.
+
+#### DMSG Server DHT (optional, recommended for production)
+
+Setting `enable_dht: true` and `redis_addr` in the dmsg-server's `config.json` turns the process into a Kademlia DHT full node on dmsg port 100, in addition to its normal dmsg relay duties. This is the serving layer that makes `dht get <pk> <salt>` from a visor return real data instead of falling through to HTTP discovery.
+
+Example `config.json`:
+
+```json
+{
+  "public_key": "0281a102c828...",
+  "secret_key": "...",
+  "discovery": "http://dmsg-discovery:9090",
+  "public_address": "192.0.2.10:30086",
+  "local_address": ":8080",
+  "health_endpoint_address": ":8082",
+  "max_sessions": 2048,
+  "enable_dht": true,
+  "redis_addr": "redis:6379"
+}
+```
+
+For Docker Compose, the dmsg-server stanza must also pass `REDIS_PASSWORD`, `TPD_URL`, and `SD_URL` in its environment, and depend on `redis` and `dmsg-discovery`. The example in `compose.yaml` already does this.
+
+How the DHT serves data:
+- `redis_addr` points the DHT full node at the same Redis used by transport-discovery, dmsg-discovery, and service-discovery. Those services already write a Kademlia-shaped mirror of every entry into Redis under `dht:*` keys (see `pkg/dht/mirror_redis.go`); the dmsg-server's DHT node rehydrates from those keys on startup.
+- The dmsg-servers form a bootstrap mesh by dialing each other's DHT port (over dmsg). The bootstrap PK list is built from the embedded `dmsg.Prod.DmsgServers`/`dmsg.Test.DmsgServers` list automatically, so visors and other dmsg-servers find each other without configuration.
+- `TPD_URL` and `SD_URL` enable the DHT-to-discovery pusher: when a visor publishes its own DHT entry directly (e.g. `tp` or `svc` salts), the dmsg-server forwards that write back into the HTTP discoveries so they stay consistent.
+
+Without `enable_dht`, the dmsg-server still works as a relay — visors just rely on HTTP discovery for everything. Without `redis_addr` (but `enable_dht: true`), the DHT runs in-memory only: it works but loses every entry on restart and won't serve the disc-mirror data.
 
 ### Setup Node Configuration
 

--- a/docs/deployment/DOCKER_DEPLOYMENT.md
+++ b/docs/deployment/DOCKER_DEPLOYMENT.md
@@ -2,6 +2,8 @@
 
 This document describes deploying skywire services using Docker Compose.
 
+For systemd / direct-on-host deployment see [DEPLOYMENT_SYSTEMD.md](DEPLOYMENT_SYSTEMD.md). For Kubernetes notes (illustrative — no production K8s deployment exists today) see [KUBERNETES_DEPLOYMENT.md](KUBERNETES_DEPLOYMENT.md).
+
 All services use the `skycoin/skywire:test` Docker image, which contains the unified skywire binary.
 
 ## Prerequisites

--- a/docs/deployment/KUBERNETES_DEPLOYMENT.md
+++ b/docs/deployment/KUBERNETES_DEPLOYMENT.md
@@ -280,6 +280,32 @@ The dmsg-server's `config.json` (stored in `dmsg-server-1-config` Secret) must i
 
 See [DOCKER_DEPLOYMENT.md "DMSG Server DHT"](DOCKER_DEPLOYMENT.md#dmsg-server-dht-optional-recommended-for-production) for what `enable_dht`, `redis_addr`, `TPD_URL`, and `SD_URL` actually do.
 
+### DHT persistence in K8s
+
+If `redis_addr` points at the cluster's Redis Service, the dmsg-server uses the same Redis-backed disc-mirror dataset as the other services and you're done — no extra volumes needed.
+
+If you want to run a dmsg-server StatefulSet without Redis access (e.g. a remote pool of relays in a separate cluster that can't reach the primary's Redis), use `persist_path` for bbolt persistence. The config Secret is mounted read-only, so the bbolt file needs its own writable PV:
+
+```yaml
+spec:
+  containers:
+    - name: dmsg-server
+      # ...
+      volumeMounts:
+        - { name: dmsg-config,    mountPath: /etc/skywire/dmsg-server, readOnly: true }
+        - { name: dmsg-state,     mountPath: /var/lib/skywire-dmsg }
+        - { name: services-config, mountPath: /etc/skywire }
+  volumeClaimTemplates:
+    - metadata: { name: dmsg-state }
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: { requests: { storage: 1Gi } }
+```
+
+Then set `"persist_path": "/var/lib/skywire-dmsg/dht.db"` in the config Secret. The pod's StatefulSet PVC survives pod restarts and rescheduling on the same node; cross-node moves require an RWX storage class or accept a cold start.
+
+If neither `redis_addr` nor `persist_path` is set, the DHT runs in-memory only — fine for ephemeral / development clusters but every pod restart starts cold.
+
 ## Ingress / TLS
 
 Standard Ingress per service, TLS via cert-manager:

--- a/docs/deployment/KUBERNETES_DEPLOYMENT.md
+++ b/docs/deployment/KUBERNETES_DEPLOYMENT.md
@@ -1,0 +1,341 @@
+# Skywire Kubernetes Deployment
+
+This document describes deploying skywire services on a Kubernetes cluster.
+
+For Docker Compose deployment see [DOCKER_DEPLOYMENT.md](DOCKER_DEPLOYMENT.md).
+For systemd / direct-on-host deployment see [DEPLOYMENT_SYSTEMD.md](DEPLOYMENT_SYSTEMD.md).
+
+## Status of this guide
+
+The reference production deployment runs on Docker Compose; there is no Kubernetes deployment in production today, and the manifests in this guide are illustrative — they describe the shape of a working deployment, not a packaged one. Treat this as a starting point for a custom Helm chart or kustomize tree, and expect to iterate. Snippets here are intentionally minimal so the structure stays readable; production manifests will need resource limits, security contexts, NetworkPolicies, monitoring sidecars, and so on.
+
+## When K8s is and isn't a good fit
+
+K8s fits the parts of the deployment that look like ordinary stateless web services — `dmsg-discovery`, `transport-discovery`, `address-resolver` (HTTP side), `service-discovery`, `route-finder`, `uptime-tracker`, `setup-node`, `config-bootstrapper`, `network-monitor`. These are clean Deployments behind ClusterIP Services with an Ingress for external traffic.
+
+K8s gets awkward for two pieces:
+
+- **STUN server.** RFC 3489 NAT detection requires the server to respond from **two distinct public IPv4 addresses** bound on the same machine, in host networking mode. Pods in K8s normally share the node's IP and don't bind raw addresses. Realistic options: run STUN outside the cluster on a dedicated host (the way Docker Compose does it via `network_mode: "host"`), or use a CNI/loadbalancer that can hand each pod a routable secondary IP. There is no clean, portable manifest for this. If you don't need a custom STUN cluster, point visors at any public RFC-compliant STUN server and skip deploying it yourself.
+
+- **`dmsg-server` public address.** Each dmsg-server advertises a `public_address` (e.g. `192.0.2.10:30086`) in `dmsg-discovery`. Visors dial that address directly over TCP — there is no service-mesh hop. In K8s this means each `dmsg-server` replica needs a stable, externally-reachable IP/port pair that matches its `config.json`. A `Service` of type `LoadBalancer` per replica works but is expensive and provider-specific; `NodePort` works if your nodes have public IPs and you pin replicas with `nodeSelector`. Either way, **`public_address` in each replica's `config.json` must match its actual external address** — there is no auto-detection.
+
+- **Address-resolver UDP port (SUDPH).** AR listens on TCP 9093 (HTTP) and UDP 30178 (KCP/SUDPH). Until K8s 1.24+ you needed two separate Services for mixed-protocol; from 1.24+ a single LoadBalancer Service with `protocol: TCP` and `protocol: UDP` ports works on most cloud providers. Either way the AR's `--public-udp-address` flag (added recently) must be set to the externally-reachable host:port that visors will UDP-dial.
+
+If those three constraints don't match your cluster (e.g. no public-IP LoadBalancer, single-NIC nodes), running the data-plane components on a small VM cluster with Docker Compose alongside a K8s control plane for the HTTP services is a reasonable hybrid.
+
+## Topology
+
+A minimal cluster runs the following workloads:
+
+| Workload | Kind | Replicas | External traffic |
+|---|---|---|---|
+| `redis` | StatefulSet | 1 (or use a managed Redis) | none |
+| `postgres` | StatefulSet | 1 (or use a managed DB) | none — only `uptime-tracker` connects |
+| `dmsg-discovery` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9090 |
+| `address-resolver` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9093, plus LoadBalancer UDP :30178 |
+| `transport-discovery` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9094 |
+| `service-discovery` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9098 |
+| `route-finder` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9092 |
+| `uptime-tracker` | Deployment | 2+ | Ingress (TLS) → ClusterIP :9095 |
+| `config-bootstrapper` | Deployment | 1 | Ingress (TLS) → ClusterIP :9082 |
+| `setup-node` | Deployment | 1+ | none — dmsg-only |
+| `network-monitor` | Deployment | 1 | none — internal |
+| `dmsg-server-N` | StatefulSet (one per server) | 1 each | LoadBalancer or NodePort with stable external IP/port |
+| `geoip` | Deployment | 1 | optional Ingress |
+
+`dmsg-server` is one StatefulSet per server (not one StatefulSet with N replicas) because each server has a unique keypair, a unique advertised `public_address`, and (in the embedded `dmsg.Prod.DmsgServers` list distributed with the binary) a fixed PK that visors expect at a specific dmsg.public-address.
+
+## Secrets and ConfigMaps
+
+Each service that takes a secret key needs one. Keep keys in `Secret` resources, not ConfigMaps:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: skywire-keys
+type: Opaque
+stringData:
+  ar-sk: "<64-hex-chars-from skywire cli config gen-keys>"
+  tpd-sk: "<...>"
+  sd-sk: "<...>"
+  rf-sk: "<...>"
+  ut-sk: "<...>"
+  dmsgd-sk: "<...>"
+  redis-password: "<...>"
+  postgres-password: "<...>"
+  ut-api-key: "<...>"
+```
+
+Whitelisted PKs (network-monitor, survey, etc.) and per-service config files (config-bootstrapper's `config.json`, setup-node config, dmsg-server config minus the secret key) belong in ConfigMaps.
+
+For dmsg-server, mount the public part of the config as a ConfigMap and the secret key as a Secret — assemble them into a single `config.json` at pod start with an init container, or pass the secret key via `--sk` on the command line if the binary supports it.
+
+## Custom services-config.json
+
+The skywire binary embeds a `services-config.json` covering the production deployment's PKs and dmsg-server list. Visors and services use this for bootstrap. **For a custom K8s deployment with its own dmsg-server PKs, override the embedded config via the `SKYDEPLOY` environment variable** pointing at a mounted ConfigMap containing your cluster's services-config.json:
+
+```yaml
+env:
+  - name: SKYDEPLOY
+    value: /etc/skywire/services-config.json
+volumeMounts:
+  - name: services-config
+    mountPath: /etc/skywire
+volumes:
+  - name: services-config
+    configMap:
+      name: skywire-services-config
+```
+
+The format follows `deployment/services-config.json` in the repo — `prod` and `test` keys, each with `dmsg_servers`, `dmsg_discovery`, `transport_discovery`, etc. **Every component in the cluster (services and visors)** must use the same `services-config.json` for DHT bootstrap to work; mismatched lists mean dmsg-servers won't peer with each other and visors won't find DHT full nodes.
+
+## Redis and Postgres
+
+Use a managed Redis / Postgres if your cloud provider offers one — the operational headache of running them as StatefulSets in your own cluster usually exceeds the cost. If you do run them in-cluster, use `volumeClaimTemplates` for persistent storage:
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector: { matchLabels: { app: redis } }
+  template:
+    metadata: { labels: { app: redis } }
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          args:
+            - --requirepass
+            - $(REDIS_PASSWORD)
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef: { name: skywire-keys, key: redis-password }
+          volumeMounts:
+            - { name: data, mountPath: /data }
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources: { requests: { storage: 10Gi } }
+```
+
+The same Redis instance can back every service that needs it (`address-resolver`, `transport-discovery`, `dmsg-discovery`, `service-discovery`, `dmsg-server` DHT). The DHT keys live alongside the discovery keys in the same database — see `pkg/dht/mirror_redis.go`.
+
+## A representative service Deployment
+
+Address-resolver, illustrating the env / args pattern shared by every HTTP service:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: address-resolver }
+spec:
+  replicas: 2
+  selector: { matchLabels: { app: address-resolver } }
+  template:
+    metadata: { labels: { app: address-resolver } }
+    spec:
+      containers:
+        - name: ar
+          image: skycoin/skywire:test
+          args:
+            - svc
+            - ar
+            - --addr
+            - ":9093"
+            - --redis
+            - redis://redis:6379
+            - --dmsg-disc
+            - http://dmsg-discovery:9090
+            - --sk
+            - $(AR_SK)
+            - --public-udp-address
+            - "ar.example.com:30178"
+            - --whitelist-keys
+            - "$(NETWORK_MONITOR_PK)"
+            - --entry-timeout
+            - 5m
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom: { secretKeyRef: { name: skywire-keys, key: redis-password } }
+            - name: AR_SK
+              valueFrom: { secretKeyRef: { name: skywire-keys, key: ar-sk } }
+            - name: SKYDEPLOY
+              value: /etc/skywire/services-config.json
+          ports:
+            - { name: http, containerPort: 9093 }
+            - { name: sudph, containerPort: 30178, protocol: UDP }
+          volumeMounts:
+            - { name: services-config, mountPath: /etc/skywire }
+      volumes:
+        - name: services-config
+          configMap: { name: skywire-services-config }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: address-resolver }
+spec:
+  selector: { app: address-resolver }
+  ports:
+    - { name: http, port: 9093, targetPort: http }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: address-resolver-sudph
+  annotations:
+    # Cloud-specific: ensure the LB is created with UDP support.
+    # Examples: service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector: { app: address-resolver }
+  ports:
+    - { name: sudph, port: 30178, targetPort: sudph, protocol: UDP }
+```
+
+Two services on purpose: HTTP behind the cluster Ingress (TLS-terminated by Ingress controller); SUDPH on a `LoadBalancer` Service so the externally-reachable UDP host:port matches `--public-udp-address`. `externalTrafficPolicy: Local` preserves the source IP so AR's `hasAddress` check passes; without it, AR sees the kube-proxy SNAT'd address and rejects the bind.
+
+The other HTTP-only services (TPD, SD, RF, UT, DMSGD, conf-service) follow the same shape, minus the UDP Service.
+
+## DMSG Server StatefulSet
+
+Each dmsg-server runs as its own StatefulSet so it can have a stable PK and a stable external address. Skeleton:
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: { name: dmsg-server-1 }
+spec:
+  serviceName: dmsg-server-1
+  replicas: 1
+  selector: { matchLabels: { app: dmsg-server-1 } }
+  template:
+    metadata: { labels: { app: dmsg-server-1 } }
+    spec:
+      containers:
+        - name: dmsg-server
+          image: skycoin/skywire:test
+          args:
+            - dmsg
+            - server
+            - start
+            - /etc/skywire/dmsg-server/config.json
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom: { secretKeyRef: { name: skywire-keys, key: redis-password } }
+            - name: TPD_URL
+              value: http://transport-discovery:9094
+            - name: SD_URL
+              value: http://service-discovery:9098
+            - name: SKYDEPLOY
+              value: /etc/skywire/services-config.json
+          ports:
+            - { name: dmsg, containerPort: 8080 }
+          volumeMounts:
+            - { name: dmsg-config, mountPath: /etc/skywire/dmsg-server }
+            - { name: services-config, mountPath: /etc/skywire }
+      volumes:
+        - name: dmsg-config
+          # Assemble at start: secret key from Secret + public config from ConfigMap
+          # via an init container, OR mount a single Secret containing the full
+          # config.json (one Secret per dmsg-server replica).
+          secret: { secretName: dmsg-server-1-config }
+        - name: services-config
+          configMap: { name: skywire-services-config }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: dmsg-server-1-public }
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+  selector: { app: dmsg-server-1 }
+  ports:
+    - { name: dmsg, port: 30081, targetPort: dmsg }
+```
+
+The dmsg-server's `config.json` (stored in `dmsg-server-1-config` Secret) must include:
+
+```json
+{
+  "public_key": "...",
+  "secret_key": "...",
+  "discovery": "http://dmsg-discovery:9090",
+  "public_address": "203.0.113.10:30081",
+  "local_address": ":8080",
+  "max_sessions": 2048,
+  "enable_dht": true,
+  "redis_addr": "redis:6379"
+}
+```
+
+`public_address` must match the LoadBalancer's external IP/port. There's no in-cluster way to discover this before the LB is provisioned; bring up the Service first, note its external IP, then write that into the config Secret. Custom controllers exist that automate this (e.g. CrossPlane, external-dns), but the manual two-step is the simplest path.
+
+See [DOCKER_DEPLOYMENT.md "DMSG Server DHT"](DOCKER_DEPLOYMENT.md#dmsg-server-dht-optional-recommended-for-production) for what `enable_dht`, `redis_addr`, `TPD_URL`, and `SD_URL` actually do.
+
+## Ingress / TLS
+
+Standard Ingress per service, TLS via cert-manager:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: skywire-services
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts:
+        - dmsgd.example.com
+        - ar.example.com
+        - tpd.example.com
+        - sd.example.com
+        - rf.example.com
+        - ut.example.com
+        - conf.example.com
+      secretName: skywire-tls
+  rules:
+    - host: dmsgd.example.com
+      http: { paths: [{ path: /, pathType: Prefix, backend: { service: { name: dmsg-discovery, port: { number: 9090 } } } }] }
+    - host: ar.example.com
+      http: { paths: [{ path: /, pathType: Prefix, backend: { service: { name: address-resolver, port: { number: 9093 } } } }] }
+    # ... and so on for tpd, sd, rf, ut, conf
+```
+
+The Ingress only carries HTTP — the AR's UDP service stays separate (LoadBalancer above). Don't proxy UDP through an HTTP Ingress controller.
+
+## Visor configuration
+
+Visors that should use this cluster get a config generated against your conf-service:
+
+```
+skywire cli config gen -ip -a conf.example.com -o skywire-config.json
+```
+
+Or, for a hand-rolled config, swap the service URLs to your cluster's hostnames. Make sure the visor's binary was built with (or has `SKYDEPLOY` pointing at) the same `services-config.json` the cluster uses, otherwise the dmsg-server PK list will be wrong and DHT bootstrap will fail.
+
+## Pprof / debug access
+
+Each service in the cluster runs pprof on `dmsg port 81`, gated by the `survey_whitelist` baked into the binary or supplied via `SKYDEPLOY`. There is no cluster-side ingress for pprof — it's only reachable over dmsg, by callers whose PK is in the whitelist. This is by design (see PR #2390 series); don't expose `/debug/pprof/` over HTTP Ingress, and don't add Service entries for the dmsg-side pprof port.
+
+For in-cluster Go pprof on individual pods, services accept `--pprof :PORT` to bind a plaintext HTTP pprof handler on a private port. Bind it to localhost or to a ClusterIP-only Service, never to the Ingress.
+
+## Troubleshooting
+
+**dmsg-servers not peering, DHT empty.** Check that every dmsg-server's `public_address` matches its LoadBalancer external address, that all dmsg-server PKs are in the same `services-config.json` mounted into every workload, and that each dmsg-server's `redis_addr` resolves and the password is correct. The dmsg-server's startup log prints "DHT bootstrap succeeded peers=N" when the mesh forms.
+
+**Visors can't register SUDPH.** AR's UDP Service must hand visors a routable host:port that matches `--public-udp-address`. `externalTrafficPolicy: Local` is required so AR sees the visor's real source IP — without it, AR's `hasAddress` check rejects the bind because the kube-proxy SNAT'd address isn't in the visor's claimed local-addresses list.
+
+**STCPR works but SUDPH doesn't.** Same as above, plus check that the cluster's egress doesn't NAT outgoing UDP differently from inbound. SUDPH hole-punching needs symmetric NAT behavior; with strict-symmetric-NAT egress, only STCPR will work.
+
+**Services start but discovery returns empty.** Confirm Redis is reachable from the service pods (try `redis-cli -h redis -a $REDIS_PASSWORD ping` from a debug pod). Confirm the Postgres connection string for uptime-tracker. If service-discovery and transport-discovery are connected to Redis but their `dht:*` mirror is empty, check that they're using the same Redis DB index (`storeconfig.RedisDB` defaults to 0).
+
+**STUN unavailable.** Run STUN outside the cluster (a dedicated VM with two public IPs and `network_mode: host`). Reference its address from the cluster's `services-config.json` `stun_servers` list. There is no portable way to run STUN inside K8s.

--- a/docs/deployment/compose.yaml
+++ b/docs/deployment/compose.yaml
@@ -78,6 +78,14 @@ services:
       - REDIS_PASSWORD=${REDIS_PASSWORD}
     depends_on:
       - redis
+  # dmsg-server stanzas below run with `enable_dht: true` and
+  # `redis_addr: "redis:6379"` set in their config.json. With those, the
+  # process also runs a DHT full node on dmsg port 100 and rehydrates its
+  # store from Redis on every restart. REDIS_PASSWORD must be in the
+  # environment so the DHT backend can authenticate; TPD_URL / SD_URL let
+  # the DHT-to-discovery pusher mirror visor-published DHT entries back
+  # to the HTTP services. See DOCKER_DEPLOYMENT.md "DMSG Server DHT" for
+  # rationale and the trade-offs of disabling DHT.
   dmsg-server-1:
     container_name: dmsg-server-1
     image: "skycoin/skywire:test"
@@ -91,6 +99,13 @@ services:
       - http
       - --pprofaddr
       - :${DMSGSERVER_1_PPROF}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - TPD_URL=http://${TPDISC_HOST}:${TPDISC_PORT}
+      - SD_URL=http://${SD_HOST}:${SD_PORT}
+    depends_on:
+      - redis
+      - dmsg-discovery
     volumes:
       - ./dmsg-server/dmsg-server-1/:/etc/skywire/dmsg-server
     ports:
@@ -109,6 +124,13 @@ services:
       - http
       - --pprofaddr
       - :${DMSGSERVER_6_PPROF}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - TPD_URL=http://${TPDISC_HOST}:${TPDISC_PORT}
+      - SD_URL=http://${SD_HOST}:${SD_PORT}
+    depends_on:
+      - redis
+      - dmsg-discovery
     volumes:
       - ./dmsg-server/dmsg-server-6/:/etc/skywire/dmsg-server
     ports:
@@ -127,6 +149,13 @@ services:
       - http
       - --pprofaddr
       - :${DMSGSERVER_7_PPROF}
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - TPD_URL=http://${TPDISC_HOST}:${TPDISC_PORT}
+      - SD_URL=http://${SD_HOST}:${SD_PORT}
+    depends_on:
+      - redis
+      - dmsg-discovery
     volumes:
       - ./dmsg-server/dmsg-server-7/:/etc/skywire/dmsg-server
     ports:

--- a/docs/deployment/compose1.yaml
+++ b/docs/deployment/compose1.yaml
@@ -6,13 +6,18 @@
 #
 # DHT note: this secondary-host file does NOT include a redis container.
 # If these dmsg-servers are configured with `enable_dht: true` (see
-# DOCKER_DEPLOYMENT.md "DMSG Server DHT"), they need access to the
-# primary host's Redis. Two options:
+# DOCKER_DEPLOYMENT.md "DMSG Server DHT" / "Persistence options"),
+# you have three choices for DHT state:
 #   1. Point each config.json's `redis_addr` at the primary host's
-#      reachable Redis address and pass REDIS_PASSWORD here.
-#   2. Set `enable_dht: false` on these instances — they'll still serve
-#      dmsg traffic and join the bootstrap mesh once at least one of the
-#      cluster's dmsg-servers is reachable, but won't carry DHT state.
+#      reachable Redis address and pass REDIS_PASSWORD here. The
+#      dmsg-server will see the full disc-mirror dataset.
+#   2. Set `persist_path: "/etc/skywire/dmsg-server/dht.db"` in the
+#      config.json — bbolt persists across restarts inside the existing
+#      ./dmsg-server/dmsg-server-N/ host volume. State stays local to
+#      this dmsg-server (no disc-mirror data) but survives `docker
+#      compose down && up`.
+#   3. Leave both unset — DHT runs in-memory only. Works, but every
+#      restart starts cold.
 #
 # Usage:
 #   docker compose -f compose-dmsg-servers.yaml up -d

--- a/docs/deployment/compose1.yaml
+++ b/docs/deployment/compose1.yaml
@@ -4,6 +4,16 @@
 # from the main deployment services. Pair with compose.yaml on the
 # primary host.
 #
+# DHT note: this secondary-host file does NOT include a redis container.
+# If these dmsg-servers are configured with `enable_dht: true` (see
+# DOCKER_DEPLOYMENT.md "DMSG Server DHT"), they need access to the
+# primary host's Redis. Two options:
+#   1. Point each config.json's `redis_addr` at the primary host's
+#      reachable Redis address and pass REDIS_PASSWORD here.
+#   2. Set `enable_dht: false` on these instances — they'll still serve
+#      dmsg traffic and join the bootstrap mesh once at least one of the
+#      cluster's dmsg-servers is reachable, but won't carry DHT state.
+#
 # Usage:
 #   docker compose -f compose-dmsg-servers.yaml up -d
 
@@ -14,6 +24,10 @@ services:
     restart: always
     environment:
       - GODEBUG=madvdontneed=1
+      # Uncomment if this dmsg-server's config.json sets enable_dht: true
+      # - REDIS_PASSWORD=
+      # - TPD_URL=http://tpd.example.com
+      # - SD_URL=http://sd.example.com
     command:
       - dmsg
       - server
@@ -30,6 +44,10 @@ services:
     restart: always
     environment:
       - GODEBUG=madvdontneed=1
+      # Uncomment if this dmsg-server's config.json sets enable_dht: true
+      # - REDIS_PASSWORD=
+      # - TPD_URL=http://tpd.example.com
+      # - SD_URL=http://sd.example.com
     command:
       - dmsg
       - server

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -53,6 +53,15 @@ type Config struct {
 	// additional infrastructure.
 	EnableDHT bool   `json:"enable_dht,omitempty"`
 	RedisAddr string `json:"redis_addr,omitempty"` // Redis for DHT persistence (optional)
+	// PersistPath is a bbolt file path for DHT persistence. Used only
+	// when RedisAddr is empty; ignored otherwise. Empty means in-memory
+	// only — DHT state is lost on every restart and the cluster's
+	// disc-mirror data (which lives in Redis) is unreachable. For
+	// Docker deployments point this at a path inside the existing
+	// config volume mount (e.g. "/etc/skywire/dmsg-server/dht.db").
+	// For Kubernetes use a writable PersistentVolume mount; the config
+	// Secret/ConfigMap is typically read-only and bbolt cannot use it.
+	PersistPath string `json:"persist_path,omitempty"`
 }
 
 // GenerateDefaultConfig generate default config for dmsg-server


### PR DESCRIPTION
## Summary

The `dmsg-server` config fields that turn it into a DHT full node (`enable_dht`, `redis_addr`) and the surrounding compose-file wiring (`REDIS_PASSWORD`, `TPD_URL`, `SD_URL`, `depends_on: redis`) weren't documented anywhere. Production runs with them set, but a fresh follower of `docs/deployment/` would have a working dmsg cluster with an empty DHT and no obvious reason why visor `dht get` was falling through to HTTP every time.

This PR updates the existing deployment docs to match what production actually does, and explains the trade-offs of the two opt-out paths (no `enable_dht` → pure relay; `enable_dht` without `redis_addr` → in-memory DHT that loses state on restart).

## Changes

- **`docs/deployment/compose.yaml`** — `dmsg-server-{1,6,7}` stanzas now declare `environment: REDIS_PASSWORD/TPD_URL/SD_URL` and `depends_on: [redis, dmsg-discovery]`. Comment block above the first stanza points readers at the new doc section.
- **`docs/deployment/compose1.yaml`** — secondary-host file gets a top-level comment block and commented-out env entries explaining the two choices when running dmsg-servers off-host (point `redis_addr` at the primary host vs. set `enable_dht: false`).
- **`DOCKER_DEPLOYMENT.md`** — services-overview row updated; new "DMSG Server DHT" subsection covers the example config, why Redis matters (rehydration of the same `dht:*` keys TPD/DMSGD/SD already write), how the bootstrap mesh forms via `dmsg.Prod.DmsgServers`, and what happens without each piece.
- **`DEPLOYMENT_SYSTEMD.md`** — Redis dependency list adds dmsg-server; the existing dmsg-server example gains an "Optional: DHT full node" note with the same content adapted for systemd `Environment=…` lines.

## Test plan

Documentation-only; no code changes. Reviewed locally for accuracy against:
- `pkg/dht/mirror_redis.go` (where TPD/DMSGD/SD write `dht:*` keys)
- `cmd/dmsg/dmsg-server/commands/start/root.go` (where `enable_dht` / `redis_addr` are consumed and the DHT-to-discovery pusher is wired with `TPD_URL`/`SD_URL`)
- `pkg/dmsg/dmsgserver/config.go` (the `Config.EnableDHT` / `Config.RedisAddr` fields)