### PR TITLE
feat(wasm-visor): runtime Go<->TinyGo variant switch in one PWA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,8 @@ tinygo-wasm-visor: ## Build the FULL browser WASM visor (dmsg+transport+router+a
 	cp ./cmd/wasm-visor/index.html ./build/wasm-visor/
 	cp ./pkg/wasmhv/browseui/winbox.min.js ./build/wasm-visor/
 	cp ./pkg/wasmhv/browseui/browse.js ./build/wasm-visor/
+	cp ./pkg/wasmhv/hv-boot.js ./build/wasm-visor/
+	cp ./pkg/wasmhv/worker.js ./build/wasm-visor/
 	@echo "built ./build/wasm-visor (TinyGo fork) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor' then open http://localhost:8085/"
 
 wasm-visor: ## Build the browser WASM visor edge with STANDARD Go js/wasm into build/wasm-visor-go — larger (~38MB) but full crypto/tls + net/http (https clearnet via skysocks). Does NOT touch the committed embed blob.

--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -11,6 +11,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"html"
@@ -235,11 +236,49 @@ page never asks anyone to type a secret key.`,
 		}
 		// The wasm-visor bootstrap files hv-boot.js fetches by name (resolved against
 		// <base href="/">). These are NOT in the Angular FS, so serve them explicitly.
-		serveBytes("/wasm-visor.wasm", "application/wasm", wasm)
-		// wasm_exec.js MUST match the embedded wasm's toolchain (Go vs TinyGo
-		// loaders differ — TinyGo's provides the WASI shims its module imports),
-		// so take it from wasmbin alongside the blob, not a fixed copy.
-		serveBytes("/wasm_exec.js", "text/javascript", wasmbin.WasmExecJSVariant(variant))
+		//
+		// Variant-aware: BOTH embedded blobs are served from the same origin so the
+		// PWA can switch Go<->TinyGo at runtime WITHOUT restarting the server or
+		// changing identity (the SK lives in localStorage, shared across variants —
+		// see hv-boot.js). `?variant=go|tinygo` selects a blob; an unknown/absent
+		// value falls back to the launch default. wasm_exec.js MUST match the blob's
+		// toolchain (Go vs TinyGo loaders differ — TinyGo's provides the WASI shims
+		// its module imports), so it is selected by the SAME variant param.
+		pickVariant := func(r *http.Request) wasmbin.Variant {
+			if q := r.URL.Query().Get("variant"); q != "" && wasmbin.Has(wasmbin.Variant(q)) {
+				return wasmbin.Variant(q)
+			}
+			return variant
+		}
+		mux.HandleFunc("/wasm-visor.wasm", func(w http.ResponseWriter, r *http.Request) {
+			b, err := wasmbin.GetVariant(pickVariant(r))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/wasm")
+			w.Header().Set("Cache-Control", "public, max-age=300")
+			_, _ = w.Write(b) //nolint:errcheck
+		})
+		mux.HandleFunc("/wasm_exec.js", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Header().Set("Cache-Control", "public, max-age=300")
+			_, _ = w.Write(wasmbin.WasmExecJSVariant(pickVariant(r))) //nolint:errcheck
+		})
+		// Discovery: lets the UI toggle offer only the variants this build actually
+		// embeds, and know which one boots by default. A standard-Go build ships
+		// both; a TinyGo build ships only TinyGo, so the toggle self-hides there.
+		mux.HandleFunc("/wasm-variants.json", func(w http.ResponseWriter, _ *http.Request) {
+			avail := wasmbin.Available()
+			names := make([]string, len(avail))
+			for i, v := range avail {
+				names[i] = string(v)
+			}
+			b, _ := json.Marshal(map[string]interface{}{"available": names, "default": string(variant)}) //nolint:errcheck
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "no-store")
+			_, _ = w.Write(b) //nolint:errcheck
+		})
 		serveBytes("/hv-boot.js", "text/javascript", wasmhv.HvBootJS)
 		// worker.js hosts the wasm runtime off the main thread; hv-boot.js loads it
 		// by name (new Worker('worker.js')) and proxies skywireVisor over postMessage.

--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -60,6 +60,18 @@
   var SK_KEY = 'skywire-visor-sk';
   function loadStoredSK() { try { return localStorage.getItem(SK_KEY) || ''; } catch (e) { return ''; } }
   function storeSK(hex) { try { localStorage.setItem(SK_KEY, hex); } catch (e) {} }
+
+  // Go<->TinyGo wasm-visor selection. The chosen variant is persisted per-origin
+  // in localStorage; the SK above is variant-INDEPENDENT, so switching keeps the
+  // same identity/PK. Workers can't read localStorage, so the variant travels to
+  // worker.js as a `?variant=` query param on its URL (and on the wasm/wasm_exec
+  // fetches it makes). An empty value = the server's default blob. A SharedWorker
+  // is keyed by (url,name); the variant is in BOTH so switching spins up a fresh
+  // worker on the new blob instead of reusing the old-variant one.
+  var VARIANT_KEY = 'skywire-visor-variant';
+  function loadVariant() { try { return localStorage.getItem(VARIANT_KEY) || ''; } catch (e) { return ''; } }
+  function variantQS() { var v = loadVariant(); return v ? ('?variant=' + encodeURIComponent(v)) : ''; }
+  function variantSuffix() { var v = loadVariant(); return v ? ('-' + v) : ''; }
   function newSKHex() {
     var b = crypto.getRandomValues(new Uint8Array(32));
     return Array.prototype.map.call(b, function (x) { return ('0' + x.toString(16)).slice(-2); }).join('');
@@ -154,7 +166,7 @@
     return new Promise(function (resolve, reject) {
       if (typeof SharedWorker === 'undefined') { reject(new Error('SharedWorker unavailable')); return; }
       var sw;
-      try { sw = new SharedWorker('worker.js', { name: 'skywire-wasm-visor' }); } catch (e) { reject(e); return; }
+      try { sw = new SharedWorker('worker.js' + variantQS(), { name: 'skywire-wasm-visor' + variantSuffix() }); } catch (e) { reject(e); return; }
       var port = sw.port;
       var nextId = 1, pending = Object.create(null);
       var upTimer = setTimeout(function () { reject(new Error('shared worker did not report ready in time')); }, 45000);
@@ -254,7 +266,7 @@
     return new Promise(function (resolve, reject) {
       if (typeof Worker === 'undefined') { reject(new Error('Web Workers unavailable')); return; }
       var worker;
-      try { worker = new Worker('worker.js'); } catch (e) { reject(e); return; }
+      try { worker = new Worker('worker.js' + variantQS()); } catch (e) { reject(e); return; }
       var nextId = 1, pending = Object.create(null);
       var upTimer = setTimeout(function () { reject(new Error('worker did not report ready in time')); }, 30000);
 
@@ -456,14 +468,14 @@
   // are unavailable or worker.js can't be loaded (e.g. exotic embeddings). Keeps the
   // page working, at the cost of the main-thread-freeze risk the worker path avoids.
   async function bootInPage(sk) {
-    await loadScript('wasm_exec.js');
+    await loadScript('wasm_exec.js' + variantQS());
     var go = new Go();
     if (go.importObject.gojs && !go.importObject.gojs['runtime.getRandomData']) {
       go.importObject.gojs['runtime.getRandomData'] = function (ptr, len) {
         crypto.getRandomValues(new Uint8Array(go._inst.exports.memory.buffer, ptr >>> 0, len >>> 0));
       };
     }
-    var buf = await fetch('wasm-visor.wasm').then(function (r) { return r.arrayBuffer(); });
+    var buf = await fetch('wasm-visor.wasm' + variantQS()).then(function (r) { return r.arrayBuffer(); });
     var res = await WebAssembly.instantiate(buf, go.importObject);
     go.run(res.instance); // installs globalThis.skywireVisor
     while (!self.skywireVisor || !self.skywireVisor.boot) {
@@ -498,4 +510,42 @@
     }
     return pk;
   })();
+
+  // Minimal Go<->TinyGo switcher. Shown only when the server advertises >1 embedded
+  // variant (a TinyGo-only build hides it). Selecting a variant persists it and
+  // reloads; the SK is variant-independent, so the page reboots the OTHER blob as
+  // the SAME PK — the A/B test harness. Lives here (not Angular) so it works in the
+  // served PWA and under --harness alike, with no UI rebuild.
+  function injectVariantToggle() {
+    try {
+      fetch('wasm-variants.json', { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (info) {
+        var avail = (info && info.available) || [];
+        if (avail.length < 2) { return; }
+        var cur = loadVariant() || (info && info.default) || avail[0];
+        function build() {
+          if (!document.body || document.getElementById('sky-variant-toggle')) { return; }
+          var wrap = document.createElement('div');
+          wrap.id = 'sky-variant-toggle';
+          wrap.style.cssText = 'position:fixed;right:8px;bottom:8px;z-index:2147483647;font:12px system-ui,sans-serif;background:rgba(20,20,24,.9);color:#ddd;padding:4px 8px;border-radius:6px;border:1px solid #555;box-shadow:0 1px 4px rgba(0,0,0,.4)';
+          var lab = document.createElement('span'); lab.textContent = 'visor: '; wrap.appendChild(lab);
+          var sel = document.createElement('select');
+          sel.title = 'wasm-visor toolchain — reloads with the same identity';
+          sel.style.cssText = 'background:#111;color:#ddd;border:1px solid #555;border-radius:4px;font:inherit';
+          avail.forEach(function (v) {
+            var o = document.createElement('option'); o.value = v; o.textContent = v;
+            if (v === cur) { o.selected = true; }
+            sel.appendChild(o);
+          });
+          sel.addEventListener('change', function () {
+            try { localStorage.setItem(VARIANT_KEY, sel.value); } catch (e) {}
+            location.reload();
+          });
+          wrap.appendChild(sel);
+          document.body.appendChild(wrap);
+        }
+        if (document.readyState === 'loading') { document.addEventListener('DOMContentLoaded', build); } else { build(); }
+      }).catch(function () {});
+    } catch (e) {}
+  }
+  injectVariantToggle();
 })();

--- a/pkg/wasmhv/worker.js
+++ b/pkg/wasmhv/worker.js
@@ -82,7 +82,13 @@
   console.error = function () { forward('error', arguments); real.error.apply(null, arguments); };
   console.warn = function () { forward('warn', arguments); real.warn.apply(null, arguments); };
 
-  importScripts('wasm_exec.js');
+  // Variant (go|tinygo) arrives on this worker's URL (hv-boot.js appends it —
+  // workers can't read localStorage). It selects BOTH the loader and the blob,
+  // which must match toolchains. Empty = the server default.
+  var __variant = '';
+  try { __variant = (new URLSearchParams(self.location.search)).get('variant') || ''; } catch (e) {}
+  var __vqs = __variant ? ('?variant=' + encodeURIComponent(__variant)) : '';
+  importScripts('wasm_exec.js' + __vqs);
   var go = new Go();
   // TinyGo's wasm_exec.js omits the gojs getRandomData import the crypto-using Go
   // runtime needs to seed itself; inject it only when absent (mirrors hv-boot.js).
@@ -349,7 +355,7 @@
     registerPort(selfPort);
   }
 
-  fetch('wasm-visor.wasm').then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
+  fetch('wasm-visor.wasm' + __vqs).then(function (r) { return r.arrayBuffer(); }).then(function (buf) {
     return WebAssembly.instantiate(buf, go.importObject);
   }).then(function (res) {
     go.run(res.instance); // installs self.skywireVisor, then parks on select{}


### PR DESCRIPTION
Wiring to switch the embedded wasm-visor between the std-Go and TinyGo blobs at runtime, in one PWA, **without changing identity** (SK is variant-independent → same PK reboots the other blob). The A/B harness for validating TinyGo before it could ever become default.

- `hv serve`: serves both blobs (`?variant=go|tinygo`) + matching `wasm_exec.js` + `/wasm-variants.json`.
- `hv-boot.js`/`worker.js`: variant persisted in localStorage, flowed to the (Shared)Worker via query param; toggle shown only when >1 variant embedded.
- Makefile: TinyGo target ships the boot glue too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)