### PR TITLE
visor: register DHT + RSN listeners early in init

### DIFF
--- a/cmd/skywire-cli/commands/visor/dht.go
+++ b/cmd/skywire-cli/commands/visor/dht.go
@@ -17,6 +17,7 @@ func init() {
 	dhtCmd.AddCommand(dhtPutCmd)
 	dhtCmd.AddCommand(dhtFullNodeCmd)
 	dhtCmd.AddCommand(dhtSyncCmd)
+	dhtCmd.AddCommand(dhtListCmd)
 	RootCmd.AddCommand(dhtCmd)
 }
 
@@ -169,5 +170,33 @@ Examples:
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
 		fmt.Printf("Synced %d items from DHT full node.\n", result)
+	},
+}
+
+var dhtListSalt string
+
+func init() {
+	dhtListCmd.Flags().StringVar(&dhtListSalt, "salt", "", "filter by namespace (dmsg, tp, svc); empty = all")
+}
+
+var dhtListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all DHT items stored locally",
+	Long: `Dump all DHT items stored by this visor's DHT node as JSON.
+
+Examples:
+  skywire cli visor dht list
+  skywire cli visor dht list --salt dmsg
+  skywire cli visor dht list --salt tp`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		data, err := rpcClient.DHTGetAll(dhtListSalt)
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		fmt.Println(data)
 	},
 }

--- a/pkg/dmsg/dmsg/client_session.go
+++ b/pkg/dmsg/dmsg/client_session.go
@@ -283,7 +283,16 @@ func (cs *ClientSession) serve() error {
 			// the root cause of the dmsg session rot seen in
 			// long-running visors (sessions decayed from 6 to 0
 			// as random bad peers triggered session kills).
-			cs.log.WithError(err).Debug("Stream handshake failed, continuing.")
+			//
+			// Include src/dst from the partially-populated stream so
+			// listener-miss diagnostics show the originator PK and
+			// the destination port. Fields default to zero values when
+			// the failure happens before prepareFields runs.
+			cs.log.WithError(err).
+				WithField("src_pk", dStr.rAddr.PK).
+				WithField("src_port", dStr.rAddr.Port).
+				WithField("dst_port", dStr.lAddr.Port).
+				Debug("Stream handshake failed, continuing.")
 			if closeErr := dStr.Close(); closeErr != nil {
 				cs.log.WithError(closeErr).
 					Debug("On handshakeResponder failure, close stream resulted in error.")

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -74,6 +74,12 @@ type Config struct {
 	RulesGCInterval  time.Duration
 	MinHops          uint16
 	MaxHops          uint16
+	// AwaitSetupListener, if non-nil, is used instead of opening a fresh
+	// listener on DmsgAwaitSetupPort. This lets callers reserve the port
+	// earlier in init (before the transport manager is ready) so peers
+	// dialing it during the router-init window don't hit "request has no
+	// associated listener" warnings.
+	AwaitSetupListener *dmsg.Listener
 }
 
 // SetDefaults sets default values for certain empty values.
@@ -213,9 +219,13 @@ type router struct {
 func New(dmsgC *dmsg.Client, config *Config, routeSetupHooks []RouteSetupHook) (Router, error) {
 	config.SetDefaults()
 
-	sl, err := dmsgC.Listen(skyenv.DmsgAwaitSetupPort)
-	if err != nil {
-		return nil, err
+	sl := config.AwaitSetupListener
+	if sl == nil {
+		var err error
+		sl, err = dmsgC.Listen(skyenv.DmsgAwaitSetupPort)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	trustedVisors := make(map[cipher.PubKey]struct{})

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -123,8 +123,12 @@ var (
 	skynetPorts vinit.Module
 	// Self-probe: periodic dmsg listener reachability check
 	selfProbe vinit.Module
-	// Kademlia DHT node
+	// Kademlia DHT node (listener registration + dmsg-discovery hybrid)
 	dhtMod vinit.Module
+	// Transport-dependent DHT wiring (transport-layer sync, hybrid TPD)
+	dhtTransportMod vinit.Module
+	// Pre-open DmsgAwaitSetupPort listener so it's ready before initRouter
+	routerListener vinit.Module
 	// Visor-local telemetry store (bbolt + sampler)
 	statsMod        vinit.Module
 	cxoUserFeedsMod vinit.Module
@@ -164,7 +168,12 @@ func registerModules(logger *logging.MasterLogger) {
 	pty = maker("dmsg_pty", initDmsgpty, &dmsgC)
 	embRouteSetup = maker("embedded_route_setup", initEmbeddedRouteSetup, &dmsgC)
 	embDmsgWeb = maker("embedded_dmsgweb", initEmbeddedDmsgWeb, &dmsgC)
-	rt = maker("router", initRouter, &tr, &dmsgC, &dmsgHTTP, &embRouteSetup)
+	// routerListener pre-opens DmsgAwaitSetupPort the moment dmsgC is
+	// ready so peers dialing it during the rt-init window (held up by
+	// &tr) don't hit "request has no associated listener". rt picks up
+	// the listener via router.Config.AwaitSetupListener.
+	routerListener = maker("router_listener", initRouterListener, &dmsgC)
+	rt = maker("router", initRouter, &tr, &dmsgC, &dmsgHTTP, &embRouteSetup, &routerListener)
 	// skynetweb depends on the router being up, unlike dmsgweb.
 	embSkynetWeb = maker("embedded_skynetweb", initEmbeddedSkynetWeb, &rt)
 	launch = maker("launcher", initLauncher, &ebc, &disc, &dmsgC, &tr, &rt)
@@ -190,7 +199,14 @@ func registerModules(logger *logging.MasterLogger) {
 	// services are up (cli, ui, logserver) so the ports are
 	// actually listening when we probe them.
 	skynetPorts = maker("skynet_ports", initSkynetForwardPorts, &cli, &dmsgHTTPLogServer, &uiServer, &skyFwd)
-	dhtMod = maker("dht", initDHT, &dmsgC, &tr)
+	// dhtMod runs as soon as v.dmsgC is ready so the DHT's dmsg listener
+	// on port 100 is registered before peers start dialing it. Holding it
+	// behind &tr previously meant ~20s of "request has no associated
+	// listener" warnings during init while peers dialed our DHT port.
+	dhtMod = maker("dht", initDHT, &dmsgC)
+	// dhtTransportMod attaches the transport-manager-dependent pieces
+	// (route-ID-0 DHT sync, hybrid TPD client) once tr is up.
+	dhtTransportMod = maker("dht_transport", initDHTTransport, &dhtMod, &tr)
 	// Stats depends on tr (transport probe), dmsgC (dmsg-online probe),
 	// and launch (proc manager — service probe). The probes are
 	// pull-style and tolerate nil at probe time, so missing-but-still-
@@ -203,7 +219,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// Depends only on dmsgC.
 	pairingMod = maker("pairing", initPairing, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &pty,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &statsMod, &cxoUserFeedsMod, &pairingMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &skyFwd, &pi, &lp, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embSkynetWeb, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &dhtMod, &dhtTransportMod, &statsMod, &cxoUserFeedsMod, &pairingMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_dht.go
+++ b/pkg/visor/init_dht.go
@@ -105,18 +105,6 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 		log.Info("DHT: wired DMSG client lookup to local DHT store")
 	}
 
-	// Register transport-layer DHT handler so DHT messages can flow
-	// over skywire transports (route ID 0) without DMSG.
-	if v.tpM != nil {
-		tlDHT := dht.NewTransportLayerDHT(v.tpM, log)
-		v.tpM.SetDHTHandler(tlDHT.HandleDHTPacket)
-		// Add transport peers to the DHT routing table as they become
-		// reachable — this happens naturally via the DHT's own Ping RPC
-		// when the transport-layer transport is used for lookups.
-		node.AddTransport(tlDHT)
-		log.Info("DHT: transport-layer sync enabled (route ID 0)")
-	}
-
 	log.WithField("id", node.ID().String()).
 		WithField("bootstrap_peers", len(bootstrapPKs)).
 		WithField("full_node", fullNode).
@@ -127,8 +115,11 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 		go dht.AdvertiseFullNode(ctx, node, log)
 	}
 
-	// Wrap discovery clients with DHT hybrid clients so reads try
-	// DHT first, fall back to HTTP. Writes go to both.
+	// Wrap the dmsg discovery client with a DHT hybrid client so reads try
+	// DHT first, fall back to HTTP. Writes go to both. The transport-
+	// discovery hybrid wrap happens in initDHTTransport once v.tpM is up
+	// (which is later than v.dmsgC, and we don't want to hold up DHT
+	// listener registration on it — see init_dht_transport.go).
 	discAdapter := dht.NewDiscAdapter(node, log)
 	discAdapter.PopulateServerCache()
 	v.initLock.Lock()
@@ -136,26 +127,11 @@ func initDHT(ctx context.Context, v *Visor, log *logging.Logger) error {
 		v.dClient = dht.NewHybridDiscClient(discAdapter, v.dClient, log)
 		log.Info("DMSG discovery: DHT-first reads enabled (HTTP fallback)")
 	}
-	if v.tpM != nil {
-		tpdAdapter := dht.NewTPDAdapter(node, log)
-		v.tpM.Conf.DiscoveryClient = dht.NewHybridTPDClient(tpdAdapter, v.tpM.Conf.DiscoveryClient, log)
-		log.Info("Transport discovery: DHT-first reads enabled (HTTP fallback)")
-	}
 	v.initLock.Unlock()
 
 	// Start background publish: mirror visor's entries to the DHT.
-	// Once the DHT has peers, tell the transport manager to skip
-	// HTTP re-registration — the DHT handles transport discovery.
 	go func() {
 		dhtPublishLoop(ctx, v, node, log)
-	}()
-	go func() {
-		// Wait for DHT to bootstrap before switching off HTTP registration.
-		// TODO: Re-enable once DiscoveryPusher (DHT → TPD) is verified
-		// working reliably. Currently premature — skipping TPD registration
-		// causes transports to disappear from the HTTP API even though
-		// they exist on the visor and in the DHT.
-		_ = node
 	}()
 
 	return nil

--- a/pkg/visor/init_dht_transport.go
+++ b/pkg/visor/init_dht_transport.go
@@ -1,0 +1,40 @@
+package visor
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/dht"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// initDHTTransport wires the transport-manager-dependent parts of the DHT
+// (transport-layer sync over route ID 0, and the hybrid TPD client that
+// reads from DHT first). Split out from initDHT so that the DHT's dmsg
+// listener on port 100 comes up as soon as v.dmsgC is ready, rather than
+// waiting on the full transport init chain (~20s on production), during
+// which peers dial port 100 and hit "request has no associated listener".
+func initDHTTransport(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dhtNode == nil || v.tpM == nil {
+		return nil
+	}
+
+	// Register transport-layer DHT handler so DHT messages can flow
+	// over skywire transports (route ID 0) without DMSG.
+	tlDHT := dht.NewTransportLayerDHT(v.tpM, log)
+	v.tpM.SetDHTHandler(tlDHT.HandleDHTPacket)
+	// Add transport peers to the DHT routing table as they become
+	// reachable — this happens naturally via the DHT's own Ping RPC
+	// when the transport-layer transport is used for lookups.
+	v.dhtNode.AddTransport(tlDHT)
+	log.Info("DHT: transport-layer sync enabled (route ID 0)")
+
+	// Wrap the transport discovery client with a DHT hybrid client so
+	// reads try DHT first, fall back to HTTP. Writes go to both.
+	tpdAdapter := dht.NewTPDAdapter(v.dhtNode, log)
+	v.initLock.Lock()
+	v.tpM.Conf.DiscoveryClient = dht.NewHybridTPDClient(tpdAdapter, v.tpM.Conf.DiscoveryClient, log)
+	v.initLock.Unlock()
+	log.Info("Transport discovery: DHT-first reads enabled (HTTP fallback)")
+
+	return nil
+}

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -151,16 +151,17 @@ func initRouter(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	rConf := router.Config{
-		Logger:           logger,
-		MasterLogger:     v.MasterLogger(),
-		PubKey:           v.conf.PK,
-		SecKey:           v.conf.SK,
-		TransportManager: v.tpM,
-		RouteFinder:      rfClient,
-		RouteGroupDialer: rgDialer,
-		SetupNodes:       v.conf.EffectiveRouteSetupNodes(),
-		RulesGCInterval:  0, // 0 = DefaultRulesGCInterval (10s)
-		MinHops:          v.conf.Routing.MinHops,
+		Logger:             logger,
+		MasterLogger:       v.MasterLogger(),
+		PubKey:             v.conf.PK,
+		SecKey:             v.conf.SK,
+		TransportManager:   v.tpM,
+		RouteFinder:        rfClient,
+		RouteGroupDialer:   rgDialer,
+		SetupNodes:         v.conf.EffectiveRouteSetupNodes(),
+		RulesGCInterval:    0, // 0 = DefaultRulesGCInterval (10s)
+		MinHops:            v.conf.Routing.MinHops,
+		AwaitSetupListener: v.awaitSetupListener,
 	}
 
 	routeSetupHooks := getRouteSetupHooks(ctx, v, log)

--- a/pkg/visor/init_router_listener.go
+++ b/pkg/visor/init_router_listener.go
@@ -1,0 +1,37 @@
+package visor
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// initRouterListener pre-opens the DmsgAwaitSetupPort (136) listener as
+// soon as v.dmsgC is ready, before initRouter runs (which depends on the
+// transport manager and so was previously held up by ~20s of transport
+// init). The listener is stashed on *Visor and picked up by initRouter
+// via Config.AwaitSetupListener — peers dialing 136 during the gap now
+// land on a real listener instead of triggering "request has no
+// associated listener" warnings.
+//
+// If the listener fails to open (port already reserved, etc.), this
+// function returns nil and lets initRouter open its own listener as
+// before. Failing visor startup over a debug-noise mitigation isn't
+// worth it.
+func initRouterListener(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.dmsgC == nil {
+		return nil
+	}
+	lis, err := v.dmsgC.Listen(skyenv.DmsgAwaitSetupPort)
+	if err != nil {
+		log.WithError(err).
+			WithField("port", skyenv.DmsgAwaitSetupPort).
+			Debug("Pre-open of await-setup listener failed; router will open it")
+		return nil
+	}
+	v.initLock.Lock()
+	v.awaitSetupListener = lis
+	v.initLock.Unlock()
+	return nil
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -87,12 +87,13 @@ type Visor struct {
 	startupComplete chan struct{}
 	uptimeTracker   utclient.APIClient
 
-	ebc           *appevent.Broadcaster // event broadcaster
-	dmsgC         *dmsg.Client
-	dmsgDC        *dmsg.Client       // dmsg direct client
-	dClient       dmsgdisc.APIClient // dmsg direct api client
-	dmsgHTTP      *http.Client       // dmsghttp client
-	dmsgHTTPReady chan struct{}      // closed when dmsgHTTP is set
+	ebc                *appevent.Broadcaster // event broadcaster
+	dmsgC              *dmsg.Client
+	dmsgDC             *dmsg.Client       // dmsg direct client
+	dClient            dmsgdisc.APIClient // dmsg direct api client
+	dmsgHTTP           *http.Client       // dmsghttp client
+	dmsgHTTPReady      chan struct{}      // closed when dmsgHTTP is set
+	awaitSetupListener *dmsg.Listener     // pre-opened DmsgAwaitSetupPort listener; consumed by initRouter
 
 	// DMSG tracker state
 	dmsgTracker dtmState


### PR DESCRIPTION
## Summary

- DHT (port 100) and RSN await-setup (port 136) dmsg listeners now register as soon as \`v.dmsgC\` is ready instead of waiting on the full transport-manager init chain (~20s on this visor). Peers dialing those ports during startup no longer hit \`dmsg error 306 - request has no associated listener\`.
- Adds \`skywire cli visor dht list [--salt ...]\` for dumping the local DHT store via the existing \`DHTGetAll\` RPC.
- Adds \`src_pk\` / \`src_port\` / \`dst_port\` fields to the listener-miss debug log so future diagnoses don't need a one-off Go program.

## Why

PR #2316 downgraded stream-handshake errors from kill-session to debug-and-continue, which made an existing condition visible: peers were already dialing port 100/136 during init, but previously each such dial just silently nuked the session. The proximate cause is timing — \`dhtMod\` and \`rt\` were held behind \`&tr\` (transport manager), and transport init takes ~20s on a real visor. The DHT itself only needs \`&dmsgC\`; its transport-layer pieces can be deferred. The router really does need \`v.tpM\`, but its dmsg listener doesn't — so the listener gets pre-opened and threaded into \`router.Config.AwaitSetupListener\`.

## Changes

- Split \`dhtMod\` into:
  - \`dhtMod\` (deps: \`&dmsgC\`) — \`Listen(100)\`, node start, dmsg-discovery hybrid, full-node advertise, publish loop.
  - \`dhtTransportMod\` (deps: \`&dhtMod, &tr\`) — transport-layer DHT (route ID 0), hybrid TPD client.
- New \`routerListener\` module (deps: \`&dmsgC\`) pre-opens \`DmsgAwaitSetupPort\` and stashes the listener on \`*Visor\`.
- \`router.Config.AwaitSetupListener\` is consumed by \`router.New\` if non-nil; falls back to opening its own listener for backward compat.
- Inbound streams during the \`rt\` init gap sit in the listener's accept buffer (size 20) until \`router.Serve\` drains them.

## Test plan

- [x] \`go build ./...\` clean
- [x] Visor restart: pre-fix run had 9× \`dst_port=100\` and 7× \`dst_port=136\` listener-miss warnings in the 22s init window; post-fix run has 0 of each. Remaining 40 warnings are all \`dst_port=46\` (peers dialing the hypervisor port on a non-hypervisor visor — unchanged, separate concern).
- [x] \`skywire cli visor dht status\` reports the same numbers as before (37 stored, 6 bootstrap peers, full node).
- [x] \`skywire cli visor dht list\` dumps 37 items; \`--salt dmsg\` filters to 15.
- [x] DHT bootstrap still succeeds; \`dht_transport\` module logs "transport-layer sync enabled (route ID 0)" and "Transport discovery: DHT-first reads enabled".