### PR TITLE
log/cli: stop truncating public keys (round 2)

### DIFF
--- a/cmd/apps/skychat/history/history.go
+++ b/cmd/apps/skychat/history/history.go
@@ -143,7 +143,7 @@ var (
 	ErrEmptyPeer      = errors.New("peer PK is empty")
 )
 
-// String returns a compact one-line representation of the message.
+// String returns a one-line representation of the message.
 func (m Message) String() string {
 	direction := "<-"
 	if m.Outgoing {
@@ -152,16 +152,9 @@ func (m Message) String() string {
 	return fmt.Sprintf("[%s] %s %s %q",
 		m.Timestamp.UTC().Format(time.RFC3339),
 		direction,
-		shortPK(m.Peer),
+		m.Peer,
 		truncate(m.Text, 60),
 	)
-}
-
-func shortPK(pk string) string {
-	if len(pk) < 16 {
-		return pk
-	}
-	return pk[:16] + "…"
 }
 
 func truncate(s string, n int) string {

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -849,7 +849,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 			}
 
 			if testVerbose {
-				fmt.Printf("Found %d transports for via visor %s\n", len(entries), viaVisor[:16]+"...")
+				fmt.Printf("Found %d transports for via visor %s\n", len(entries), viaVisor)
 			}
 
 			// Extract destination PKs (the "other" edge from each transport)
@@ -864,7 +864,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 			}
 
 			if testVerbose {
-				fmt.Printf("Found %d unique destination visors via %s\n", len(viaDestinations), viaVisor[:16]+"...")
+				fmt.Printf("Found %d unique destination visors via %s\n", len(viaDestinations), viaVisor)
 			}
 		}
 
@@ -1001,7 +1001,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 			}
 
 			if testVerbose {
-				fmt.Printf("Testing %d destinations via %s\n", len(proxiesToTest), viaVisor[:16]+"...")
+				fmt.Printf("Testing %d destinations via %s\n", len(proxiesToTest), viaVisor)
 			}
 		} else {
 			// Fetch proxy servers from service discovery
@@ -1102,7 +1102,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 		// Progress indicator
 		total := len(proxiesToTest)
 		if viaVisor != "" {
-			fmt.Printf("Testing %d destinations via %s (batch=%d, timeout=%ds)\n", total, viaVisor[:16]+"...", testBatchSize, testTimeout)
+			fmt.Printf("Testing %d destinations via %s (batch=%d, timeout=%ds)\n", total, viaVisor, testBatchSize, testTimeout)
 		} else {
 			fmt.Printf("Processing %d proxies (batch=%d, timeout=%ds)...\n", total, testBatchSize, testTimeout)
 		}
@@ -1615,15 +1615,15 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				successCount++
 			}
 			if testConnectOnly {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.PublicKey[:16]+"...", r.Country, r.Version, statusStr, latency) //nolint:errcheck,gosec
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.PublicKey, r.Country, r.Version, statusStr, latency) //nolint:errcheck,gosec
 			} else if viaVisor != "" {
 				via := "-"
 				if r.ViaVisor != "" {
-					via = r.ViaVisor[:8] + "..."
+					via = r.ViaVisor
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", r.PublicKey[:16]+"...", via, statusStr, latency, bandwidth, proxyLoc, proxyIP) //nolint:errcheck,gosec
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", r.PublicKey, via, statusStr, latency, bandwidth, proxyLoc, proxyIP) //nolint:errcheck,gosec
 			} else {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", r.PublicKey[:16]+"...", r.Country, statusStr, latency, bandwidth, proxyLoc, proxyIP) //nolint:errcheck,gosec
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", r.PublicKey, r.Country, statusStr, latency, bandwidth, proxyLoc, proxyIP) //nolint:errcheck,gosec
 			}
 		}
 		w.Flush() //nolint:errcheck,gosec

--- a/cmd/skywire-cli/commands/rewards/server/stats.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats.go
@@ -1089,12 +1089,8 @@ func GenerateVisorBandwidthChartHTML(history []BandwidthHistoryEntry, chartWidth
 				segmentHeight = 1
 			}
 			color := labelColors[pk]
-			shortPK := pk
-			if len(shortPK) > 8 {
-				shortPK = shortPK[:8] + "..."
-			}
 			sb.WriteString(fmt.Sprintf("<div style='position: absolute; left: %dpx; bottom: %dpx; width: %dpx; height: %dpx; background: %s;' title='%s: %s (%s)'></div>\n",
-				x, currentY, barWidth-1, segmentHeight, color, entry.Date, shortPK, formatBytesChart(bw)))
+				x, currentY, barWidth-1, segmentHeight, color, entry.Date, pk, formatBytesChart(bw)))
 			currentY += segmentHeight
 		}
 
@@ -1140,16 +1136,12 @@ func GenerateVisorBandwidthChartHTML(history []BandwidthHistoryEntry, chartWidth
 	}
 	sb.WriteString("</div>\n")
 
-	// Legend — show short PKs with total bandwidth
+	// Legend — show full PKs with total bandwidth
 	sb.WriteString("<div style='margin-top: 15px; display: flex; flex-wrap: wrap; gap: 8px 15px; font-size: 12px;'>\n")
 	for _, pk := range topVisors {
 		color := labelColors[pk]
-		shortPK := pk
-		if len(shortPK) > 16 {
-			shortPK = shortPK[:16] + "..."
-		}
-		sb.WriteString(fmt.Sprintf("<span style='display: inline-flex; align-items: center; gap: 4px; white-space: nowrap;'><span style='display: inline-block; width: 12px; height: 12px; background: %s; flex-shrink: 0;'></span>%s (%s)</span>\n",
-			color, html.EscapeString(shortPK), formatBytesChart(visorTotals[pk])))
+		sb.WriteString(fmt.Sprintf("<span style='display: inline-flex; align-items: center; gap: 4px;'><span style='display: inline-block; width: 12px; height: 12px; background: %s; flex-shrink: 0;'></span><span style='font-family: monospace; word-break: break-all;'>%s</span> (%s)</span>\n",
+			color, html.EscapeString(pk), formatBytesChart(visorTotals[pk])))
 	}
 	if hasOther {
 		var otherTotal uint64
@@ -1643,13 +1635,9 @@ func renderTPDVisorBandwidthChart(metrics []tpdTransportMetric) string {
 		for _, d := range dates {
 			data = append(data, fmt.Sprintf("%d", v.daily[d]))
 		}
-		shortPK := v.pk
-		if len(shortPK) > 12 {
-			shortPK = shortPK[:8] + "..."
-		}
 		color := colors[i%len(colors)]
 		datasets = append(datasets, fmt.Sprintf("{ label: '%s', data: [%s], backgroundColor: '%s' }",
-			shortPK, strings.Join(data, ","), color))
+			v.pk, strings.Join(data, ","), color))
 	}
 
 	l := "<canvas id='visor-bw-chart' width='800' height='400'></canvas>\n"

--- a/cmd/skywire-cli/commands/route/rsn_remote.go
+++ b/cmd/skywire-cli/commands/route/rsn_remote.go
@@ -57,7 +57,7 @@ visor's config.`,
 		url := fmt.Sprintf("dmsg://%s:80/stats", pk)
 		body, err := clirpc.FetchServiceURL(cmd.Flags(), url)
 		if err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to fetch RSN stats from %s: %w", pk[:16], err))
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to fetch RSN stats from %s: %w", pk, err))
 		}
 
 		// Try to pretty-print JSON

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -156,7 +156,7 @@ func DmsgClient(cmdFlags *pflag.FlagSet) (visor.API, error) {
 	// Use the configured timeout for RPC calls
 	rpcCallTimeout := time.Duration(Timeout) * time.Second
 	// Use logger with dmsg address as tag for better identification
-	dmsgLogger := logging.MustGetLogger(fmt.Sprintf("dmsg://%s", VisorPK[:8]))
+	dmsgLogger := logging.MustGetLogger(fmt.Sprintf("dmsg://%s", VisorPK))
 	return visor.NewRPCClient(dmsgLogger, conn, visor.RPCPrefix, rpcCallTimeout), nil
 }
 

--- a/cmd/skywire-cli/commands/skychat/root.go
+++ b/cmd/skywire-cli/commands/skychat/root.go
@@ -80,7 +80,7 @@ var sendCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("server error (%d): %s", resp.StatusCode, errBody.String()))
 		}
 
-		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("Message sent to %s via %s\n", recipient[:16]+"...", networkType))
+		internal.PrintOutput(cmd.Flags(), nil, fmt.Sprintf("Message sent to %s via %s\n", recipient, networkType))
 	},
 }
 
@@ -121,12 +121,7 @@ var listenCmd = &cobra.Command{
 					continue
 				}
 
-				// Format and display the message
-				senderShort := msg.Sender
-				if len(senderShort) > 16 {
-					senderShort = senderShort[:16] + "..."
-				}
-				fmt.Printf("[%s] %s\n", senderShort, msg.Message)
+				fmt.Printf("[%s] %s\n", msg.Sender, msg.Message)
 			}
 		}
 

--- a/cmd/skywire-cli/commands/skynet/root.go
+++ b/cmd/skywire-cli/commands/skynet/root.go
@@ -142,11 +142,7 @@ var startCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to start %s: %w", appName, err))
 		}
 
-		pkShort := remotePk
-		if len(pkShort) > 16 {
-			pkShort = pkShort[:16] + "..."
-		}
-		fmt.Printf("Starting %s -> %s:%d -> localhost:%d ", appName, pkShort, remotePort, localPort)
+		fmt.Printf("Starting %s -> %s:%d -> localhost:%d ", appName, remotePk, remotePort, localPort)
 
 		// Poll for app status until running, errored, or stopped
 		for {
@@ -320,11 +316,7 @@ Examples:
 				// Show connection info from args
 				for i, arg := range state.Args {
 					if arg == "--srv" && i+1 < len(state.Args) {
-						pk := state.Args[i+1]
-						if len(pk) > 16 {
-							pk = pk[:16] + "..."
-						}
-						_, err = fmt.Fprintf(w, "Server:\t%s\n", pk)
+						_, err = fmt.Fprintf(w, "Server:\t%s\n", state.Args[i+1])
 						internal.Catch(cmd.Flags(), err)
 					}
 					if arg == "--remote" && i+1 < len(state.Args) {

--- a/cmd/skywire-cli/commands/tp/tp-add-pv.go
+++ b/cmd/skywire-cli/commands/tp/tp-add-pv.go
@@ -30,7 +30,7 @@ func isVisorUnreachableError(err error, remotePK string) bool {
 	errStr := err.Error()
 	// Only consider it unreachable if the error specifically mentions the remote PK
 	// and indicates a dial timeout or EOF
-	if strings.Contains(errStr, remotePK[:16]) || strings.Contains(errStr, remotePK) {
+	if strings.Contains(errStr, remotePK) {
 		if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "EOF") {
 			return true
 		}

--- a/cmd/skywire-cli/commands/visor/hv.go
+++ b/cmd/skywire-cli/commands/visor/hv.go
@@ -224,9 +224,6 @@ transport count, and other details. The local visor is shown first.`,
 		fmt.Fprintln(tw, "PK\tVERSION\tUPTIME\tTP\tAPPS\tIP\tCC\tSTATUS") //nolint:errcheck
 		for _, e := range entries {
 			pk := e.PK.String()
-			if len(pk) > 10 {
-				pk = pk[:8] + ".."
-			}
 			status := "ok"
 			if e.IsLocal {
 				status = "local"

--- a/cmd/skywire-cli/commands/visor/ping/graph.go
+++ b/cmd/skywire-cli/commands/visor/ping/graph.go
@@ -539,7 +539,7 @@ var pingGraphCmd = &cobra.Command{
 								if ctx.Err() != nil {
 									return false, detail
 								}
-								fmt.Printf("    Server %s: error: %v\n", server[:16]+"...", err)
+								fmt.Printf("    Server %s: error: %v\n", server, err)
 							}
 						}
 					}
@@ -598,13 +598,13 @@ var pingGraphCmd = &cobra.Command{
 							hopLatencies[i] = hopLatencyMs
 							segmentLatency := hopLatencyMs - prevLatency
 							if i == 0 {
-								fmt.Printf("    Hop %d (%s): %.2f ms\n", i+1, hopPK[:8]+"...", hopLatencyMs)
+								fmt.Printf("    Hop %d (%s): %.2f ms\n", i+1, hopPK, hopLatencyMs)
 							} else {
-								fmt.Printf("    Hop %d (%s): %.2f ms (segment: +%.2f ms)\n", i+1, hopPK[:8]+"...", hopLatencyMs, segmentLatency)
+								fmt.Printf("    Hop %d (%s): %.2f ms (segment: +%.2f ms)\n", i+1, hopPK, hopLatencyMs, segmentLatency)
 							}
 							prevLatency = hopLatencyMs
 						} else {
-							fmt.Printf("    Hop %d (%s): failed\n", i+1, hopPK[:8]+"...")
+							fmt.Printf("    Hop %d (%s): failed\n", i+1, hopPK)
 						}
 					}
 					detail.hopLatencies = hopLatencies
@@ -1025,12 +1025,12 @@ func runTreeViewMode(
 	// Helper to get DMSG servers for a visor
 	getVisorDmsgServers := func(visorPK string) []string {
 		if !dmsgClientsLoaded {
-			fmt.Fprintf(os.Stderr, "DEBUG: DMSG clients not loaded, skipping DMSG pre-check for %s\n", visorPK[:16])
+			fmt.Fprintf(os.Stderr, "DEBUG: DMSG clients not loaded, skipping DMSG pre-check for %s\n", visorPK)
 			return nil
 		}
 		servers := visorDmsgServers[visorPK]
 		if len(servers) == 0 {
-			fmt.Fprintf(os.Stderr, "DEBUG: No DMSG servers found for visor %s\n", visorPK[:16])
+			fmt.Fprintf(os.Stderr, "DEBUG: No DMSG servers found for visor %s\n", visorPK)
 		}
 		return servers
 	}
@@ -1149,7 +1149,7 @@ func runTreeViewMode(
 		}
 		// Remove from local tracking
 		delete(localTpIDs, tpID)
-		fmt.Fprintf(os.Stderr, "Removed local transport %s\n", tpID[:16])
+		fmt.Fprintf(os.Stderr, "Removed local transport %s\n", tpID)
 		return nil
 	}
 
@@ -1179,7 +1179,7 @@ func runTreeViewMode(
 			return fmt.Errorf("timeout removing remote transport")
 		}
 
-		fmt.Fprintf(os.Stderr, "Requested removal of transport %s from remote visor %s\n", tpID[:16], remotePK[:16])
+		fmt.Fprintf(os.Stderr, "Requested removal of transport %s from remote visor %s\n", tpID, remotePK)
 		return nil
 	}
 
@@ -1349,7 +1349,7 @@ func runTreeViewMode(
 			var localPKObj cipher.PubKey
 			if err := remotePKObj.Set(remotePK); err == nil {
 				if err := localPKObj.Set(localPK); err == nil {
-					fmt.Printf("  Attempting to remake transport to %s...\n", remotePK[:16])
+					fmt.Printf("  Attempting to remake transport to %s...\n", remotePK)
 					newTp, err := rpcClient.TPSAddTransport(localPKObj, remotePKObj, tpType)
 					if err != nil {
 						fmt.Printf("  Failed to remake transport: %v\n", err)
@@ -2120,7 +2120,7 @@ func runTreeViewMode(
 		var dmsgServers []string
 		if graphDmsgPreCheck {
 			dmsgServers = getVisorDmsgServers(remotePK)
-			fmt.Fprintf(os.Stderr, "DEBUG: DMSG pre-check for %s, got %d servers\n", remotePK[:16], len(dmsgServers))
+			fmt.Fprintf(os.Stderr, "DEBUG: DMSG pre-check for %s, got %d servers\n", remotePK, len(dmsgServers))
 		}
 
 		// DMSG pings goroutine (sequential through servers, concurrent with route ping)
@@ -2297,7 +2297,7 @@ func runTreeViewMode(
 					} else if graphUseTPS {
 						localSideTps := getRemoteVisorTransports(localVisorPK)
 						if localSideTps != nil && !localSideTps[tpIDToVerify] {
-							fmt.Fprintf(os.Stderr, "Transport %s not found on local-side %s\n", tpIDToVerify[:16], localVisorPK[:16])
+							fmt.Fprintf(os.Stderr, "Transport %s not found on local-side %s\n", tpIDToVerify[:16], localVisorPK)
 							return false
 						}
 					}
@@ -2305,7 +2305,7 @@ func runTreeViewMode(
 					if graphUseTPS {
 						remoteTps := getRemoteVisorTransports(remoteVisorPK)
 						if remoteTps != nil && !remoteTps[tpIDToVerify] {
-							fmt.Fprintf(os.Stderr, "Transport %s not found on remote %s\n", tpIDToVerify[:16], remoteVisorPK[:16])
+							fmt.Fprintf(os.Stderr, "Transport %s not found on remote %s\n", tpIDToVerify[:16], remoteVisorPK)
 							return false
 						}
 					}
@@ -2832,7 +2832,7 @@ func runTreeViewMode(
 				if path, ok := visorPath[entry.parentPK]; ok && len(path) > 0 {
 					firstHopInfo = fmt.Sprintf(" (1st: %s)", path[0].tpID[:8])
 				}
-				textOut.WriteString(fmt.Sprintf("  %s via %s %s%s %s\n", entry.remotePK, entry.parentPK[:16], entry.tpID, firstHopInfo, latStr))
+				textOut.WriteString(fmt.Sprintf("  %s via %s %s%s %s\n", entry.remotePK, entry.parentPK, entry.tpID, firstHopInfo, latStr))
 			}
 		}
 

--- a/cmd/skywire-cli/commands/visor/ping/tree2.go
+++ b/cmd/skywire-cli/commands/visor/ping/tree2.go
@@ -1564,7 +1564,7 @@ func (m *pingTreeModel) runDmsgMode() {
 		m.setStatus(fmt.Sprintf("DMSG ping %d/%d", i+1, len(targets)))
 
 		entry := tuiTreeEntry{
-			tpID:     fmt.Sprintf("dmsg-%s", remotePK[:16]),
+			tpID:     fmt.Sprintf("dmsg-%s", remotePK),
 			tpType:   "dmsg",
 			remotePK: remotePK,
 			level:    1,

--- a/cmd/skywire-cli/commands/visor/reward.go
+++ b/cmd/skywire-cli/commands/visor/reward.go
@@ -87,11 +87,11 @@ func fetchAndDisplayReward(rpcClient visor.API, rewardDmsg, pk string) {
 		Method: "GET",
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to fetch reward data for %s: %v\n", pk[:16]+"...", err)
+		fmt.Fprintf(os.Stderr, "Failed to fetch reward data for %s: %v\n", pk, err)
 		return
 	}
 	if resp.StatusCode != 200 {
-		fmt.Fprintf(os.Stderr, "Reward system returned status %d for %s\n", resp.StatusCode, pk[:16]+"...")
+		fmt.Fprintf(os.Stderr, "Reward system returned status %d for %s\n", resp.StatusCode, pk)
 		return
 	}
 
@@ -113,14 +113,14 @@ func fetchAndDisplayReward(rpcClient visor.API, rewardDmsg, pk string) {
 	}
 
 	if err := json.Unmarshal(resp.Body, &result); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse reward data for %s: %v\n", pk[:16]+"...", err)
+		fmt.Fprintf(os.Stderr, "Failed to parse reward data for %s: %v\n", pk, err)
 		return
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(w, "Reward history for %s (%d days)\n\n", pk[:16]+"...", rewardDays) //nolint:errcheck,gosec
-	fmt.Fprintf(w, "DATE\tAMOUNT (SKY)\tSHARE (%%)\tSTATUS\tTXID\n")                 //nolint:errcheck,gosec
-	fmt.Fprintf(w, "----\t------------\t---------\t------\t----\n")                  //nolint:errcheck,gosec
+	fmt.Fprintf(w, "Reward history for %s (%d days)\n\n", pk, rewardDays) //nolint:errcheck,gosec
+	fmt.Fprintf(w, "DATE\tAMOUNT (SKY)\tSHARE (%%)\tSTATUS\tTXID\n")      //nolint:errcheck,gosec
+	fmt.Fprintf(w, "----\t------------\t---------\t------\t----\n")       //nolint:errcheck,gosec
 
 	var total float64
 	for _, day := range result.History {

--- a/pkg/tpviz/wasm/ui/app.go
+++ b/pkg/tpviz/wasm/ui/app.go
@@ -1041,7 +1041,7 @@ func (a *App) localCreateTransport() {
 		return
 	}
 
-	a.updateLocalTPResult("success", "Created: "+strings.ToUpper(resp.Type)+" → "+resp.RemotePK[:16]+"...")
+	a.updateLocalTPResult("success", "Created: "+strings.ToUpper(resp.Type)+" → "+resp.RemotePK)
 
 	// Clear input after success
 	input := getElement("local-tp-remote-pk")
@@ -1195,7 +1195,7 @@ func (a *App) tpsAddTransport() {
 	resultEl.Get("classList").Call("remove", "tps-loading")
 	resultEl.Get("classList").Call("add", "tps-success")
 	resultEl.Set("innerHTML", "Created "+strings.ToUpper(resp.Type)+"<br>"+
-		resp.LocalPK[:12]+"... ↔ "+resp.RemotePK[:12]+"...")
+		resp.LocalPK+" ↔ "+resp.RemotePK)
 
 	// Add the new transport as an edge in the graph immediately (will be
 	// confirmed/replaced on the next data refresh cycle).
@@ -1283,7 +1283,7 @@ func (a *App) tpsRefreshTransports() {
 		html.WriteString("style=\"padding:1px 5px;font-size:0.65em;background:#e94560;color:#fff;border:none;border-radius:2px;cursor:pointer;\">✕</button>")
 		html.WriteString("</div>")
 		html.WriteString("<div style=\"font-size:0.7em;color:#aaa;margin-top:2px;word-break:break-all;\">")
-		html.WriteString(t.RemotePK[:20] + "...")
+		html.WriteString(t.RemotePK)
 		html.WriteString("</div></div>")
 	}
 	html.WriteString("</div>")

--- a/pkg/tpviz/wasm/ui/graph.go
+++ b/pkg/tpviz/wasm/ui/graph.go
@@ -463,14 +463,6 @@ func (o *RenderOptions) ShowNodeStatus(s NodeStatus) bool {
 
 // Helper functions
 
-// shortPK returns a shortened version of a public key
-func shortPK(pk string) string {
-	if len(pk) <= 8 {
-		return pk
-	}
-	return pk[:8]
-}
-
 // itoa converts int to string without fmt
 func itoa(i int) string {
 	if i == 0 {

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -744,7 +744,7 @@ func initDmsgServerLatency(ctx context.Context, v *Visor, log *logging.Logger) e
 			// Use DmsgPingViaServer to ping ourselves through this specific server
 			latencies, err := v.DmsgPingViaServer(conf, serverPK)
 			if err != nil {
-				log.WithError(err).WithField("server", serverPKStr[:16]+"...").Warn("Failed to measure server latency")
+				log.WithError(err).WithField("server", serverPKStr).Warn("Failed to measure server latency")
 				continue
 			}
 
@@ -761,7 +761,7 @@ func initDmsgServerLatency(ctx context.Context, v *Visor, log *logging.Logger) e
 			v.dmsgLatency.mu.Unlock()
 
 			log.WithFields(logrus.Fields{
-				"server":  serverPKStr[:16] + "...",
+				"server":  serverPKStr,
 				"latency": avgLatency.Round(time.Millisecond),
 				"elapsed": time.Since(start).Round(time.Millisecond),
 			}).Info("Measured DMSG server latency")


### PR DESCRIPTION
## Summary

Followup to #2391. The first audit caught typed-PK truncations (`pk.Hex()[:N]`, `pk.String()[:N]`) but missed already-stringified PKs assigned via short-name shadowing (`shortPK := pk; shortPK = shortPK[:N]+"..."`) and a few sites passing the raw `string` PK through `[:N]+"..."` directly.

Sites fixed:
- `cli skynet status` server PK (the trigger for this PR — visible truncation in the user-reported output)
- `cli skynet start` startup line
- `cli skychat send` / `listen` sender PK in SSE output
- `cli proxy` table rows, via-visor labels, test-batch/timing logs
- `cli ping graph` per-hop logs, visor-DMSG-precheck DEBUG, transport-not-found errors, parent-PK in tree text output
- `cli rsn` remote stats fetch error, reward fetch/parse errors, reward history table header
- `hv ls` table column (PK column)
- `tpviz` wasm UI: TPS create-result label, transport list per-target line
- `pkg/visor/init_dmsg.go`: DMSG server-latency log fields (operator-facing log)
- `cli rpc/root.go` dmsg logger tag (visor PK)

Transport IDs and content-addressed object hashes (cxo skyobject `Hash`, etc.) retain their existing shorteners — they are not public keys.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean
- [ ] Operator output spot-check after deploy: `cli skynet status` shows full server PK; `cli proxy ls` shows full PKs; `cli ping graph` no truncation in DEBUG/info lines; reward history full PK