### PR TITLE
visor: enforce per-port PK whitelist on raw-TCP skynet and DMSG paths

### DIFF
--- a/pkg/visor/api_network.go
+++ b/pkg/visor/api_network.go
@@ -17,6 +17,7 @@ import (
 	clirewardsserver "github.com/skycoin/skywire/cmd/skywire-cli/commands/rewards/server"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/routing"
 	"github.com/skycoin/skywire/pkg/skyenv"
@@ -292,6 +293,23 @@ func (v *Visor) ListForwardedPorts() ([]ForwardedPort, error) {
 	return v.forwardedPorts.List(), nil
 }
 
+// isPeerAllowed reports whether the peer is allowed to access the given
+// forwarded port. The port is treated as open when there is no entry in
+// forwardedPorts (legacy compatibility) or when its Whitelist is empty;
+// otherwise the peer PK must appear in the list.
+func (v *Visor) isPeerAllowed(port int, pk cipher.PubKey) bool {
+	fp := v.forwardedPorts.Get(port)
+	if fp == nil || len(fp.Whitelist) == 0 {
+		return true
+	}
+	for _, wl := range fp.Whitelist {
+		if wl == pk {
+			return true
+		}
+	}
+	return false
+}
+
 func isPortAvailable(log *logging.Logger, port int) bool {
 	timeout := time.Second
 	conn, err := net.DialTimeout("tcp", fmt.Sprintf(":%v", port), timeout)
@@ -466,6 +484,20 @@ func (v *Visor) startDmsgForwarder(port, localPort int) {
 			}
 			go func() {
 				defer conn.Close() //nolint:errcheck
+				// Enforce per-port PK whitelist if one is set. The DMSG
+				// listener's RemoteAddr is dmsg.Addr — fail closed if
+				// the assertion fails on a whitelisted port.
+				if fp := v.forwardedPorts.Get(port); fp != nil && len(fp.Whitelist) > 0 {
+					a, ok := conn.RemoteAddr().(dmsg.Addr)
+					if !ok {
+						log.Warn("Rejected: cannot identify peer on whitelisted port")
+						return
+					}
+					if !v.isPeerAllowed(port, a.PK) {
+						log.WithField("peer", a.PK).Warn("Rejected: peer not in whitelist")
+						return
+					}
+				}
 				local, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", localPort))
 				if err != nil {
 					log.WithError(err).Debug("Failed to dial local port")

--- a/pkg/visor/forwarded_ports_test.go
+++ b/pkg/visor/forwarded_ports_test.go
@@ -1,0 +1,53 @@
+package visor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestForwardedPorts_IsWhitelisted(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+	pk3, _ := cipher.GenerateKeyPair()
+
+	t.Run("unregistered port denies", func(t *testing.T) {
+		fp := NewForwardedPorts("")
+		assert.False(t, fp.IsWhitelisted(8080, pk1))
+	})
+
+	t.Run("empty whitelist allows everyone", func(t *testing.T) {
+		fp := NewForwardedPorts("")
+		assert.NoError(t, fp.Register(ForwardedPort{Port: 8080, Skynet: true}))
+		assert.True(t, fp.IsWhitelisted(8080, pk1))
+		assert.True(t, fp.IsWhitelisted(8080, pk2))
+	})
+
+	t.Run("whitelist allows listed PKs only", func(t *testing.T) {
+		fp := NewForwardedPorts("")
+		assert.NoError(t, fp.Register(ForwardedPort{
+			Port:      8080,
+			Skynet:    true,
+			Whitelist: []cipher.PubKey{pk1, pk2},
+		}))
+		assert.True(t, fp.IsWhitelisted(8080, pk1))
+		assert.True(t, fp.IsWhitelisted(8080, pk2))
+		assert.False(t, fp.IsWhitelisted(8080, pk3))
+	})
+
+	t.Run("clearing whitelist re-opens port", func(t *testing.T) {
+		fp := NewForwardedPorts("")
+		assert.NoError(t, fp.Register(ForwardedPort{
+			Port:      8080,
+			Skynet:    true,
+			Whitelist: []cipher.PubKey{pk1},
+		}))
+		assert.False(t, fp.IsWhitelisted(8080, pk2))
+		// Re-register with empty whitelist — the in-place update path
+		// used by `cli serve whitelist <port> clear`.
+		assert.NoError(t, fp.Register(ForwardedPort{Port: 8080, Skynet: true}))
+		assert.True(t, fp.IsWhitelisted(8080, pk2))
+	})
+}

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -306,6 +306,21 @@ func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) 
 	return nil
 }
 
+// remotePKFromForwardingConn extracts the remote visor PK from a conn
+// delivered through the skynet sky-forwarding path. Both delivery paths
+// (appnet-wrapped route conns and direct VStream conns) carry the PK;
+// this normalizes the access so callers don't need to switch on the
+// underlying type. Returns ok=false only if neither route works.
+func remotePKFromForwardingConn(c net.Conn) (cipher.PubKey, bool) {
+	if pkp, ok := c.(interface{ RemotePK() cipher.PubKey }); ok {
+		return pkp.RemotePK(), true
+	}
+	if a, ok := c.RemoteAddr().(appnet.Addr); ok {
+		return a.PubKey, true
+	}
+	return cipher.PubKey{}, false
+}
+
 // vstreamConn wraps a VStream to implement net.Conn.
 type vstreamConn struct {
 	*transport.VStream
@@ -375,6 +390,25 @@ func handleServerConn(log *logging.Logger, remoteConn net.Conn, v *Visor) {
 		log.Errorf("Port :%v not registered", cMsg.Port)
 		sendError(log, remoteConn, fmt.Errorf("port :%v not registered", cMsg.Port))
 		return
+	}
+
+	// Enforce per-port PK whitelist if one is set on the forwarded port.
+	// Fail-closed when a whitelist is set but the peer PK can't be
+	// determined — the alternative would silently bypass the gate.
+	if fp := v.forwardedPorts.Get(cMsg.Port); fp != nil && len(fp.Whitelist) > 0 {
+		remotePK, pkOK := remotePKFromForwardingConn(remoteConn)
+		if !pkOK {
+			log.WithField("port", cMsg.Port).
+				Warn("Rejected: cannot identify peer on whitelisted port")
+			sendError(log, remoteConn, fmt.Errorf("port :%v: cannot verify peer", cMsg.Port))
+			return
+		}
+		if !v.isPeerAllowed(cMsg.Port, remotePK) {
+			log.WithField("peer", remotePK).WithField("port", cMsg.Port).
+				Warn("Rejected: peer not in whitelist")
+			sendError(log, remoteConn, fmt.Errorf("port :%v: not whitelisted", cMsg.Port))
+			return
+		}
 	}
 
 	ok = isPortAvailable(log, cMsg.Port)


### PR DESCRIPTION
## Summary

Until now, the `Whitelist` field on a `ForwardedPort` was only honored by the `dmsghttp` logserver's port-80 reverse proxy. The skynet sky-forwarding server and the DMSG raw-TCP forwarder accepted incoming connections and piped them to the local target without consulting the list, which made `cli serve whitelist` (#2394) and the matching hypervisor UI control silently ineffective for any port other than 80.

This PR closes the gap:

- **`Visor.isPeerAllowed(port, pk)`** is the single decision point — unknown ports are allowed (legacy compat for entries living only in the legacy `allowed.ports` map), open whitelists are allowed, otherwise the PK must be in the list.
- **DMSG forwarder** (`startDmsgForwarder` in `api_network.go`): asserts the conn's `RemoteAddr` to `dmsg.Addr` and gates the local dial on `isPeerAllowed`. Fail-closed: if the assertion fails on a port with a non-empty whitelist, the conn is dropped before the local dial.
- **Skynet sky-forwarding** (`handleServerConn` in `init_services.go`): a new helper `remotePKFromForwardingConn` extracts the remote PK from either the appnet-wrapped route conn (`RemoteAddr` → `appnet.Addr`) or the direct `VStream` conn (`RemotePK()` via embedding). Same fail-closed logic.

The service-registry dispatch path (visor-managed services like the sky-forwarding server itself) is intentionally **not** gated — those handlers own their own access control and aren't represented in `forwardedPorts`.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` clean
- [x] New unit tests cover the four whitelist outcomes (unregistered / empty / allowed / denied) and the in-place clear path used by `cli serve whitelist <port> clear`
- [ ] Live test: `cli serve add 8080 --to 8080 --whitelist <peer-A-pk>` — peer A connects ok, peer B gets refused before the local dial
- [ ] Live test: `cli serve whitelist 8080 clear` — both peers connect again
- [ ] Live test on DMSG path: `<visor>.dmsg:8080` from a non-whitelisted peer is dropped at accept; from a whitelisted peer it goes through

## Related

- #2394 introduced the `serve whitelist` CLI/UI surface but only the port-80 logserver actually honored the field. This PR makes the gate real for raw-TCP.