### PR TITLE
refactor(skychat): move history store to pkg/skychat/history + wasm-safe MemStore

### DIFF
--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/skycoin/skywire/cmd/apps/skychat/history"
+	"github.com/skycoin/skywire/pkg/skychat/history"
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"

--- a/pkg/skychat/history/group_since_bolt_test.go
+++ b/pkg/skychat/history/group_since_bolt_test.go
@@ -1,4 +1,7 @@
-// Package history — cmd/apps/skychat/history/group_since_test.go:
+//go:build !js
+// +build !js
+
+// Package history — pkg/skychat/history/group_since_bolt_test.go:
 // pins the BoltStore.ListGroupSince contract added so the gRPC
 // StreamGroupMessages handler can backfill a reconnecting subscriber
 // whose disconnect gap exceeds the in-memory inbox ring. Without

--- a/pkg/skychat/history/history.go
+++ b/pkg/skychat/history/history.go
@@ -1,7 +1,7 @@
-// Package history cmd/apps/skychat/history/history.go c4-app-chat
+// Package history pkg/skychat/history/history.go c4-app-chat
 //
 // By default skychat is entirely ephemeral — messages pass through and are not
-// stored anywhere. The history package adds an opt-in BoltDB-backed store with
+// stored anywhere. The history package adds an opt-in persistent store with
 // strict limits to prevent disk-fill/spam attacks:
 //
 //   - per-message size cap (drop larger)
@@ -14,6 +14,13 @@
 // The ephemeral delivery path is never blocked by the store. Messages that
 // can't be persisted are still delivered to the UI SSE stream; only the
 // side-effect of durable storage is skipped.
+//
+// Two backends implement Store: BoltStore (durable, BoltDB-backed, native
+// only — bbolt does not compile under GOOS=js) lives in store_bolt.go behind
+// a `!js` build tag; MemStore (in-memory, all platforms including the wasm
+// visor) lives in store_mem.go. The Message/GroupMessage types, the Store
+// interface, and Limits are pure Go and shared by both, so this file compiles
+// everywhere.
 package history
 
 import (

--- a/pkg/skychat/history/store_bolt.go
+++ b/pkg/skychat/history/store_bolt.go
@@ -1,4 +1,13 @@
-// Package history cmd/apps/skychat/history/store.go c4-app-chat
+//go:build !js
+// +build !js
+
+// Package history pkg/skychat/history/store_bolt.go c4-app-chat
+//
+// BoltStore is the durable, BoltDB-backed Store. bbolt mmaps a file and
+// references syscalls (e.g. MaxAllocSize) that don't exist under GOOS=js, so
+// this backend is native-only — the `!js` build tag keeps the wasm visor's
+// build green. Under js the in-memory MemStore (store_mem.go) is the only
+// Store; it implements the same interface with the same limit semantics.
 package history
 
 import (

--- a/pkg/skychat/history/store_bolt_test.go
+++ b/pkg/skychat/history/store_bolt_test.go
@@ -1,4 +1,7 @@
-// Package history store_test.go
+//go:build !js
+// +build !js
+
+// Package history store_bolt_test.go
 package history
 
 import (

--- a/pkg/skychat/history/store_mem.go
+++ b/pkg/skychat/history/store_mem.go
@@ -1,0 +1,346 @@
+// Package history pkg/skychat/history/store_mem.go c4-app-chat
+//
+// MemStore is a non-durable, in-memory Store. It exists so the history
+// package compiles and runs under GOOS=js (the wasm visor) where BoltStore's
+// bbolt backend can't build, and so tests / ephemeral deployments have a
+// dependency-free Store. It honors the same Limits as BoltStore — per-message
+// size, per-peer rate (token bucket), per-peer FIFO cap, total-bytes cap, TTL
+// sweep, and whitelist — with one documented difference: TotalCapBytes is
+// measured against the accumulated JSON size of stored records rather than an
+// on-disk file size, so the numbers won't line up byte-for-byte with a bolt
+// file, but the reject-when-full contract is identical.
+package history
+
+import (
+	"encoding/json"
+	"sort"
+	"sync"
+	"time"
+)
+
+// MemStore keeps messages in per-peer and per-group slices guarded by a single
+// mutex. Slices are held sorted by Timestamp ascending (newest last) so reads
+// and FIFO eviction are trivial. It is safe for concurrent use.
+type MemStore struct {
+	mu     sync.Mutex
+	limits Limits
+
+	byPeer  map[string][]Message
+	byGroup map[string][]GroupMessage
+	// totalBytes is the running sum of the JSON size of every stored record
+	// (1:1 and group), maintained incrementally on append and eviction/sweep.
+	totalBytes int64
+
+	// rate limiting state: per-key token bucket in a 1-minute window, keyed
+	// by peer PK (1:1) or group ID (group). Mirrors BoltStore.acceptRate.
+	rateWindow   time.Time
+	rateCount    map[string]int
+	peerLastSeen map[string]time.Time
+
+	done   chan struct{}
+	closed bool
+	wg     sync.WaitGroup
+}
+
+// NewMemStore returns an in-memory Store. A non-zero Limits.TTL starts a
+// background sweep goroutine (stopped by Close), exactly as BoltStore does.
+func NewMemStore(limits Limits) (*MemStore, error) {
+	if err := limits.Validate(); err != nil {
+		return nil, err
+	}
+	s := &MemStore{
+		limits:       limits,
+		byPeer:       make(map[string][]Message),
+		byGroup:      make(map[string][]GroupMessage),
+		rateWindow:   time.Now().UTC().Truncate(time.Minute),
+		rateCount:    make(map[string]int),
+		peerLastSeen: make(map[string]time.Time),
+		done:         make(chan struct{}),
+	}
+	if limits.TTL > 0 {
+		s.wg.Add(1)
+		go s.sweepLoop()
+	}
+	return s, nil
+}
+
+func msgSize(v interface{}) int64 {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return 0
+	}
+	return int64(len(raw))
+}
+
+// Append implements Store.
+func (s *MemStore) Append(msg Message) error {
+	if msg.Peer == "" {
+		return ErrEmptyPeer
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now().UTC()
+	}
+	if s.limits.MaxMessageSize > 0 && len(msg.Text) > s.limits.MaxMessageSize {
+		return ErrTooLarge
+	}
+	if s.limits.WhitelistOnly && !s.limits.Whitelist[msg.Peer] {
+		return ErrNotWhitelisted
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.acceptRateLocked(msg.Peer) {
+		return ErrRateLimited
+	}
+	if s.limits.TotalCapBytes > 0 && s.totalBytes >= s.limits.TotalCapBytes {
+		return ErrStorageFull
+	}
+
+	msgs := append(s.byPeer[msg.Peer], msg)
+	sort.SliceStable(msgs, func(i, j int) bool { return msgs[i].Timestamp.Before(msgs[j].Timestamp) })
+	s.totalBytes += msgSize(msg)
+
+	// Per-peer FIFO cap: drop oldest (front) beyond the cap.
+	if s.limits.PerPeerCap > 0 && len(msgs) > s.limits.PerPeerCap {
+		drop := len(msgs) - s.limits.PerPeerCap
+		for _, ev := range msgs[:drop] {
+			s.totalBytes -= msgSize(ev)
+		}
+		msgs = append([]Message(nil), msgs[drop:]...)
+	}
+	s.byPeer[msg.Peer] = msgs
+	return nil
+}
+
+// acceptRateLocked mirrors BoltStore.acceptRate; caller holds s.mu.
+func (s *MemStore) acceptRateLocked(key string) bool {
+	if s.limits.PerPeerRatePerMin == 0 {
+		return true
+	}
+	now := time.Now().UTC()
+	currentWindow := now.Truncate(time.Minute)
+	if currentWindow.After(s.rateWindow) {
+		s.rateWindow = currentWindow
+		s.rateCount = make(map[string]int, len(s.rateCount))
+	}
+	s.peerLastSeen[key] = now
+	if len(s.peerLastSeen) > 1024 {
+		cutoff := now.Add(-10 * time.Minute)
+		for p, t := range s.peerLastSeen {
+			if t.Before(cutoff) {
+				delete(s.peerLastSeen, p)
+			}
+		}
+	}
+	if s.rateCount[key] >= s.limits.PerPeerRatePerMin {
+		return false
+	}
+	s.rateCount[key]++
+	return true
+}
+
+// ListByPeer implements Store.
+func (s *MemStore) ListByPeer(peer string, limit int) ([]Message, error) {
+	if peer == "" {
+		return nil, ErrEmptyPeer
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src := s.byPeer[peer]
+	return tailCopy(src, limit), nil
+}
+
+// ListRecent implements Store.
+func (s *MemStore) ListRecent(limit int) ([]Message, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var all []Message
+	for _, msgs := range s.byPeer {
+		all = append(all, msgs...)
+	}
+	sort.SliceStable(all, func(i, j int) bool { return all[i].Timestamp.Before(all[j].Timestamp) })
+	if limit > 0 && len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+// Peers implements Store.
+func (s *MemStore) Peers() ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	peers := make([]string, 0, len(s.byPeer))
+	for p := range s.byPeer {
+		peers = append(peers, p)
+	}
+	return peers, nil
+}
+
+// AppendGroup implements Store.
+func (s *MemStore) AppendGroup(msg GroupMessage) error {
+	if msg.GroupID == "" {
+		return ErrEmptyPeer
+	}
+	if msg.Timestamp.IsZero() {
+		msg.Timestamp = time.Now().UTC()
+	}
+	if s.limits.MaxMessageSize > 0 && len(msg.Text) > s.limits.MaxMessageSize {
+		return ErrTooLarge
+	}
+	if s.limits.WhitelistOnly && !s.limits.Whitelist[msg.GroupID] {
+		return ErrNotWhitelisted
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.acceptRateLocked(msg.GroupID) {
+		return ErrRateLimited
+	}
+	if s.limits.TotalCapBytes > 0 && s.totalBytes >= s.limits.TotalCapBytes {
+		return ErrStorageFull
+	}
+
+	msgs := append(s.byGroup[msg.GroupID], msg)
+	sort.SliceStable(msgs, func(i, j int) bool { return msgs[i].Timestamp.Before(msgs[j].Timestamp) })
+	s.totalBytes += msgSize(msg)
+
+	if s.limits.PerPeerCap > 0 && len(msgs) > s.limits.PerPeerCap {
+		drop := len(msgs) - s.limits.PerPeerCap
+		for _, ev := range msgs[:drop] {
+			s.totalBytes -= msgSize(ev)
+		}
+		msgs = append([]GroupMessage(nil), msgs[drop:]...)
+	}
+	s.byGroup[msg.GroupID] = msgs
+	return nil
+}
+
+// ListByGroup implements Store.
+func (s *MemStore) ListByGroup(groupID string, limit int) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return tailCopyGroup(s.byGroup[groupID], limit), nil
+}
+
+// ListGroupSince implements Store. Returns messages strictly newer than
+// `since`, oldest first — matching BoltStore's exclusive-cursor semantics.
+func (s *MemStore) ListGroupSince(groupID string, since time.Time) ([]GroupMessage, error) {
+	if groupID == "" {
+		return nil, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	src := s.byGroup[groupID]
+	if len(src) == 0 {
+		return nil, nil
+	}
+	var out []GroupMessage
+	for _, m := range src {
+		if since.IsZero() || m.Timestamp.After(since) {
+			out = append(out, m)
+		}
+	}
+	return out, nil
+}
+
+// Groups implements Store.
+func (s *MemStore) Groups() ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	groups := make([]string, 0, len(s.byGroup))
+	for g := range s.byGroup {
+		groups = append(groups, g)
+	}
+	return groups, nil
+}
+
+// Close implements Store. Idempotent.
+func (s *MemStore) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil
+	}
+	s.closed = true
+	close(s.done)
+	s.mu.Unlock()
+	s.wg.Wait()
+	return nil
+}
+
+func (s *MemStore) sweepLoop() {
+	defer s.wg.Done()
+	interval := 10 * time.Minute
+	if s.limits.TTL/10 < interval {
+		interval = s.limits.TTL / 10
+		if interval < time.Minute {
+			interval = time.Minute
+		}
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.done:
+			return
+		case <-t.C:
+			s.sweep()
+		}
+	}
+}
+
+// sweep drops 1:1 messages older than the TTL. Group messages are NOT swept
+// — matching BoltStore.sweep, which only walks the messages bucket.
+func (s *MemStore) sweep() {
+	cutoff := time.Now().UTC().Add(-s.limits.TTL)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for peer, msgs := range s.byPeer {
+		kept := msgs[:0:0]
+		for _, m := range msgs {
+			if m.Timestamp.After(cutoff) {
+				kept = append(kept, m)
+			} else {
+				s.totalBytes -= msgSize(m)
+			}
+		}
+		if len(kept) == 0 {
+			delete(s.byPeer, peer)
+		} else {
+			s.byPeer[peer] = kept
+		}
+	}
+}
+
+// tailCopy returns a fresh slice of the most recent `limit` messages (all if
+// limit <= 0), so callers can't mutate the store's backing array.
+func tailCopy(src []Message, limit int) []Message {
+	if len(src) == 0 {
+		return nil
+	}
+	start := 0
+	if limit > 0 && len(src) > limit {
+		start = len(src) - limit
+	}
+	out := make([]Message, len(src)-start)
+	copy(out, src[start:])
+	return out
+}
+
+func tailCopyGroup(src []GroupMessage, limit int) []GroupMessage {
+	if len(src) == 0 {
+		return nil
+	}
+	start := 0
+	if limit > 0 && len(src) > limit {
+		start = len(src) - limit
+	}
+	out := make([]GroupMessage, len(src)-start)
+	copy(out, src[start:])
+	return out
+}

--- a/pkg/skychat/history/store_mem_test.go
+++ b/pkg/skychat/history/store_mem_test.go
@@ -1,0 +1,307 @@
+// Package history store_mem_test.go — mirrors the BoltStore coverage for the
+// in-memory backend (which is the only Store under GOOS=js) plus a few
+// mem-specific cases (total-bytes cap, group-since, idempotent Close). No
+// build tag: MemStore compiles and these run on every platform.
+package history
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestMemStore(t *testing.T, limits Limits) *MemStore {
+	t.Helper()
+	s, err := NewMemStore(limits)
+	if err != nil {
+		t.Fatalf("NewMemStore: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Logf("store close: %v", err)
+		}
+	})
+	return s
+}
+
+func TestMemStore_AppendAndListByPeer(t *testing.T) {
+	s := newTestMemStore(t, DefaultLimits())
+	peer := "03abc" + strings.Repeat("0", 61)
+	for i := 0; i < 5; i++ {
+		if err := s.Append(Message{
+			Peer:      peer,
+			Text:      fmt.Sprintf("msg-%d", i),
+			Timestamp: time.Now().Add(time.Duration(i) * time.Millisecond),
+		}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	msgs, err := s.ListByPeer(peer, 0)
+	if err != nil {
+		t.Fatalf("ListByPeer: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Fatalf("want 5 messages, got %d", len(msgs))
+	}
+	for i, m := range msgs {
+		if want := fmt.Sprintf("msg-%d", i); m.Text != want {
+			t.Errorf("msg %d: text = %q, want %q", i, m.Text, want)
+		}
+	}
+}
+
+func TestMemStore_MaxMessageSize(t *testing.T) {
+	lim := DefaultLimits()
+	lim.MaxMessageSize = 10
+	s := newTestMemStore(t, lim)
+	if err := s.Append(Message{Peer: "abc", Text: strings.Repeat("x", 11)}); !errors.Is(err, ErrTooLarge) {
+		t.Fatalf("want ErrTooLarge, got %v", err)
+	}
+	if err := s.Append(Message{Peer: "abc", Text: "short"}); err != nil {
+		t.Fatalf("short message should succeed: %v", err)
+	}
+}
+
+func TestMemStore_RateLimit(t *testing.T) {
+	lim := DefaultLimits()
+	lim.PerPeerRatePerMin = 3
+	s := newTestMemStore(t, lim)
+	peer := "rate-peer"
+	for i := 0; i < 3; i++ {
+		if err := s.Append(Message{Peer: peer, Text: "ok"}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	if err := s.Append(Message{Peer: peer, Text: "overflow"}); !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("want ErrRateLimited, got %v", err)
+	}
+	if err := s.Append(Message{Peer: "other-peer", Text: "ok"}); err != nil {
+		t.Fatalf("other peer should not be rate-limited: %v", err)
+	}
+}
+
+func TestMemStore_PerPeerCap(t *testing.T) {
+	lim := DefaultLimits()
+	lim.PerPeerCap = 3
+	lim.PerPeerRatePerMin = 0
+	s := newTestMemStore(t, lim)
+	peer := "cap-peer"
+	for i := 0; i < 5; i++ {
+		if err := s.Append(Message{
+			Peer:      peer,
+			Text:      fmt.Sprintf("m%d", i),
+			Timestamp: time.Now().Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("Append %d: %v", i, err)
+		}
+	}
+	msgs, err := s.ListByPeer(peer, 0)
+	if err != nil {
+		t.Fatalf("ListByPeer: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages after cap eviction, got %d", len(msgs))
+	}
+	want := []string{"m2", "m3", "m4"}
+	for i, m := range msgs {
+		if m.Text != want[i] {
+			t.Errorf("msg %d: want %q got %q", i, want[i], m.Text)
+		}
+	}
+}
+
+func TestMemStore_Whitelist(t *testing.T) {
+	lim := DefaultLimits()
+	lim.WhitelistOnly = true
+	lim.Whitelist = map[string]bool{"allowed": true}
+	s := newTestMemStore(t, lim)
+	if err := s.Append(Message{Peer: "allowed", Text: "ok"}); err != nil {
+		t.Fatalf("allowed peer should succeed: %v", err)
+	}
+	if err := s.Append(Message{Peer: "blocked", Text: "ok"}); !errors.Is(err, ErrNotWhitelisted) {
+		t.Fatalf("want ErrNotWhitelisted, got %v", err)
+	}
+}
+
+func TestMemStore_ListRecent(t *testing.T) {
+	s := newTestMemStore(t, Limits{})
+	now := time.Now().UTC()
+	writes := []Message{
+		{Peer: "a", Text: "a1", Timestamp: now.Add(1 * time.Second)},
+		{Peer: "b", Text: "b1", Timestamp: now.Add(2 * time.Second)},
+		{Peer: "a", Text: "a2", Timestamp: now.Add(3 * time.Second)},
+		{Peer: "b", Text: "b2", Timestamp: now.Add(4 * time.Second)},
+	}
+	for _, m := range writes {
+		if err := s.Append(m); err != nil {
+			t.Fatal(err)
+		}
+	}
+	all, err := s.ListRecent(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("want 4 messages, got %d", len(all))
+	}
+	want := []string{"a1", "b1", "a2", "b2"}
+	for i, m := range all {
+		if m.Text != want[i] {
+			t.Errorf("msg %d: want %q got %q", i, want[i], m.Text)
+		}
+	}
+	recent, err := s.ListRecent(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recent) != 2 || recent[0].Text != "a2" || recent[1].Text != "b2" {
+		t.Errorf("unexpected recent list: %+v", recent)
+	}
+}
+
+func TestMemStore_Peers(t *testing.T) {
+	s := newTestMemStore(t, Limits{})
+	for _, p := range []string{"a", "b", "c"} {
+		if err := s.Append(Message{Peer: p, Text: "x"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	peers, err := s.Peers()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(peers) != 3 {
+		t.Fatalf("want 3 peers, got %d: %v", len(peers), peers)
+	}
+}
+
+func TestMemStore_EmptyPeerRejected(t *testing.T) {
+	s := newTestMemStore(t, Limits{})
+	if err := s.Append(Message{Peer: "", Text: "x"}); !errors.Is(err, ErrEmptyPeer) {
+		t.Fatalf("want ErrEmptyPeer, got %v", err)
+	}
+}
+
+func TestMemStore_TTLSweep(t *testing.T) {
+	s := newTestMemStore(t, Limits{TTL: 10 * time.Second})
+	now := time.Now().UTC()
+	if err := s.Append(Message{Peer: "p", Text: "old", Timestamp: now.Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Append(Message{Peer: "p", Text: "new", Timestamp: now}); err != nil {
+		t.Fatal(err)
+	}
+	s.sweep() // trigger directly rather than waiting on the ticker
+	msgs, err := s.ListByPeer("p", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 message after sweep, got %d", len(msgs))
+	}
+	if msgs[0].Text != "new" {
+		t.Errorf("sweep removed wrong message: %+v", msgs[0])
+	}
+}
+
+func TestMemStore_TotalCapBytes(t *testing.T) {
+	// A tiny cap: the first message writes, and once totalBytes >= cap the
+	// next write is rejected with ErrStorageFull.
+	s := newTestMemStore(t, Limits{TotalCapBytes: 60})
+	if err := s.Append(Message{Peer: "p", Text: strings.Repeat("x", 40)}); err != nil {
+		t.Fatalf("first append should succeed: %v", err)
+	}
+	if err := s.Append(Message{Peer: "p", Text: "y"}); !errors.Is(err, ErrStorageFull) {
+		t.Fatalf("want ErrStorageFull once over cap, got %v", err)
+	}
+}
+
+func TestMemStore_GroupAppendAndSince(t *testing.T) {
+	s := newTestMemStore(t, Limits{})
+	base := time.Now().UTC()
+	for i := 0; i < 4; i++ {
+		if err := s.AppendGroup(GroupMessage{
+			GroupID:   "g1",
+			SenderPK:  "s",
+			Text:      fmt.Sprintf("g%d", i),
+			Timestamp: base.Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("AppendGroup %d: %v", i, err)
+		}
+	}
+	// ListByGroup newest-last.
+	all, err := s.ListByGroup("g1", 0)
+	if err != nil || len(all) != 4 {
+		t.Fatalf("ListByGroup: len=%d err=%v", len(all), err)
+	}
+	if all[0].Text != "g0" || all[3].Text != "g3" {
+		t.Errorf("group order wrong: %+v", groupTexts(all))
+	}
+	// ListGroupSince strictly-after cursor: cursor at g1's ts → g2,g3.
+	since := base.Add(1 * time.Second)
+	after, err := s.ListGroupSince("g1", since)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := groupTexts(after); len(got) != 2 || got[0] != "g2" || got[1] != "g3" {
+		t.Errorf("ListGroupSince returned %v, want [g2 g3]", got)
+	}
+	// Zero time returns all.
+	zeroAll, err := s.ListGroupSince("g1", time.Time{})
+	if err != nil || len(zeroAll) != 4 {
+		t.Fatalf("zero-time ListGroupSince: len=%d err=%v", len(zeroAll), err)
+	}
+	// Unknown group → nil.
+	if got, _ := s.ListGroupSince("nope", since); got != nil {
+		t.Errorf("unknown group should be nil, got %v", got)
+	}
+	// Groups() lists the one group.
+	groups, _ := s.Groups()
+	if len(groups) != 1 || groups[0] != "g1" {
+		t.Errorf("Groups() = %v, want [g1]", groups)
+	}
+}
+
+func TestMemStore_GroupIsolation(t *testing.T) {
+	// A 1:1 message and a group message with the same key must not leak
+	// across ListByPeer / ListByGroup.
+	s := newTestMemStore(t, Limits{})
+	if err := s.Append(Message{Peer: "x", Text: "dm"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendGroup(GroupMessage{GroupID: "x", SenderPK: "x", Text: "grp"}); err != nil {
+		t.Fatal(err)
+	}
+	dm, _ := s.ListByPeer("x", 0)
+	if len(dm) != 1 || dm[0].Text != "dm" {
+		t.Errorf("ListByPeer leaked group traffic: %+v", dm)
+	}
+	grp, _ := s.ListByGroup("x", 0)
+	if len(grp) != 1 || grp[0].Text != "grp" {
+		t.Errorf("ListByGroup leaked dm traffic: %+v", grp)
+	}
+}
+
+func TestMemStore_CloseIdempotent(t *testing.T) {
+	s, err := NewMemStore(Limits{TTL: time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second close should be a no-op: %v", err)
+	}
+}
+
+// texts extracts the Text field from group messages for concise assertions.
+func groupTexts(msgs []GroupMessage) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Text
+	}
+	return out
+}

--- a/pkg/visor/init_group.go
+++ b/pkg/visor/init_group.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	skychatgroup "github.com/skycoin/skywire/cmd/apps/skychat/group"
-	"github.com/skycoin/skywire/cmd/apps/skychat/history"
+	"github.com/skycoin/skywire/pkg/skychat/history"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/logging"
 )


### PR DESCRIPTION
## What

Moves the skychat history store into the shared `pkg/skychat` tree and makes it compile under `GOOS=js` so the wasm visor can adopt it — the enabling seam for the rest of the DM-controller convergence (#3596).

Previously the store lived in `cmd/apps/skychat/history` and its only backend was `BoltStore`, which can't build under js (bbolt mmaps a file / uses syscalls absent in the js runtime). That kept persistence out of reach of the browser visor, which fell back to an ad-hoc in-memory `chatLog`.

## Changes

- **Move** `cmd/apps/skychat/history` → `pkg/skychat/history` (importers updated: `pkg/visor/init_group.go`, `cmd/apps/skychat/commands/skychat.go`).
- **Split backends**:
  - `history.go` — `Message`/`GroupMessage`, the `Store` interface, `Limits`, errors. Pure Go, compiles everywhere.
  - `store_bolt.go` — `BoltStore` behind `//go:build !js` (unchanged behavior).
  - `store_mem.go` — new **`MemStore`**, all platforms, implementing the same 9-method `Store` with the same limit semantics: per-message size, per-peer token-bucket rate limit, per-peer FIFO cap, total-bytes cap, TTL sweep (1:1 only — matching `BoltStore.sweep`), whitelist. Documented difference: `TotalCapBytes` is measured against accumulated JSON size, not on-disk file size.
- **Tests**: bolt tests tagged `!js`; new `store_mem_test.go` mirrors them on all platforms + adds total-bytes-cap, group-since cursor, group/DM isolation, and idempotent-`Close` cases.

## Validation

- `go build ./...` — OK
- `GOOS=js GOARCH=wasm go build ./pkg/skychat/history` — **OK** (the point of the change)
- `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` — OK
- `go test ./pkg/skychat/history/` — ok (both backends)

Next in #3596: wire the wasm visor's chat buffer onto `MemStore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)