### PR TITLE
cli: route calc returns multiple routes; respects visor min_hops

### DIFF
--- a/cmd/dmsg/dmsg-server/commands/start/root.go
+++ b/cmd/dmsg/dmsg-server/commands/start/root.go
@@ -403,6 +403,14 @@ var RootCmd = &cobra.Command{
 						WithField("bootstrap_peers", len(bootstrapPKs)).
 						Info("DHT full node started on port 100")
 
+					// Advertise this DHT full node under salt "fullnode"
+					// so visor full nodes running fullNodePullLoop can
+					// discover us without relying on hardcoded bootstrap
+					// PKs. The advert is signed by conf.SecKey at PUT
+					// time; a stale advert (>30min old) is filtered out
+					// downstream by FindAdvertisedFullNodes.
+					go dht.AdvertiseFullNode(ctx, dhtNode, dhtLog)
+
 					// Mirror DHT writes back to HTTP discoveries so they
 					// stay in sync when visors publish directly to the DHT.
 					discEndpoints := map[string]string{

--- a/cmd/skywire-cli/commands/rg/rg.go
+++ b/cmd/skywire-cli/commands/rg/rg.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -14,7 +15,11 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 )
 
-var statusJSON bool
+var (
+	statusJSON   bool
+	statusFilter string
+	statusHops   bool
+)
 
 // RootCmd is the root command for route group operations.
 var RootCmd = &cobra.Command{
@@ -45,6 +50,29 @@ var listCmd = &cobra.Command{
 		routes, err := rpcClient.ActiveRoutes()
 		internal.Catch(cmd.Flags(), err)
 
+		switch strings.ToLower(statusFilter) {
+		case "", "all":
+		case "initiator":
+			filtered := routes[:0]
+			for _, r := range routes {
+				if r.Route.Initiator {
+					filtered = append(filtered, r)
+				}
+			}
+			routes = filtered
+		case "responder":
+			filtered := routes[:0]
+			for _, r := range routes {
+				if !r.Route.Initiator {
+					filtered = append(filtered, r)
+				}
+			}
+			routes = filtered
+		default:
+			internal.PrintFatalError(cmd.Flags(),
+				fmt.Errorf("invalid --filter %q; expected all|initiator|responder", statusFilter))
+		}
+
 		if statusJSON {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
@@ -58,7 +86,7 @@ var listCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "APP\tREMOTE\tPORTS\tLATENCY\tTX\tRX\tUP\tDOWN\tROUTES\tMUX") //nolint:errcheck,gosec
+		fmt.Fprintln(w, "APP\tROLE\tREMOTE\tPORTS\tLATENCY\tTX\tRX\tUP\tDOWN\tROUTES\tMUX") //nolint:errcheck,gosec
 		for _, r := range routes {
 			remote := r.Route.RemotePK.String() + ".."
 			ports := fmt.Sprintf("%d:%d", r.Route.LocalPort, r.Route.RemotePort)
@@ -75,9 +103,13 @@ var listCmd = &cobra.Command{
 			if r.Route.MuxEnabled {
 				mux = "yes"
 			}
+			role := "responder"
+			if r.Route.Initiator {
+				role = "initiator"
+			}
 
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", //nolint:errcheck,gosec
-				r.AppName, remote, ports, latency, tx, rx, up, down, nRoutes, mux)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%s\n", //nolint:errcheck,gosec
+				r.AppName, role, remote, ports, latency, tx, rx, up, down, nRoutes, mux)
 
 			// Show transport details for mux routes
 			if nRoutes > 1 {
@@ -87,8 +119,24 @@ var listCmd = &cobra.Command{
 					if tp.Latency > 0 {
 						lat = fmt.Sprintf("%.0fms", tp.Latency)
 					}
-					fmt.Fprintf(w, "  └─\t%s\t%s\t%s\t\t\t\t\t%d\t\n", //nolint:errcheck,gosec
+					fmt.Fprintf(w, "  └─\t\t%s\t%s\t%s\t\t\t\t\t%d\t\n", //nolint:errcheck,gosec
 						tpID, tp.Type, lat, tp.FwdRuleID)
+				}
+			}
+
+			// Optionally show the full forward hop path.
+			if statusHops {
+				if len(r.Route.Hops) == 0 {
+					fmt.Fprintln(w, "    hops:\t(not recorded)") //nolint:errcheck,gosec
+					continue
+				}
+				for j, h := range r.Route.Hops {
+					tpType := h.TpType
+					if tpType == "" {
+						tpType = "?"
+					}
+					fmt.Fprintf(w, "  hop %d/%d:\t%s -> %s @ %s (%s)\n", //nolint:errcheck,gosec
+						j+1, len(r.Route.Hops), h.From, h.To, h.TpID, tpType)
 				}
 			}
 		}
@@ -98,6 +146,10 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().BoolVar(&statusJSON, "json", false, "output as JSON")
+	listCmd.Flags().StringVar(&statusFilter, "filter", "all",
+		"role filter: all | initiator | responder")
+	listCmd.Flags().BoolVar(&statusHops, "hops", false,
+		"also print the full forward hop path for each route group")
 }
 
 func formatBytes(b uint64) string {

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -101,7 +101,7 @@ var calcCmd = &cobra.Command{
 
 		// Try the visor RPC once for both srcPK fallback and min_hops default.
 		// Best-effort: if RPC isn't available we fall back to local config / 1.
-		rpcClient, _ := clirpc.Client(cmd.Flags())
+		rpcClient, _ := clirpc.Client(cmd.Flags()) //nolint:errcheck
 
 		if len(args) == 1 {
 			if rpcClient != nil {

--- a/cmd/skywire-cli/commands/route/calc.go
+++ b/cmd/skywire-cli/commands/route/calc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -33,6 +34,7 @@ var (
 	tpdURL      string
 	calcMinHops uint16
 	calcMaxHops uint16
+	calcCount   int
 )
 
 func init() {
@@ -40,8 +42,9 @@ func init() {
 	calcCmd.Flags().BoolVar(&calcDisable, "disable", false, "disable local route calculation in visor")
 	calcCmd.Flags().DurationVarP(&calcTimeout, "timeout", "t", 30*time.Second, "request timeout")
 	calcCmd.Flags().StringVarP(&tpdURL, "tpd", "a", deployment.Prod.TransportDiscovery, "transport discovery URL")
-	calcCmd.Flags().Uint16VarP(&calcMinHops, "min", "n", 1, "minimum hops")
+	calcCmd.Flags().Uint16VarP(&calcMinHops, "min", "n", 0, "minimum hops (0 = use visor's routing.min_hops, fallback 1)")
 	calcCmd.Flags().Uint16VarP(&calcMaxHops, "max", "x", 5, "maximum hops")
+	calcCmd.Flags().IntVarP(&calcCount, "count", "c", 1, "max routes to return (0 = all matching)")
 	clirpc.RegisterFetchFlags(calcCmd)
 }
 
@@ -96,12 +99,13 @@ var calcCmd = &cobra.Command{
 		// Calculate route with provided PKs
 		var srcPK, dstPK cipher.PubKey
 
+		// Try the visor RPC once for both srcPK fallback and min_hops default.
+		// Best-effort: if RPC isn't available we fall back to local config / 1.
+		rpcClient, _ := clirpc.Client(cmd.Flags())
+
 		if len(args) == 1 {
-			// Get local PK from visor or config
-			rpcClient, err := clirpc.Client(cmd.Flags())
-			if err == nil {
-				overview, err := rpcClient.Overview()
-				if err == nil {
+			if rpcClient != nil {
+				if overview, err := rpcClient.Overview(); err == nil {
 					srcPK = overview.PubKey
 				}
 			}
@@ -123,6 +127,27 @@ var calcCmd = &cobra.Command{
 			internal.Catch(cmd.Flags(), dstPK.Set(args[1]))
 		}
 
+		// Resolve min_hops: 0 means "ask the visor what it would use".
+		minHops := calcMinHops
+		if minHops == 0 {
+			if rpcClient != nil {
+				if n, err := rpcClient.GetMinHops(); err == nil {
+					minHops = n
+				}
+			}
+			if minHops == 0 {
+				minHops = 1
+			}
+		}
+
+		// 0 means "every route the BFS finds". GetRoute walks the slice
+		// returned by finder until it hits the cap, so a large sentinel
+		// is equivalent to "all".
+		count := calcCount
+		if count <= 0 {
+			count = math.MaxInt32
+		}
+
 		// Fetch all transports and calculate route
 		ctx, cancel := context.WithTimeout(context.Background(), calcTimeout)
 		defer cancel()
@@ -138,19 +163,36 @@ var calcCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to build graph: %w", err))
 		}
 
-		routes, err := graph.GetRoute(ctx, srcPK, dstPK, int(calcMinHops), int(calcMaxHops), 1)
+		routes, err := graph.GetRoute(ctx, srcPK, dstPK, int(minHops), int(calcMaxHops), count)
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("no route found: %w", err))
 		}
 
-		fwd := routes[0].Hops
-		rev := reverseHops(fwd)
-
-		output := fmt.Sprintf("forward: %v\nreverse: %v", fwd, rev)
-		internal.PrintOutput(cmd.Flags(), struct {
+		type routePair struct {
 			Forward []routing.Hop `json:"forward"`
 			Reverse []routing.Hop `json:"reverse"`
-		}{fwd, rev}, output)
+		}
+		pairs := make([]routePair, len(routes))
+		var textBuf strings.Builder
+		for i, r := range routes {
+			fwd := r.Hops
+			rev := reverseHops(fwd)
+			pairs[i] = routePair{Forward: fwd, Reverse: rev}
+			if i > 0 {
+				textBuf.WriteString("\n\n")
+			}
+			if calcCount != 1 {
+				fmt.Fprintf(&textBuf, "[%d/%d]\n", i+1, len(routes))
+			}
+			fmt.Fprintf(&textBuf, "forward: %v\nreverse: %v", fwd, rev)
+		}
+
+		// Preserve the single-route shape for back-compat when --count=1.
+		if calcCount == 1 && len(pairs) == 1 {
+			internal.PrintOutput(cmd.Flags(), pairs[0], textBuf.String())
+			return
+		}
+		internal.PrintOutput(cmd.Flags(), pairs, textBuf.String())
 	},
 }
 

--- a/cmd/skywire-cli/commands/route/route.go
+++ b/cmd/skywire-cli/commands/route/route.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -503,10 +504,24 @@ func parseUint(cmdFlags *pflag.FlagSet, name, v string, bitSize int) uint64 {
 	return i
 }
 
+var (
+	groupsFilter string
+	groupsHops   bool
+)
+
+func init() {
+	groupsCmd.Flags().StringVar(&groupsFilter, "filter", "all",
+		"role filter: all | initiator | responder")
+	groupsCmd.Flags().BoolVar(&groupsHops, "hops", false,
+		"also print the full hop path for each route group")
+}
+
 var groupsCmd = &cobra.Command{
 	Use:   "groups",
 	Short: "List active route groups",
-	Long:  "List active route groups with their consume and forward rules",
+	Long: `List active route groups with their descriptor, rule IDs, and
+the role this visor played in setup (initiator = we dialed, responder =
+we accepted). Use --hops to also print the full forward path.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
@@ -516,6 +531,30 @@ var groupsCmd = &cobra.Command{
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to get route groups: %w", err))
 		}
+
+		switch strings.ToLower(groupsFilter) {
+		case "", "all":
+		case "initiator":
+			filtered := rgs[:0]
+			for _, rg := range rgs {
+				if rg.Initiator {
+					filtered = append(filtered, rg)
+				}
+			}
+			rgs = filtered
+		case "responder":
+			filtered := rgs[:0]
+			for _, rg := range rgs {
+				if !rg.Initiator {
+					filtered = append(filtered, rg)
+				}
+			}
+			rgs = filtered
+		default:
+			internal.PrintFatalError(cmd.Flags(),
+				fmt.Errorf("invalid --filter %q; expected all|initiator|responder", groupsFilter))
+		}
+
 		if len(rgs) == 0 {
 			internal.PrintOutput(cmd.Flags(), rgs, "No active route groups\n")
 			return
@@ -523,22 +562,43 @@ var groupsCmd = &cobra.Command{
 
 		var b bytes.Buffer
 		w := tabwriter.NewWriter(&b, 0, 0, 3, ' ', tabwriter.TabIndent)
-		fmt.Fprintln(w, "index\tlocal_pk\tremote_pk\tlocal_port\tremote_port\tfwd_id\tconsume_id\ttransport") //nolint:errcheck
+		fmt.Fprintln(w, "index\trole\tlocal_pk\tremote_pk\tlocal_port\tremote_port\tfwd_id\tconsume_id\ttransport") //nolint:errcheck
 		for i, rg := range rgs {
 			tpID := rg.FwdNextTpID
 			if tpID == "" {
 				tpID = "-"
 			}
-			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%d\t%d\t%d\t%s\n", //nolint:errcheck
+			role := "responder"
+			if rg.Initiator {
+				role = "initiator"
+			}
+			// Local end is whichever side's the destination of the consume
+			// rule's descriptor — i.e., DstPK in the descriptor as stored.
+			fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%s\n", //nolint:errcheck
 				i,
-				rg.Desc.SrcPK,
+				role,
 				rg.Desc.DstPK,
-				rg.Desc.SrcPort,
+				rg.Desc.SrcPK,
 				rg.Desc.DstPort,
+				rg.Desc.SrcPort,
 				rg.FwdRuleID,
 				rg.ConsumeRuleID,
 				tpID,
 			)
+			if groupsHops {
+				if len(rg.Hops) == 0 {
+					fmt.Fprintln(w, "    hops:\t(not recorded)") //nolint:errcheck
+					continue
+				}
+				for j, h := range rg.Hops {
+					tpType := h.TpType
+					if tpType == "" {
+						tpType = "?"
+					}
+					fmt.Fprintf(w, "    hop %d/%d:\t%s -> %s @ %s (%s)\n", //nolint:errcheck
+						j+1, len(rg.Hops), h.From, h.To, h.TpID, tpType)
+				}
+			}
 		}
 		internal.Catch(cmd.Flags(), w.Flush())
 		internal.PrintOutput(cmd.Flags(), rgs, b.String())

--- a/cmd/skywire-cli/commands/visor/dht.go
+++ b/cmd/skywire-cli/commands/visor/dht.go
@@ -173,10 +173,14 @@ Examples:
 	},
 }
 
-var dhtListSalt string
+var (
+	dhtListSalt       string
+	dhtListWithTarget bool
+)
 
 func init() {
 	dhtListCmd.Flags().StringVar(&dhtListSalt, "salt", "", "filter by namespace (dmsg, tp, svc); empty = all")
+	dhtListCmd.Flags().BoolVar(&dhtListWithTarget, "with-target", false, "emit {target, value} objects instead of bare values (for diffing against HTTP discoveries)")
 }
 
 var dhtListCmd = &cobra.Command{
@@ -184,16 +188,25 @@ var dhtListCmd = &cobra.Command{
 	Short: "List all DHT items stored locally",
 	Long: `Dump all DHT items stored by this visor's DHT node as JSON.
 
+With --with-target, each item is emitted as {"target": "<hex>", "value": ...}
+where target is the storage key (subject PK ⊕ salt hash). Useful when
+diffing against an HTTP discovery whose records are keyed by visor PK.
+
 Examples:
   skywire cli visor dht list
   skywire cli visor dht list --salt dmsg
-  skywire cli visor dht list --salt tp`,
+  skywire cli visor dht list --salt tp --with-target`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}
-		data, err := rpcClient.DHTGetAll(dhtListSalt)
+		var data string
+		if dhtListWithTarget {
+			data, err = rpcClient.DHTListWithTargets(dhtListSalt)
+		} else {
+			data, err = rpcClient.DHTGetAll(dhtListSalt)
+		}
 		if err != nil {
 			internal.PrintFatalError(cmd.Flags(), err)
 		}

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -386,6 +386,51 @@ func (n *Node) rpcPutValue(ctx context.Context, p Peer, item MutableItem) error 
 	return nil
 }
 
+// rpcPutBatch sends many items+targets in a single RPC round-trip.
+// Returns a count of items the peer reported as stored, plus a count
+// of per-item errors (errors are only logged at debug; the call as a
+// whole succeeds if the RPC round-trip completed). The peer-side
+// MaxValueSize cap on the wire (4MB) is enforced by readMsg's
+// length-bounded check; chunk large pushes if you can hit that.
+func (n *Node) rpcPutBatch(ctx context.Context, p Peer, items []MutableItem, targets []NodeID) (stored int, errs int, err error) {
+	if len(items) == 0 {
+		return 0, 0, nil
+	}
+	ctx, cancel := rpcCtx(ctx)
+	defer cancel()
+
+	conn, err := n.dial(ctx, p.PK)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer conn.Close() //nolint:errcheck,gosec
+
+	req := PutBatchRequest{
+		SenderID: n.id,
+		SenderPK: n.pk,
+		Items:    items,
+		Targets:  targets,
+	}
+	var resp PutBatchResponse
+	if err := rpcCall(ctx, conn, methodPutBatch, req, &resp); err != nil {
+		return 0, 0, err
+	}
+	for i, ok := range resp.Stored {
+		if ok {
+			stored++
+		} else {
+			errs++
+			if i < len(resp.Errors) && resp.Errors[i] != "" {
+				n.log.WithField("peer", p.PK.String()).
+					WithField("err", resp.Errors[i]).
+					Debug("rpcPutBatch: item rejected")
+			}
+		}
+	}
+	n.rt.Update(Peer{ID: p.ID, PK: p.PK, LastSeen: time.Now()})
+	return stored, errs, nil
+}
+
 func (n *Node) rpcPutMirror(ctx context.Context, p Peer, item MutableItem, target NodeID) error {
 	ctx, cancel := rpcCtx(ctx)
 	defer cancel()
@@ -479,12 +524,15 @@ func (n *Node) reconcile(ctx context.Context, remotePK cipher.PubKey, salt strin
 		return pulled, 0, err
 	}
 
-	// Push phase: paginate our local store and rpcPutMirror items
-	// whose target keys weren't returned by the peer. Pagination uses
-	// the same Seq cursor strategy as the pull phase to avoid the
-	// 1000-item GetItems batch cap.
+	// Push phase: paginate our local store and batch-push items whose
+	// target keys weren't returned by the peer. Pagination uses the
+	// same Seq cursor strategy as the pull phase to avoid the
+	// 1000-item GetItems batch cap. Within each store page we also
+	// chunk the wire payload so a single PutBatch never crosses the
+	// 4MB rpcCall size limit.
 	peerID := NodeIDFromPubKey(remotePK)
 	peer := Peer{ID: peerID, PK: remotePK}
+	const maxBatchBytes = 3 * 1024 * 1024 // headroom under readMsg's 4MB cap
 	var cursor uint64
 	for {
 		items, targets, hasMore := n.store.GetItems(salt, cursor, 0)
@@ -492,25 +540,43 @@ func (n *Node) reconcile(ctx context.Context, remotePK cipher.PubKey, salt strin
 			break
 		}
 		var maxSeq uint64
-		for i, item := range items {
-			// Don't push items the peer already gave us back to them.
-			if _, ok := seen[targets[i]]; ok {
-				if item.Seq > maxSeq {
-					maxSeq = item.Seq
-				}
-				continue
+		batchItems := make([]MutableItem, 0, len(items))
+		batchTargets := make([]NodeID, 0, len(items))
+		batchBytes := 0
+		flush := func() {
+			if len(batchItems) == 0 {
+				return
 			}
-			if pushErr := n.rpcPutMirror(ctx, peer, item, targets[i]); pushErr != nil {
+			stored, _, pushErr := n.rpcPutBatch(ctx, peer, batchItems, batchTargets)
+			if pushErr != nil {
 				n.log.WithError(pushErr).
 					WithField("peer", remotePK.String()).
-					Debug("Reconcile: rpcPutMirror failed")
-			} else {
-				pushed++
+					Debug("Reconcile: rpcPutBatch failed")
 			}
+			pushed += stored
+			batchItems = batchItems[:0]
+			batchTargets = batchTargets[:0]
+			batchBytes = 0
+		}
+		for i, item := range items {
 			if item.Seq > maxSeq {
 				maxSeq = item.Seq
 			}
+			// Don't push items the peer already gave us back to them.
+			if _, ok := seen[targets[i]]; ok {
+				continue
+			}
+			// Estimate item wire size: V dominates, plus K (33), Sig (65),
+			// Salt, and target (32). Round generously to stay safe.
+			itemBytes := len(item.V) + len(item.Salt) + 200
+			if batchBytes+itemBytes > maxBatchBytes && len(batchItems) > 0 {
+				flush()
+			}
+			batchItems = append(batchItems, item)
+			batchTargets = append(batchTargets, targets[i])
+			batchBytes += itemBytes
 		}
+		flush()
 		if !hasMore || maxSeq <= cursor {
 			break
 		}
@@ -651,6 +717,48 @@ func (n *Node) handleConn(conn io.ReadWriteCloser, remotePK cipher.PubKey) {
 		items, targets, hasMore := n.store.GetItems(req.Salt, req.SinceSeq, req.Limit)
 		resp := GetItemsResponse{Items: items, Targets: targets, HasMore: hasMore}
 		writeMsg(conn, methodGetItems, resp) //nolint:errcheck,gosec
+
+	case methodPutBatch:
+		var req PutBatchRequest
+		if json.Unmarshal(data, &req) != nil {
+			return
+		}
+		n.rt.Update(Peer{ID: req.SenderID, PK: req.SenderPK})
+		stored := make([]bool, len(req.Items))
+		errs := make([]string, len(req.Items))
+		for i := range req.Items {
+			var hasTarget bool
+			if i < len(req.Targets) && !req.Targets[i].IsZero() {
+				hasTarget = true
+			}
+			if hasTarget {
+				// PutMirror is void — verify happens inside; we
+				// can't distinguish accepted from rejected, but a
+				// fresh-or-newer item will always land. Treat as
+				// accepted to keep the wire shape simple.
+				n.store.PutMirror(req.Targets[i], req.Items[i])
+				stored[i] = true
+				continue
+			}
+			if putErr := n.store.Put(req.Items[i]); putErr != nil {
+				errs[i] = putErr.Error()
+			} else {
+				stored[i] = true
+			}
+		}
+		// Drop the all-empty error slice to keep small batches tiny.
+		var hasErr bool
+		for _, e := range errs {
+			if e != "" {
+				hasErr = true
+				break
+			}
+		}
+		resp := PutBatchResponse{Stored: stored}
+		if hasErr {
+			resp.Errors = errs
+		}
+		writeMsg(conn, methodPutBatch, resp) //nolint:errcheck,gosec
 	}
 }
 
@@ -745,21 +853,49 @@ func (n *Node) fullNodePullLoop() {
 	}
 }
 
-// fullNodePullOnce reconciles with each bootstrap peer once, with a
-// per-peer timeout. Reconcile pulls items we don't have from the peer
-// and pushes back items they don't have from us — so over time the
-// bootstrap full nodes converge to the same data set rather than each
-// keeping its own partial view forever. The dial layer already skips
-// peers in the noDHT negative cache, so we just let Reconcile return
-// an error and move on.
+// fullNodePullOnce reconciles with bootstrap peers AND any peers
+// advertising themselves as full nodes (signed FullNodeAdvert in salt
+// "fullnode"), with a per-peer timeout. The signed advert is what
+// makes pushing to non-bootstrap peers safe: the peer explicitly
+// claims it accepts the full-node responsibility of storing arbitrary
+// mirror puts.
+//
+// Reconcile pulls items we don't have from the peer and pushes back
+// items they don't have from us, so over time the full nodes
+// converge. The dial layer already skips peers in the noDHT negative
+// cache, so we just let Reconcile return an error and move on.
 func (n *Node) fullNodePullOnce(perPeerTimeout time.Duration) {
-	totalPulled := 0
-	totalPushed := 0
-	tried := 0
+	// Bootstrap PKs first (deployment-trusted full nodes), then
+	// peer-advertised full nodes (signed advert verified by store
+	// signature check at insertion time, freshness re-checked here).
+	peers := make([]cipher.PubKey, 0, len(n.cfg.BootstrapPKs))
+	seen := make(map[cipher.PubKey]struct{})
 	for _, pk := range n.cfg.BootstrapPKs {
 		if pk == n.pk {
 			continue
 		}
+		if _, dup := seen[pk]; dup {
+			continue
+		}
+		seen[pk] = struct{}{}
+		peers = append(peers, pk)
+	}
+	advertised := FindAdvertisedFullNodes(n)
+	for _, pk := range advertised {
+		if pk == n.pk {
+			continue
+		}
+		if _, dup := seen[pk]; dup {
+			continue
+		}
+		seen[pk] = struct{}{}
+		peers = append(peers, pk)
+	}
+
+	totalPulled := 0
+	totalPushed := 0
+	tried := 0
+	for _, pk := range peers {
 		tried++
 		ctx, cancel := context.WithTimeout(n.ctx, perPeerTimeout)
 		// Empty salt => all salts.
@@ -779,6 +915,8 @@ func (n *Node) fullNodePullOnce(perPeerTimeout time.Duration) {
 	}
 	if tried > 0 {
 		n.log.WithField("tried", tried).
+			WithField("bootstrap", len(n.cfg.BootstrapPKs)).
+			WithField("advertised", len(advertised)).
 			WithField("pulled", totalPulled).
 			WithField("pushed", totalPushed).
 			WithField("store_size", n.store.Len()).

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -120,6 +120,21 @@ func (n *Node) Start(ctx context.Context) error {
 			defer n.wg.Done()
 			n.bootstrapLoop()
 		}()
+
+		// Full nodes also bulk-pull the data set from each bootstrap
+		// peer at startup and periodically thereafter, so that "full
+		// node" actually means "holds the network's data" rather than
+		// "would store it if anyone Put through me." Without this loop
+		// a freshly-restarted full node sat near-empty until passive
+		// peer Puts trickled in (observed in the field: ~87 items on a
+		// dev visor while a long-lived hub had ~3500).
+		if n.store.IsFullNode() {
+			n.wg.Add(1)
+			go func() {
+				defer n.wg.Done()
+				n.fullNodePullLoop()
+			}()
+		}
 	}
 
 	return nil
@@ -389,6 +404,48 @@ func (n *Node) rpcPutMirror(ctx context.Context, p Peer, item MutableItem, targe
 	return nil
 }
 
+// SyncFrom paginates GetItems from a single remote peer, mirroring each
+// returned item into the local store under its server-supplied target
+// key. Returns the count of items mirrored and the first call-level
+// error encountered (partial progress is reported as a return value).
+//
+// Used by both the manual `dht sync` RPC and the periodic full-node
+// pull loop (fullNodePullLoop) so they share identical semantics.
+func (n *Node) SyncFrom(ctx context.Context, remotePK cipher.PubKey, salt string) (int, error) {
+	stored := 0
+	var cursor uint64
+	for {
+		resp, err := n.GetItemsFrom(ctx, remotePK, salt, cursor, 0)
+		if err != nil {
+			return stored, err
+		}
+		var maxSeq uint64
+		for i, item := range resp.Items {
+			// PutMirror with the server's target key. Mirrored items
+			// have item.K = mirror's PK (not subject), so item.Target()
+			// would point to the wrong storage slot.
+			if i < len(resp.Targets) {
+				n.store.PutMirror(resp.Targets[i], item)
+				stored++
+			} else {
+				// Old servers don't send targets — fall back to the
+				// item's own (possibly self-keyed) target.
+				if putErr := n.store.Put(item); putErr == nil {
+					stored++
+				}
+			}
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
+			}
+		}
+		if !resp.HasMore || len(resp.Items) == 0 || maxSeq <= cursor {
+			break
+		}
+		cursor = maxSeq
+	}
+	return stored, nil
+}
+
 // GetItemsFrom fetches a batch of items from a specific peer.
 // Used for bulk sync from a full node.
 func (n *Node) GetItemsFrom(ctx context.Context, pk cipher.PubKey, salt string, sinceSeq uint64, limit int) (*GetItemsResponse, error) {
@@ -575,6 +632,74 @@ func (n *Node) bootstrapOnce() int {
 		found++
 	}
 	return found
+}
+
+// fullNodePullLoop bulk-pulls the data set from each bootstrap peer at
+// startup, then re-pulls on a long interval to catch items that other
+// full nodes received via paths that didn't reach us.
+//
+// Failure mode: any individual peer call may fail (peer offline, slow,
+// non-DHT). Errors are logged at Debug and the loop moves on to the
+// next peer. The whole pass is "best effort" — we'd rather fill in
+// from one peer than block on a dead one.
+func (n *Node) fullNodePullLoop() {
+	const (
+		startupDelay   = 5 * time.Second
+		retryInterval  = 1 * time.Hour
+		perPeerTimeout = 5 * time.Minute
+	)
+
+	// Wait for bootstrap to ping at least once before our first pull;
+	// dialing a peer that hasn't been pinged yet adds extra noDHT-cache
+	// misses for no benefit.
+	select {
+	case <-n.ctx.Done():
+		return
+	case <-time.After(startupDelay):
+	}
+
+	for {
+		n.fullNodePullOnce(perPeerTimeout)
+
+		select {
+		case <-n.ctx.Done():
+			return
+		case <-time.After(retryInterval):
+		}
+	}
+}
+
+// fullNodePullOnce pulls from each bootstrap peer once, with a per-peer
+// timeout. The dial layer already skips peers in the noDHT negative
+// cache, so we just let SyncFrom return an error and move on.
+func (n *Node) fullNodePullOnce(perPeerTimeout time.Duration) {
+	pulled := 0
+	tried := 0
+	for _, pk := range n.cfg.BootstrapPKs {
+		if pk == n.pk {
+			continue
+		}
+		tried++
+		ctx, cancel := context.WithTimeout(n.ctx, perPeerTimeout)
+		// Empty salt => all salts.
+		stored, err := n.SyncFrom(ctx, pk, "")
+		cancel()
+		if err != nil {
+			n.log.WithError(err).WithField("peer", pk.String()).
+				Debug("Full-node pull from peer failed")
+			continue
+		}
+		pulled += stored
+		n.log.WithField("peer", pk.String()).
+			WithField("items", stored).
+			Debug("Full-node pull from peer complete")
+	}
+	if tried > 0 {
+		n.log.WithField("tried", tried).
+			WithField("pulled", pulled).
+			WithField("store_size", n.store.Len()).
+			Info("Full-node bulk pull pass complete")
+	}
 }
 
 func (n *Node) maintenanceLoop() {

--- a/pkg/dht/dht.go
+++ b/pkg/dht/dht.go
@@ -409,15 +409,23 @@ func (n *Node) rpcPutMirror(ctx context.Context, p Peer, item MutableItem, targe
 // key. Returns the count of items mirrored and the first call-level
 // error encountered (partial progress is reported as a return value).
 //
-// Used by both the manual `dht sync` RPC and the periodic full-node
-// pull loop (fullNodePullLoop) so they share identical semantics.
+// Used by the manual `dht sync` RPC. The full-node pull loop uses
+// Reconcile, which is SyncFrom plus a write-back phase.
 func (n *Node) SyncFrom(ctx context.Context, remotePK cipher.PubKey, salt string) (int, error) {
+	stored, _, err := n.syncFromCollect(ctx, remotePK, salt)
+	return stored, err
+}
+
+// syncFromCollect is SyncFrom that also returns the set of target keys
+// seen on the remote, for callers that need to compute a delta.
+func (n *Node) syncFromCollect(ctx context.Context, remotePK cipher.PubKey, salt string) (int, map[NodeID]struct{}, error) {
 	stored := 0
+	seen := make(map[NodeID]struct{})
 	var cursor uint64
 	for {
 		resp, err := n.GetItemsFrom(ctx, remotePK, salt, cursor, 0)
 		if err != nil {
-			return stored, err
+			return stored, seen, err
 		}
 		var maxSeq uint64
 		for i, item := range resp.Items {
@@ -425,12 +433,14 @@ func (n *Node) SyncFrom(ctx context.Context, remotePK cipher.PubKey, salt string
 			// have item.K = mirror's PK (not subject), so item.Target()
 			// would point to the wrong storage slot.
 			if i < len(resp.Targets) {
+				seen[resp.Targets[i]] = struct{}{}
 				n.store.PutMirror(resp.Targets[i], item)
 				stored++
 			} else {
 				// Old servers don't send targets — fall back to the
 				// item's own (possibly self-keyed) target.
 				if putErr := n.store.Put(item); putErr == nil {
+					seen[item.Target()] = struct{}{}
 					stored++
 				}
 			}
@@ -443,7 +453,71 @@ func (n *Node) SyncFrom(ctx context.Context, remotePK cipher.PubKey, salt string
 		}
 		cursor = maxSeq
 	}
-	return stored, nil
+	return stored, seen, nil
+}
+
+// reconcile pulls from a remote peer (like SyncFrom) and then pushes
+// back any items in our store that the remote didn't report. The push
+// phase is what makes full-node-to-full-node coverage actually
+// converge: with pull alone, each full node ends up with the union of
+// every other full node's data, but the source peers themselves never
+// see what they were missing.
+//
+// Lowercase by design: callers must verify that remotePK is a full
+// node before invoking, since the receiver-side PutMirror handler
+// stores anything we push without distance/admission gating. The only
+// in-tree caller (fullNodePullOnce) iterates BootstrapPKs, which the
+// deployment guarantees are DHT full nodes; other callers should
+// satisfy the same invariant.
+//
+// Returns (pulled, pushed) item counts plus any error from either
+// phase. Push errors are aggregated as debug logs and don't fail the
+// overall reconcile — best-effort.
+func (n *Node) reconcile(ctx context.Context, remotePK cipher.PubKey, salt string) (pulled, pushed int, err error) {
+	pulled, seen, err := n.syncFromCollect(ctx, remotePK, salt)
+	if err != nil {
+		return pulled, 0, err
+	}
+
+	// Push phase: paginate our local store and rpcPutMirror items
+	// whose target keys weren't returned by the peer. Pagination uses
+	// the same Seq cursor strategy as the pull phase to avoid the
+	// 1000-item GetItems batch cap.
+	peerID := NodeIDFromPubKey(remotePK)
+	peer := Peer{ID: peerID, PK: remotePK}
+	var cursor uint64
+	for {
+		items, targets, hasMore := n.store.GetItems(salt, cursor, 0)
+		if len(items) == 0 {
+			break
+		}
+		var maxSeq uint64
+		for i, item := range items {
+			// Don't push items the peer already gave us back to them.
+			if _, ok := seen[targets[i]]; ok {
+				if item.Seq > maxSeq {
+					maxSeq = item.Seq
+				}
+				continue
+			}
+			if pushErr := n.rpcPutMirror(ctx, peer, item, targets[i]); pushErr != nil {
+				n.log.WithError(pushErr).
+					WithField("peer", remotePK.String()).
+					Debug("Reconcile: rpcPutMirror failed")
+			} else {
+				pushed++
+			}
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
+			}
+		}
+		if !hasMore || maxSeq <= cursor {
+			break
+		}
+		cursor = maxSeq
+	}
+
+	return pulled, pushed, nil
 }
 
 // GetItemsFrom fetches a batch of items from a specific peer.
@@ -634,9 +708,11 @@ func (n *Node) bootstrapOnce() int {
 	return found
 }
 
-// fullNodePullLoop bulk-pulls the data set from each bootstrap peer at
-// startup, then re-pulls on a long interval to catch items that other
-// full nodes received via paths that didn't reach us.
+// fullNodePullLoop reconciles the data set with each bootstrap peer at
+// startup, then re-runs on a long interval. Each pass pulls items the
+// peer has that we don't AND pushes items we have that the peer
+// doesn't, so the bootstrap full nodes converge to the same content
+// over time instead of each keeping its own partial view.
 //
 // Failure mode: any individual peer call may fail (peer offline, slow,
 // non-DHT). Errors are logged at Debug and the loop moves on to the
@@ -669,11 +745,16 @@ func (n *Node) fullNodePullLoop() {
 	}
 }
 
-// fullNodePullOnce pulls from each bootstrap peer once, with a per-peer
-// timeout. The dial layer already skips peers in the noDHT negative
-// cache, so we just let SyncFrom return an error and move on.
+// fullNodePullOnce reconciles with each bootstrap peer once, with a
+// per-peer timeout. Reconcile pulls items we don't have from the peer
+// and pushes back items they don't have from us — so over time the
+// bootstrap full nodes converge to the same data set rather than each
+// keeping its own partial view forever. The dial layer already skips
+// peers in the noDHT negative cache, so we just let Reconcile return
+// an error and move on.
 func (n *Node) fullNodePullOnce(perPeerTimeout time.Duration) {
-	pulled := 0
+	totalPulled := 0
+	totalPushed := 0
 	tried := 0
 	for _, pk := range n.cfg.BootstrapPKs {
 		if pk == n.pk {
@@ -682,23 +763,26 @@ func (n *Node) fullNodePullOnce(perPeerTimeout time.Duration) {
 		tried++
 		ctx, cancel := context.WithTimeout(n.ctx, perPeerTimeout)
 		// Empty salt => all salts.
-		stored, err := n.SyncFrom(ctx, pk, "")
+		pulled, pushed, err := n.reconcile(ctx, pk, "")
 		cancel()
 		if err != nil {
 			n.log.WithError(err).WithField("peer", pk.String()).
-				Debug("Full-node pull from peer failed")
+				Debug("Full-node reconcile with peer failed")
 			continue
 		}
-		pulled += stored
+		totalPulled += pulled
+		totalPushed += pushed
 		n.log.WithField("peer", pk.String()).
-			WithField("items", stored).
-			Debug("Full-node pull from peer complete")
+			WithField("pulled", pulled).
+			WithField("pushed", pushed).
+			Debug("Full-node reconcile with peer complete")
 	}
 	if tried > 0 {
 		n.log.WithField("tried", tried).
-			WithField("pulled", pulled).
+			WithField("pulled", totalPulled).
+			WithField("pushed", totalPushed).
 			WithField("store_size", n.store.Len()).
-			Info("Full-node bulk pull pass complete")
+			Info("Full-node reconcile pass complete")
 	}
 }
 

--- a/pkg/dht/fullnode_advert.go
+++ b/pkg/dht/fullnode_advert.go
@@ -72,6 +72,11 @@ func AdvertiseFullNode(ctx context.Context, node *Node, log *logging.Logger) {
 // Returns a list of PKs that are running DHT full nodes.
 // Prioritizes peers actually in the routing table (confirmed reachable)
 // over the raw bootstrap list (which includes non-DHT services).
+//
+// NOTE: this is a candidate list, not a verified one — peers in the
+// routing table aren't guaranteed to be full nodes. For a verified
+// list, use FindAdvertisedFullNodes (filters by signed advert in
+// "fullnode" salt).
 func FindFullNodes(ctx context.Context, node *Node) []cipher.PubKey {
 	// First: peers in the routing table (confirmed DHT-reachable).
 	var fullNodes []cipher.PubKey
@@ -98,4 +103,72 @@ func FindFullNodes(ctx context.Context, node *Node) []cipher.PubKey {
 	}
 
 	return fullNodes
+}
+
+// fullNodeAdvertFreshness is the maximum advert age we accept when
+// verifying a peer is a live full node. AdvertiseFullNode publishes
+// every 5 minutes, so 30 minutes (6×) tolerates 5 missed publishes
+// without unnecessarily forgetting a still-running peer.
+const fullNodeAdvertFreshness = 30 * time.Minute
+
+// FindAdvertisedFullNodes returns PKs that have a fresh, signed
+// FullNodeAdvert in this node's DHT store under salt "fullnode". Each
+// returned peer can be safely targeted by reconcile pushes — the
+// signed advert proves the peer accepts the full-node responsibility
+// of storing arbitrary mirror puts.
+//
+// Excludes this node's own PK and bootstrap PKs (caller is expected
+// to merge with cfg.BootstrapPKs separately so the unioned list
+// drives one loop).
+func FindAdvertisedFullNodes(node *Node) []cipher.PubKey {
+	if node == nil || node.store == nil {
+		return nil
+	}
+	bootstrap := make(map[cipher.PubKey]struct{}, len(node.cfg.BootstrapPKs))
+	for _, pk := range node.cfg.BootstrapPKs {
+		bootstrap[pk] = struct{}{}
+	}
+
+	cutoff := time.Now().Add(-fullNodeAdvertFreshness).UnixNano()
+	var out []cipher.PubKey
+	seen := make(map[cipher.PubKey]struct{})
+	var cursor uint64
+	for {
+		items, _, hasMore := node.store.GetItems("fullnode", cursor, 0)
+		if len(items) == 0 {
+			break
+		}
+		var maxSeq uint64
+		for _, item := range items {
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
+			}
+			var advert FullNodeAdvert
+			if err := json.Unmarshal(item.V, &advert); err != nil {
+				continue
+			}
+			if !advert.FullNode {
+				continue
+			}
+			if advert.Timestamp < cutoff {
+				continue
+			}
+			if advert.PK == node.pk {
+				continue
+			}
+			if _, ok := bootstrap[advert.PK]; ok {
+				continue
+			}
+			if _, ok := seen[advert.PK]; ok {
+				continue
+			}
+			seen[advert.PK] = struct{}{}
+			out = append(out, advert.PK)
+		}
+		if !hasMore || maxSeq <= cursor {
+			break
+		}
+		cursor = maxSeq
+	}
+	return out
 }

--- a/pkg/dht/rpc.go
+++ b/pkg/dht/rpc.go
@@ -18,6 +18,7 @@ const (
 	methodGetValue uint8 = 3
 	methodPutValue uint8 = 4
 	methodGetItems uint8 = 5
+	methodPutBatch uint8 = 6
 )
 
 // rpcTimeout is the deadline for a single RPC round-trip.
@@ -75,6 +76,30 @@ type PutValueRequest struct {
 type PutValueResponse struct {
 	Stored bool   `json:"stored"`
 	Error  string `json:"error,omitempty"`
+}
+
+// PutBatchRequest asks a peer to store many mutable items in one
+// round-trip. Items[i] and Targets[i] are paired: a non-zero target
+// stores under that key (PutMirror), zero falls back to the item's
+// own derived target (Put).
+//
+// Used by full-node reconcile to push hundreds of items per peer
+// without paying a fresh dmsg connection / noise handshake per item
+// (the per-item rpcPutMirror loop ran ~600ms × N items).
+type PutBatchRequest struct {
+	SenderID NodeID        `json:"sender_id"`
+	SenderPK cipher.PubKey `json:"sender_pk"`
+	Items    []MutableItem `json:"items"`
+	Targets  []NodeID      `json:"targets,omitempty"`
+}
+
+// PutBatchResponse reports per-item store outcomes. Stored[i] is true
+// if Items[i] was accepted (signature valid AND, for non-mirror puts,
+// monotonic seq satisfied). Errors short enough to share are surfaced
+// via Errors[i]; long errors are dropped to keep response size bounded.
+type PutBatchResponse struct {
+	Stored []bool   `json:"stored"`
+	Errors []string `json:"errors,omitempty"`
 }
 
 // GetItemsRequest asks a full node for a batch of stored items.

--- a/pkg/dht/store.go
+++ b/pkg/dht/store.go
@@ -2,6 +2,7 @@ package dht
 
 import (
 	"errors"
+	"sort"
 	"sync"
 	"time"
 
@@ -269,7 +270,11 @@ func (s *Store) Refresh(target NodeID) {
 
 // GetItems returns items matching the given salt filter and sequence threshold.
 // If salt is empty, all items are returned. Only items with Seq > sinceSeq
-// are included. Results are capped at limit (default 1000).
+// are included. Results are sorted by Seq ascending (with target key as a
+// stable tiebreaker for items with the same Seq) and capped at limit
+// (default 1000). The ascending sort makes Seq-based cursor pagination
+// safe: callers can advance sinceSeq to the highest Seq seen and the next
+// batch will return strictly later items without skipping anything.
 // Returns items, their storage target keys, and whether more items exist.
 func (s *Store) GetItems(salt string, sinceSeq uint64, limit int) ([]MutableItem, []NodeID, bool) {
 	if limit <= 0 {
@@ -278,8 +283,11 @@ func (s *Store) GetItems(salt string, sinceSeq uint64, limit int) ([]MutableItem
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var items []MutableItem
-	var targets []NodeID
+	type entry struct {
+		item   MutableItem
+		target NodeID
+	}
+	candidates := make([]entry, 0)
 	for target, si := range s.items {
 		if salt != "" && string(si.item.Salt) != salt {
 			continue
@@ -287,13 +295,44 @@ func (s *Store) GetItems(salt string, sinceSeq uint64, limit int) ([]MutableItem
 		if si.item.Seq <= sinceSeq {
 			continue
 		}
-		items = append(items, si.item)
-		targets = append(targets, target)
-		if len(items) >= limit+1 {
-			return items[:limit], targets[:limit], true // hasMore
-		}
+		candidates = append(candidates, entry{item: si.item, target: target})
 	}
-	return items, targets, false
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].item.Seq != candidates[j].item.Seq {
+			return candidates[i].item.Seq < candidates[j].item.Seq
+		}
+		// Stable order on Seq ties so paginated callers see a deterministic
+		// boundary if many items share a Seq value.
+		a, b := candidates[i].target, candidates[j].target
+		for k := range a {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+		return false
+	})
+
+	hasMore := len(candidates) > limit
+	if hasMore {
+		// Don't split a Seq tie across batches: the cursor returned to the
+		// caller is the last item's Seq, and items with that same Seq in
+		// later batches would be filtered out by `Seq > sinceSeq`. Extend
+		// the batch to swallow the entire tie at the boundary.
+		end := limit
+		boundarySeq := candidates[end-1].item.Seq
+		for end < len(candidates) && candidates[end].item.Seq == boundarySeq {
+			end++
+		}
+		hasMore = end < len(candidates)
+		candidates = candidates[:end]
+	}
+	items := make([]MutableItem, len(candidates))
+	targets := make([]NodeID, len(candidates))
+	for i, c := range candidates {
+		items[i] = c.item
+		targets[i] = c.target
+	}
+	return items, targets, hasMore
 }
 
 // Len returns the number of stored items.

--- a/pkg/dht/svc_adapter.go
+++ b/pkg/dht/svc_adapter.go
@@ -7,21 +7,20 @@ import (
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/servicedisc"
 )
 
-// ServiceRecord is a DHT-native service advertisement.
-// It mirrors the essential fields from servicedisc.Service but is
-// independent of the HTTP service discovery types to avoid import cycles.
-type ServiceRecord struct {
-	PK      cipher.PubKey `json:"pk"`
-	Port    uint16        `json:"port"`
-	Type    string        `json:"type"`    // e.g., "vpn", "skysocks", "proxy"
-	Version string        `json:"version"` // visor version
-	Addr    string        `json:"addr,omitempty"`
-}
+// svcSalt is the DHT namespace for service-discovery records.
+//
+// Service-discovery (SD) writes one DHT entry per visor at this single salt;
+// the value is the full list of services that visor offers. This avoids the
+// overwrite hazard of the older per-type scheme (a visor running both vpn
+// and skysocks would write twice to the same target if the salt were
+// identical and only differed by an out-of-key Type field). See
+// pkg/service-discovery/api/api.go: dhtMirror documentation.
+var svcSalt = []byte("svc")
 
 // SvcAdapter publishes and queries service records via the DHT.
-// Salt format: "svc:" + serviceType (e.g., "svc:vpn", "svc:skysocks").
 type SvcAdapter struct {
 	node *Node
 	log  *logging.Logger
@@ -32,35 +31,54 @@ func NewSvcAdapter(node *Node, log *logging.Logger) *SvcAdapter {
 	return &SvcAdapter{node: node, log: log}
 }
 
-func svcSalt(serviceType string) []byte {
-	return []byte("svc:" + serviceType)
-}
-
-// Register publishes a service record to the DHT.
-func (d *SvcAdapter) Register(ctx context.Context, rec ServiceRecord, seq uint64) error {
-	data, err := json.Marshal(rec)
+// Register publishes the visor's full service list to the DHT.
+//
+// All of a visor's services live under one DHT target; callers must publish
+// the complete list (vpn + skysocks + visor + …) on every change. Passing
+// an empty slice clears the entry (see Deregister).
+func (d *SvcAdapter) Register(ctx context.Context, services []servicedisc.Service, seq uint64) error {
+	data, err := json.Marshal(services)
 	if err != nil {
 		return fmt.Errorf("dht svc: marshal: %w", err)
 	}
-	return d.node.Put(ctx, data, seq, svcSalt(rec.Type))
+	return d.node.Put(ctx, data, seq, svcSalt)
 }
 
-// Lookup retrieves a service record for a given PK and service type.
-func (d *SvcAdapter) Lookup(ctx context.Context, pk cipher.PubKey, serviceType string) (*ServiceRecord, error) {
-	item, err := d.node.Get(ctx, pk, svcSalt(serviceType))
+// Lookup retrieves a single service of the given type for a visor PK.
+//
+// Returns nil with no error if the visor has no service of that type
+// (the DHT entry exists but the type isn't in the list); returns the
+// underlying error if the DHT lookup itself fails.
+func (d *SvcAdapter) Lookup(ctx context.Context, pk cipher.PubKey, serviceType string) (*servicedisc.Service, error) {
+	services, err := d.LookupAll(ctx, pk)
 	if err != nil {
 		return nil, err
 	}
-	var rec ServiceRecord
-	if err := json.Unmarshal(item.V, &rec); err != nil {
-		return nil, fmt.Errorf("dht svc: unmarshal: %w", err)
+	for i := range services {
+		if services[i].Type == serviceType {
+			return &services[i], nil
+		}
 	}
-	return &rec, nil
+	return nil, nil
 }
 
-// Deregister removes a service record by publishing an empty tombstone.
-func (d *SvcAdapter) Deregister(ctx context.Context, serviceType string, seq uint64) error {
-	return d.node.Put(ctx, []byte("{}"), seq, svcSalt(serviceType))
+// LookupAll retrieves the full service list for a visor PK.
+func (d *SvcAdapter) LookupAll(ctx context.Context, pk cipher.PubKey) ([]servicedisc.Service, error) {
+	item, err := d.node.Get(ctx, pk, svcSalt)
+	if err != nil {
+		return nil, err
+	}
+	var services []servicedisc.Service
+	if err := json.Unmarshal(item.V, &services); err != nil {
+		return nil, fmt.Errorf("dht svc: unmarshal: %w", err)
+	}
+	return services, nil
+}
+
+// Deregister clears the visor's service list by publishing an empty array
+// at a fresh seq.
+func (d *SvcAdapter) Deregister(ctx context.Context, seq uint64) error {
+	return d.node.Put(ctx, []byte("[]"), seq, svcSalt)
 }
 
 // AddressRecord is a DHT-native address resolver entry.

--- a/pkg/route-finder/store/finder.go
+++ b/pkg/route-finder/store/finder.go
@@ -38,7 +38,14 @@ func (g *Graph) GetRoute(ctx context.Context, source, destination cipher.PubKey,
 		return nil, err
 	}
 
-	routes := make([]routing.Route, 0, number)
+	// Cap preallocated capacity to the number of paths the BFS actually
+	// found. Callers may pass a large sentinel (e.g., math.MaxInt32) to
+	// request "all routes"; pre-sizing to that would OOM the process.
+	cap := number
+	if len(paths) < cap {
+		cap = len(paths)
+	}
+	routes := make([]routing.Route, 0, cap)
 	for _, path := range paths {
 		if len(routes) == number {
 			break

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -93,6 +93,13 @@ type RouteGroup struct {
 	// This is the full multi-hop route, not just local transports.
 	forwardHops []routing.Hop
 
+	// initiator is true when this visor dialed the remote end (called
+	// router.DialRoutes); false when this visor accepted the route via
+	// AcceptRoutes / saveRouteGroupRules from a setup-node request.
+	// Set once at construction in saveRouteGroupRules from nsConf.Initiator
+	// and never mutated afterwards.
+	initiator bool
+
 	// 'tps' is transports used for writing/forward rules.
 	// It should have the same number of elements as 'fwd'
 	// where each element corresponds with the adjacent element in 'fwd'.
@@ -475,6 +482,12 @@ func (rg *RouteGroup) SetForwardHops(hops []routing.Hop) {
 	rg.mu.Lock()
 	defer rg.mu.Unlock()
 	rg.forwardHops = hops
+}
+
+// Initiator reports whether this visor dialed the remote end of the route
+// (true) or accepted the route from a setup-node request (false).
+func (rg *RouteGroup) Initiator() bool {
+	return rg.initiator
 }
 
 // RouteHopDetails returns detailed information about each hop in the route,

--- a/pkg/router/route_status.go
+++ b/pkg/router/route_status.go
@@ -19,6 +19,11 @@ type RouteStatus struct {
 	LocalPort  routing.Port  `json:"local_port"`
 	RemotePort routing.Port  `json:"remote_port"`
 
+	// Initiator is true when this visor dialed the route (called
+	// router.DialRoutes). False when this visor accepted the route
+	// from a remote setup-node request.
+	Initiator bool `json:"initiator"`
+
 	// Status
 	Alive   bool          `json:"alive"`
 	Latency time.Duration `json:"latency_ns"`
@@ -32,6 +37,11 @@ type RouteStatus struct {
 	// Mux info
 	MuxEnabled bool             `json:"mux_enabled"`
 	Transports []RouteTransport `json:"transports"`
+
+	// Hops is the full forward path for this route group, populated from
+	// rg.forwardHops. Empty if the path wasn't recorded (older routes or
+	// the fallback reconstruction).
+	Hops []RouteHopInfo `json:"hops,omitempty"`
 }
 
 // RouteTransport describes one transport within a muxed route.
@@ -41,6 +51,9 @@ type RouteTransport struct {
 	RemotePK  cipher.PubKey   `json:"remote_pk"`
 	Latency   float64         `json:"latency_ms"`
 	FwdRuleID routing.RouteID `json:"fwd_rule_id"`
+	// RvsRuleID is the matching reverse (Consume) rule on this side.
+	// Paired by index with FwdRuleID.
+	RvsRuleID routing.RouteID `json:"rvs_rule_id"`
 }
 
 // ActiveRouteStatuses returns the status of all active route groups.
@@ -58,6 +71,7 @@ func (r *router) ActiveRouteStatuses() []RouteStatus {
 			RemotePK:          desc.SrcPK(),
 			LocalPort:         desc.DstPort(),
 			RemotePort:        desc.SrcPort(),
+			Initiator:         rg.Initiator(),
 			Alive:             nrg.IsAlive(),
 			Latency:           nrg.Latency(),
 			BandwidthSent:     nrg.BandwidthSent(),
@@ -65,6 +79,7 @@ func (r *router) ActiveRouteStatuses() []RouteStatus {
 			UploadSpeed:       nrg.UploadSpeed(),
 			DownloadSpeed:     nrg.DownloadSpeed(),
 			MuxEnabled:        rg.mux != nil,
+			Hops:              rg.RouteHopDetails(),
 		}
 
 		rg.mu.Lock()
@@ -80,6 +95,9 @@ func (r *router) ActiveRouteStatuses() []RouteStatus {
 			}
 			if i < len(rg.fwd) {
 				rt.FwdRuleID = rg.fwd[i].KeyRouteID()
+			}
+			if i < len(rg.rvs) {
+				rt.RvsRuleID = rg.rvs[i].KeyRouteID()
 			}
 			status.Transports = append(status.Transports, rt)
 		}

--- a/pkg/router/router_serve.go
+++ b/pkg/router/router_serve.go
@@ -201,6 +201,7 @@ func (r *router) saveRouteGroupRules(ctx context.Context, rules routing.EdgeRule
 	}
 
 	rg := NewRouteGroup(DefaultRouteGroupConfig(), r.rt, rules.Desc, r.mLogger)
+	rg.initiator = nsConf.Initiator
 	rg.appendRules(rules.Forward, rules.Reverse, tp)
 	// we put raw rg so it can be accessible to the router when handshake packets come in
 	r.rgsRaw[rules.Desc] = rg

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -138,6 +138,7 @@ type API interface {
 	ServiceHealth() ([]ServiceHealthEntry, error)
 	FetchServiceData(service, path string) ([]byte, error)
 	SetMinHops(uint16) error
+	GetMinHops() (uint16, error)
 	SetCalculateRoutes(enabled bool) error
 	GetCalculateRoutes() (bool, error)
 

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -286,6 +286,7 @@ type API interface {
 	HVUpdateForwardedPort(pk cipher.PubKey, p ForwardedPort) error
 	DHTSync(remotePK string, salt string) (int, error)
 	DHTGetAll(salt string) (string, error)
+	DHTListWithTargets(salt string) (string, error)
 
 	// Close closes the API connection (for RPC clients)
 	Close() error

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -66,6 +66,11 @@ func (v *Visor) DmsgReconnect() (int, error) {
 
 // DHTSync fetches items from a DHT full node and stores them locally.
 // If remotePK is empty, uses the first available bootstrap peer.
+//
+// Paginates until the remote reports no more items: each batch advances
+// the sinceSeq cursor to the highest Seq seen so far, so a single CLI
+// invocation pulls the full inventory rather than just the first batch
+// (capped at 1000 server-side).
 func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 	if v.dhtNode == nil {
 		return 0, fmt.Errorf("DHT node not running")
@@ -85,34 +90,52 @@ func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 		targetPK = fullNodes[0]
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	resp, err := v.dhtNode.GetItemsFrom(ctx, targetPK, salt, 0, 0)
-	if err != nil {
-		return 0, fmt.Errorf("sync from %s: %w", targetPK.String(), err)
-	}
-
 	stored := 0
-	for i, item := range resp.Items {
-		// Use PutMirror with the explicit target key from the response.
-		// Mirrored items have item.K set to the mirror's PK (not the
-		// subject PK), so item.Target() returns the wrong key.
-		if i < len(resp.Targets) {
-			v.dhtNode.Store().PutMirror(resp.Targets[i], item)
-			stored++
-		} else {
-			// Fallback for old servers that don't send targets.
-			if putErr := v.dhtNode.Store().Put(item); putErr == nil {
+	var cursor uint64
+	for {
+		resp, err := v.dhtNode.GetItemsFrom(ctx, targetPK, salt, cursor, 0)
+		if err != nil {
+			if stored > 0 {
+				// Partial-progress: surface what we got rather than discarding.
+				v.log.WithError(err).WithField("stored", stored).
+					Warn("DHT sync: partial progress, remote call failed")
+				return stored, nil
+			}
+			return 0, fmt.Errorf("sync from %s: %w", targetPK.String(), err)
+		}
+
+		var maxSeq uint64
+		for i, item := range resp.Items {
+			// Use PutMirror with the explicit target key from the response.
+			// Mirrored items have item.K set to the mirror's PK (not the
+			// subject PK), so item.Target() returns the wrong key.
+			if i < len(resp.Targets) {
+				v.dhtNode.Store().PutMirror(resp.Targets[i], item)
 				stored++
+			} else {
+				// Fallback for old servers that don't send targets.
+				if putErr := v.dhtNode.Store().Put(item); putErr == nil {
+					stored++
+				}
+			}
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
 			}
 		}
+
+		if !resp.HasMore || len(resp.Items) == 0 || maxSeq <= cursor {
+			// !HasMore: server says we have everything.
+			// no items: nothing came back, nothing more to do.
+			// maxSeq <= cursor: defensive — would loop forever otherwise.
+			break
+		}
+		cursor = maxSeq
 	}
 
-	v.log.WithField("received", len(resp.Items)).
-		WithField("stored", stored).
-		WithField("hasMore", resp.HasMore).
-		Info("DHT sync result")
+	v.log.WithField("stored", stored).Info("DHT sync result")
 
 	return stored, nil
 }

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -67,10 +67,9 @@ func (v *Visor) DmsgReconnect() (int, error) {
 // DHTSync fetches items from a DHT full node and stores them locally.
 // If remotePK is empty, uses the first available bootstrap peer.
 //
-// Paginates until the remote reports no more items: each batch advances
-// the sinceSeq cursor to the highest Seq seen so far, so a single CLI
-// invocation pulls the full inventory rather than just the first batch
-// (capped at 1000 server-side).
+// Delegates pagination to dht.Node.SyncFrom, which is shared with the
+// node's own periodic full-node pull loop so they have identical
+// semantics.
 func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 	if v.dhtNode == nil {
 		return 0, fmt.Errorf("DHT node not running")
@@ -93,46 +92,15 @@ func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	stored := 0
-	var cursor uint64
-	for {
-		resp, err := v.dhtNode.GetItemsFrom(ctx, targetPK, salt, cursor, 0)
-		if err != nil {
-			if stored > 0 {
-				// Partial-progress: surface what we got rather than discarding.
-				v.log.WithError(err).WithField("stored", stored).
-					Warn("DHT sync: partial progress, remote call failed")
-				return stored, nil
-			}
-			return 0, fmt.Errorf("sync from %s: %w", targetPK.String(), err)
+	stored, err := v.dhtNode.SyncFrom(ctx, targetPK, salt)
+	if err != nil {
+		if stored > 0 {
+			// Partial-progress: surface what we got rather than discarding.
+			v.log.WithError(err).WithField("stored", stored).
+				Warn("DHT sync: partial progress, remote call failed")
+			return stored, nil
 		}
-
-		var maxSeq uint64
-		for i, item := range resp.Items {
-			// Use PutMirror with the explicit target key from the response.
-			// Mirrored items have item.K set to the mirror's PK (not the
-			// subject PK), so item.Target() returns the wrong key.
-			if i < len(resp.Targets) {
-				v.dhtNode.Store().PutMirror(resp.Targets[i], item)
-				stored++
-			} else {
-				// Fallback for old servers that don't send targets.
-				if putErr := v.dhtNode.Store().Put(item); putErr == nil {
-					stored++
-				}
-			}
-			if item.Seq > maxSeq {
-				maxSeq = item.Seq
-			}
-		}
-
-		if !resp.HasMore || len(resp.Items) == 0 || maxSeq <= cursor {
-			// !HasMore: server says we have everything.
-			// no items: nothing came back, nothing more to do.
-			// maxSeq <= cursor: defensive — would loop forever otherwise.
-			break
-		}
-		cursor = maxSeq
+		return 0, fmt.Errorf("sync from %s: %w", targetPK.String(), err)
 	}
 
 	v.log.WithField("stored", stored).Info("DHT sync result")

--- a/pkg/visor/api_dmsg_diag.go
+++ b/pkg/visor/api_dmsg_diag.go
@@ -142,19 +142,84 @@ func (v *Visor) DHTSync(remotePK string, salt string) (int, error) {
 
 // DHTGetAll returns all DHT items matching the given salt as a JSON string.
 // Requires the visor to have a DHT node (full or regular).
+//
+// Pages over the local store with a Seq cursor until exhausted so the
+// returned array reflects every matching item rather than just the first
+// 1000 (the default GetItems batch cap).
 func (v *Visor) DHTGetAll(salt string) (string, error) {
 	if v.dhtNode == nil {
 		return "", fmt.Errorf("DHT node not running")
 	}
-	items, _, _ := v.dhtNode.Store().GetItems(salt, 0, 0)
-	if len(items) == 0 {
+	results := make([]json.RawMessage, 0)
+	var cursor uint64
+	for {
+		items, _, hasMore := v.dhtNode.Store().GetItems(salt, cursor, 0)
+		if len(items) == 0 {
+			break
+		}
+		var maxSeq uint64
+		for _, item := range items {
+			results = append(results, json.RawMessage(item.V))
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
+			}
+		}
+		if !hasMore || maxSeq <= cursor {
+			break
+		}
+		cursor = maxSeq
+	}
+	if len(results) == 0 {
 		return "[]", nil
 	}
+	data, err := json.MarshalIndent(results, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal DHT items: %w", err)
+	}
+	return string(data), nil
+}
 
-	// Decode each item's value and collect into an array.
-	var results []json.RawMessage
-	for _, item := range items {
-		results = append(results, json.RawMessage(item.V))
+// DHTListWithTargets returns all DHT items matching the given salt as a JSON
+// array of {target, value} objects, where target is the hex-encoded storage
+// key (subject PK ⊕ salt hash) and value is the raw stored payload.
+//
+// Diff-friendly counterpart to DHTGetAll: callers comparing the DHT against
+// HTTP discoveries need to know which subject PK each value belongs to,
+// which the bare values do not always carry (e.g. a transport list under
+// salt "tp" is keyed by edge PK but the JSON array of transports does not
+// repeat the subject's own PK).
+func (v *Visor) DHTListWithTargets(salt string) (string, error) {
+	if v.dhtNode == nil {
+		return "", fmt.Errorf("DHT node not running")
+	}
+	type withTarget struct {
+		Target string          `json:"target"`
+		Value  json.RawMessage `json:"value"`
+	}
+	results := make([]withTarget, 0)
+	var cursor uint64
+	for {
+		items, targets, hasMore := v.dhtNode.Store().GetItems(salt, cursor, 0)
+		if len(items) == 0 {
+			break
+		}
+		var maxSeq uint64
+		for i, item := range items {
+			results = append(results, withTarget{
+				Target: targets[i].String(),
+				Value:  json.RawMessage(item.V),
+			})
+			if item.Seq > maxSeq {
+				maxSeq = item.Seq
+			}
+		}
+		if !hasMore || maxSeq <= cursor {
+			break
+		}
+		cursor = maxSeq
+	}
+	if len(results) == 0 {
+		return "[]", nil
 	}
 	data, err := json.MarshalIndent(results, "", "  ")
 	if err != nil {

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -35,13 +35,20 @@ func (v *Visor) RemoveRoutingRule(key routing.RouteID) error {
 	return nil
 }
 
-// RouteGroups implements API.
+// RouteGroups implements API. Returns one entry per active route group on
+// the visor, with the descriptor, hop path, and initiator flag.
+//
+// The previous implementation walked v.router.Rules() looking for Reverse
+// rules and then dereferenced the matching forward rule via NextRouteID().
+// Reverse (Consume) rules don't carry a NextRouteID, so the lookup always
+// failed and this function returned an empty list. We now drive directly
+// off the router's active route-group set (rgsNs) via ActiveRouteStatuses,
+// which already holds the descriptor, hops, and initiator flag.
 func (v *Visor) RouteGroups() (rgs []RouteGroupInfo, err error) {
 	if v.router == nil {
 		return nil, nil
 	}
 
-	// Protect against panics from corrupt/race-condition rules
 	defer func() {
 		if r := recover(); r != nil {
 			rgs = nil
@@ -49,52 +56,33 @@ func (v *Visor) RouteGroups() (rgs []RouteGroupInfo, err error) {
 		}
 	}()
 
-	rules := v.router.Rules()
-	for _, consumeRule := range rules {
-		func() {
-			defer func() { recover() }() //nolint:errcheck
-
-			if len(consumeRule) == 0 || consumeRule.Type() != routing.RuleReverse {
-				return
+	statuses := v.router.ActiveRouteStatuses()
+	rgs = make([]RouteGroupInfo, 0, len(statuses))
+	for _, s := range statuses {
+		info := RouteGroupInfo{
+			Desc: routing.RouteDescriptorFields{
+				DstPK:   s.LocalPK,
+				SrcPK:   s.RemotePK,
+				DstPort: s.LocalPort,
+				SrcPort: s.RemotePort,
+			},
+			Initiator: s.Initiator,
+		}
+		// Primary forward + reverse rules are the first entries in the
+		// mux transport set (mux secondaries follow at index 1+).
+		if len(s.Transports) > 0 {
+			info.FwdRuleID = s.Transports[0].FwdRuleID
+			info.ConsumeRuleID = s.Transports[0].RvsRuleID
+			info.FwdNextTpID = s.Transports[0].ID.String()
+		}
+		if len(s.Hops) > 0 {
+			hops := make([]RouteHopInfo, len(s.Hops))
+			for i, h := range s.Hops {
+				hops[i] = RouteHopInfo{TpID: h.TpID, From: h.From, To: h.To, TpType: h.TpType}
 			}
-
-			consumeSummary := consumeRule.Summary()
-			if consumeSummary == nil || consumeSummary.ConsumeFields == nil {
-				return
-			}
-
-			fwdRID := consumeRule.NextRouteID()
-			fwdRule, err := v.router.Rule(fwdRID)
-			if err != nil || fwdRule == nil || len(fwdRule) == 0 {
-				return
-			}
-
-			fwdSummary := fwdRule.Summary()
-			if fwdSummary == nil {
-				return
-			}
-
-			info := RouteGroupInfo{
-				ConsumeRuleID: consumeSummary.KeyRouteID,
-				FwdRuleID:     fwdSummary.KeyRouteID,
-				Desc:          consumeSummary.ConsumeFields.RouteDescriptor,
-			}
-			if fwdSummary.ForwardFields != nil {
-				info.FwdNextTpID = fwdSummary.ForwardFields.NextTID.String()
-			}
-
-			descFields := consumeSummary.ConsumeFields.RouteDescriptor
-			desc := routing.NewRouteDescriptor(descFields.SrcPK, descFields.DstPK, descFields.SrcPort, descFields.DstPort)
-			if rgHops := v.router.RouteGroupHops(desc); len(rgHops) > 0 {
-				hops := make([]RouteHopInfo, len(rgHops))
-				for i, h := range rgHops {
-					hops[i] = RouteHopInfo{TpID: h.TpID, From: h.From, To: h.To, TpType: h.TpType}
-				}
-				info.Hops = hops
-			}
-
-			rgs = append(rgs, info)
-		}()
+			info.Hops = hops
+		}
+		rgs = append(rgs, info)
 	}
 
 	return rgs, nil

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -201,6 +201,14 @@ func (v *Visor) SetMinHops(in uint16) error {
 	return v.conf.UpdateMinHops(in)
 }
 
+// GetMinHops returns the visor's configured routing.min_hops value.
+func (v *Visor) GetMinHops() (uint16, error) {
+	if v.conf == nil || v.conf.Routing == nil {
+		return 0, nil
+	}
+	return v.conf.Routing.MinHops, nil
+}
+
 // SetCalculateRoutes sets calculate_routes routing config of visor
 func (v *Visor) SetCalculateRoutes(enabled bool) error {
 	// Update router's local route calculation setting

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -578,6 +578,7 @@ type routeGroupResp struct {
 	FwdRuleID     routing.RouteID               `json:"fwd_rule_id"`
 	Desc          routing.RouteDescriptorFields `json:"desc"`
 	FwdNextTpID   string                        `json:"fwd_next_tp_id,omitempty"`
+	Initiator     bool                          `json:"initiator"`
 	Hops          []RouteHopInfo                `json:"hops,omitempty"`
 }
 

--- a/pkg/visor/rpc.go
+++ b/pkg/visor/rpc.go
@@ -163,6 +163,11 @@ type RouteGroupInfo struct {
 	FwdRuleID     routing.RouteID               `json:"fwd_rule_id"`
 	Desc          routing.RouteDescriptorFields `json:"desc"`
 	FwdNextTpID   string                        `json:"fwd_next_tp_id,omitempty"`
+	// Initiator is true when this visor dialed the remote end of the
+	// route, false when the route was accepted from a remote setup-node
+	// request. Distinguishes outbound proxy/VPN client connections from
+	// inbound listener connections.
+	Initiator bool `json:"initiator"`
 	// Hops is the stored forward route path (transport IDs, edges, types)
 	// for this route group, populated when the route group is active.
 	Hops []RouteHopInfo `json:"hops,omitempty"`

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -668,6 +668,15 @@ func (rc *rpcClient) SetMinHops(hops uint16) error {
 	return err
 }
 
+// GetMinHops returns the visor's configured routing.min_hops value.
+func (rc *rpcClient) GetMinHops() (uint16, error) {
+	var out uint16
+	if err := rc.Call("GetMinHops", &struct{}{}, &out); err != nil {
+		return 0, err
+	}
+	return out, nil
+}
+
 // SetCalculateRoutes sets the calculate_routes from visor routing config
 func (rc *rpcClient) SetCalculateRoutes(enabled bool) error {
 	err := rc.Call("SetCalculateRoutes", &enabled, &struct{}{})

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -1296,6 +1296,16 @@ func (rc *rpcClient) DHTGetAll(salt string) (string, error) {
 	return resp, nil
 }
 
+// DHTListWithTargets returns all DHT items matching a salt as JSON,
+// each annotated with its storage target key.
+func (rc *rpcClient) DHTListWithTargets(salt string) (string, error) {
+	var resp string
+	if err := rc.Call("DHTListWithTargets", &salt, &resp); err != nil {
+		return "", err
+	}
+	return resp, nil
+}
+
 // DHTSync syncs items from a DHT full node.
 func (rc *rpcClient) DHTSync(remotePK string, salt string) (int, error) {
 	req := DHTSyncRequest{RemotePK: remotePK, Salt: salt}

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -802,6 +802,11 @@ func (mc *mockRPCClient) SetMinHops(_ uint16) error {
 	return nil
 }
 
+// GetMinHops implements API
+func (mc *mockRPCClient) GetMinHops() (uint16, error) {
+	return 0, nil
+}
+
 // SetCalculateRoutes implements API
 func (mc *mockRPCClient) SetCalculateRoutes(_ bool) error {
 	return nil

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -1190,6 +1190,11 @@ func (mc *mockRPCClient) DHTGetAll(_ string) (string, error) {
 	return "[]", nil
 }
 
+// DHTListWithTargets implements API.
+func (mc *mockRPCClient) DHTListWithTargets(_ string) (string, error) {
+	return "[]", nil
+}
+
 // DHTSync implements API.
 func (mc *mockRPCClient) DHTSync(_ string, _ string) (int, error) {
 	return 0, fmt.Errorf("not supported in mock")

--- a/pkg/visor/rpc_dht.go
+++ b/pkg/visor/rpc_dht.go
@@ -50,6 +50,18 @@ func (r *RPC) DHTGetAll(salt *string, out *string) (err error) {
 	return nil
 }
 
+// DHTListWithTargets returns all DHT items matching a salt as JSON,
+// with each entry annotated with its storage target key.
+func (r *RPC) DHTListWithTargets(salt *string, out *string) (err error) {
+	defer rpcutil.LogCall(r.log, "DHTListWithTargets", salt)(out, &err)
+	result, err := r.visor.DHTListWithTargets(*salt)
+	if err != nil {
+		return err
+	}
+	*out = result
+	return nil
+}
+
 // DHTSync syncs items from a DHT full node.
 func (r *RPC) DHTSync(req *DHTSyncRequest, out *int) (err error) {
 	defer rpcutil.LogCall(r.log, "DHTSync", req)(out, &err)

--- a/pkg/visor/rpc_routing.go
+++ b/pkg/visor/rpc_routing.go
@@ -69,6 +69,17 @@ func (r *RPC) SetMinHops(n *uint16, _ *struct{}) (err error) {
 	return
 }
 
+// GetMinHops returns the visor's configured routing.min_hops value.
+func (r *RPC) GetMinHops(_ *struct{}, out *uint16) (err error) {
+	defer rpcutil.LogCall(r.log, "GetMinHops", nil)(out, &err)
+	n, err := r.visor.GetMinHops()
+	if err != nil {
+		return err
+	}
+	*out = n
+	return nil
+}
+
 // SetCalculateRoutes sets calculate_routes in visor's routing config
 func (r *RPC) SetCalculateRoutes(enabled *bool, _ *struct{}) (err error) {
 	defer rpcutil.LogCall(r.log, "SetCalculateRoutes", *enabled)(nil, &err)


### PR DESCRIPTION
## Summary

- \`skywire cli route calc <pk>\` now defaults \`--min\` to the visor's configured \`routing.min_hops\` (via a new \`GetMinHops\` RPC) instead of always 1.
- New \`--count\`/\`-c\` flag (default 1, 0 = all) — \`GetRoute\` was always called with a hardcoded \`1\` and the CLI only printed \`routes[0]\`, so the BFS finder's other paths were silently dropped.
- Fixes a pre-existing OOM in \`finder.GetRoute\` exposed by passing a large count sentinel.

## Why

A visor with \`min_hops: 2\` running \`route calc <dst>\` was still getting a 1-hop direct route back, because the CLI flag defaulted to 1 and never consulted the visor. And there was no way to enumerate alternative paths even though the BFS finder already collected them all internally.

## Changes

- \`pkg/visor/api.go\`, \`api_routing.go\`, \`rpc_routing.go\`, \`rpc_client.go\`, \`rpc_client_mock.go\` — new \`GetMinHops()\` RPC.
- \`cmd/skywire-cli/commands/route/calc.go\`:
  - \`--min\` default flipped from \`1\` → \`0\` (0 = "use visor's \`routing.min_hops\`, fallback 1").
  - New \`--count\`/\`-c\` flag (default 1, 0 = all).
  - Output: single route still emits \`{forward, reverse}\` (back-compat); multi-route emits an array of those pairs. Text mode prefixes each pair with \`[N/total]\` when \`--count != 1\`.
- \`pkg/route-finder/store/finder.go\` — cap the preallocated routes slice at \`len(paths)\` so passing a large \`number\` doesn't try to reserve ~2B entries.

## Test plan

- [x] \`go build ./...\` clean.
- [x] On a visor with \`min_hops: 2\`, \`route calc <dst>\` (no flags) returns a 2-hop route. Previously returned 1-hop via direct transport.
- [x] \`route calc <dst> -c 5\` returns 5 distinct paths via different intermediaries.
- [x] \`route calc <dst> --max 5 -c 0\` enumerates all 48k paths in <1.5s on a graph with ~50 visors.
- [x] \`route calc <dst>\` with \`--count 1\` (default) emits the original single \`{forward, reverse}\` JSON shape — back-compat preserved.