### PR TITLE
docs(packaging): document the three auto-update mechanisms + AUR packages

### DIFF
--- a/docs/packaging/README.md
+++ b/docs/packaging/README.md
@@ -1,0 +1,17 @@
+# Packaging & Updates
+
+How Skywire is packaged for Linux distributions, and how installed nodes keep
+themselves up to date.
+
+- [Auto-Update Mechanisms](auto-update.md) — the three independent ways a
+  node updates itself: apt `unattended-upgrades` (via `skyrepo`), source
+  rebuilds (`skywire-autoupdate` / `skywire-update.service`), and docker image
+  auto-pull (`skywire-docker-autopull`). Includes how to tell which one you're
+  running and how to enable/disable each.
+- [AUR Packages](aur-packages.md) — the Arch Linux packages (`skywire-bin`,
+  `skywire`, `skyrepo`) and the variant PKGBUILDs that also produce the
+  auto-update packages and the Debian `.deb`s.
+
+For the underlying rolling-release / CI machinery that all three update paths
+track (the `skywire-commit` branch and the `:test` Docker tag), see
+[AUTO_UPDATE.md](https://github.com/skycoin/skywire/blob/develop/AUTO_UPDATE.md).

--- a/docs/packaging/aur-packages.md
+++ b/docs/packaging/aur-packages.md
@@ -1,0 +1,120 @@
+# AUR Packages (Arch Linux)
+
+Skywire is packaged for Arch Linux through the AUR. There are **two AUR
+pkgbases** — `skywire-bin` (prebuilt binary) and `skywire` (from source) —
+plus a repository/provisioning package, `skyrepo`. Each pkgbase's git tree
+also carries *variant* `*.PKGBUILD` recipes that produce the auto-update
+packages and the Debian `.deb`s published to the apt repo, so the AUR trees
+are the single source of packaging truth for both distros.
+
+All are maintained by Moses Narrow. Note that every recipe builds/installs
+from the upstream module path `github.com/skycoin/skywire` regardless of which
+fork the working tree is checked out from.
+
+## Quick pick
+
+| You want… | Install |
+|-----------|---------|
+| The stable release, fastest install (no compiler) | `skywire-bin` |
+| A locally-compiled build (musl-static, release tag) | `skywire` |
+| A build tracking the `develop` branch | `skywire` via `git.PKGBUILD` |
+| Automatic daily source rebuilds | `skywire-autoupdate` (see [Auto-Update](auto-update.md)) |
+| The Skycoin apt repo + provisioning helpers | `skyrepo` |
+
+---
+
+## pkgbase `skywire-bin` — prebuilt binary
+
+Installs the **prebuilt release binary** downloaded from the GitHub release
+(`releases/download/v<ver>/skywire-v<ver>-linux-<arch>.tar.gz`, per-arch
+`source_*`). No Go toolchain needed. `provides`/`conflicts` = `skywire`, so it
+is interchangeable with the from-source package. Binary lands at
+`/opt/skywire/bin/skywire` with `/usr/bin` symlinks. optdepends: redis,
+postgresql, jq.
+
+It installs only the **runtime** systemd units — `skywire.service`,
+`skywire-autoconfig.service`, the deployment-service group
+(`skywire-{sn,ar,rf,tpd,dmsgd,dmsg,sd}.service`), `dmsgpty-tcp.socket` +
+`dmsgpty-tcp@.service`, a user unit, plus `sysusers.d`/`tmpfiles.d` entries. It
+does **not** install any auto-update units — those come from the separate
+`skywire-autoupdate` / `skywire-docker-autopull` packages.
+
+Variant recipes in the same tree:
+
+- **`PKGBUILD`** → `skywire-bin` (the above).
+- **`cc.deb.PKGBUILD`** → repackages the release tarballs into per-arch `.deb`s
+  (amd64/arm64/armhf/armel/riscv64/i386) for the apt repo. Shared deb scripts
+  do sysusers/tmpfiles setup, `setcap`, generate `/etc/skywire.conf`, run
+  `skywire autoconfig`, and try-restart the service.
+- **`autoupdate.PKGBUILD`** / **`autoupdate.deb.PKGBUILD`** →
+  the `skywire-autoupdate` package.
+- **`docker-autopull.PKGBUILD`** / **`docker-autopull.deb.PKGBUILD`** →
+  the `skywire-docker-autopull` package.
+
+---
+
+## pkgbase `skywire` — from source
+
+Builds skywire **from source** with a musl static link:
+`go install github.com/skycoin/skywire/cmd/skywire@v<ver>` with `CC=musl-gcc`
+and `-linkmode external -extldflags '-static'`.
+`makedepends=(git go>=1.24 musl kernel-headers-musl)` (plus `npm` when
+`REBUILDUI=1`). It pulls the service/desktop/icon files from a nested
+`skywire-bin` AUR checkout, so it installs the **same runtime units** as
+`skywire-bin`. It also installs the `skywire-autoconfig` script to
+`/opt/skywire/scripts` and `/usr/bin`.
+
+Variant recipes in the same tree:
+
+- **`PKGBUILD`** → `skywire`, from the release tag.
+- **`git.PKGBUILD`** → develop-branch build; `pkgver()` derived from
+  `go list -m github.com/skycoin/skywire@develop`, builds `cmd/skywire@develop`.
+- **`deb.PKGBUILD`** → from-source Debian `.deb`.
+- **`dev.PKGBUILD`** → develop-branch `.deb` (sources `deb.PKGBUILD` +
+  `git.PKGBUILD`).
+- **`systray-git.PKGBUILD`** → the systray build variant.
+
+---
+
+## Auto-update packages (from the `skywire-bin` tree)
+
+These are produced by variant recipes above but are worth calling out as
+distinct installable packages. See [Auto-Update Mechanisms](auto-update.md)
+for what their timers do.
+
+- **`skywire-autoupdate`** — `depends=(skywire-bin go)`. Installs
+  `/usr/bin/skywire-update` + `/usr/bin/skywire-docker-update` and their
+  service/timer pairs. Its `.install` creates the unprivileged
+  `skywire-build` user and enables `skywire-update.timer`.
+- **`skywire-docker-autopull`** — its **own** package, `depends=(docker
+  docker-compose)`. Installs `skywire-docker-autopull.service` + `.timer`
+  (every 5 min) that pulls `skycoin/skywire:test` and recreates the compose
+  stack.
+
+---
+
+## pkgbase `skyrepo` — apt repo + provisioning
+
+`arch=('any')`. Registers the Skycoin **apt repository** source list and GPG
+key (`48F19E5157BE6014D80A47328D6D51BC4AD7AE64`), ships the opt-in
+[unattended-upgrades example files](auto-update.md#1-unattended-upgrades-debian-apt),
+and a first-boot `install-skywire.service` (one-shot `apt reinstall
+skywire-bin`). It also absorbs the former skybian provisioning payload
+(`skymanager`, `skybian-reset`, `skyenv`, MOTD snippets) and therefore
+`Replaces`/`Conflicts`/`Provides` `skybian`.
+
+Despite a lockstep-versioning comment in the PKGBUILD, the three pkgbases are
+versioned independently in practice (e.g. `skywire-bin` and the from-source
+`skywire` track different points, and `skyrepo` its own).
+
+---
+
+## Relationship to the Debian apt repo
+
+The apt repo build scripts (in the `apt-repo` project) drive the
+`*.deb.PKGBUILD` variants above with `makepkg` and publish the resulting
+`.deb`s via `reprepro` — one publish script per package
+(`updskywirebin.sh`, `updskywire.sh`, `updskywireautoupdate.sh`,
+`updskywiredockerautopull.sh`). So the AUR PKGBUILD trees are also the
+upstream of the Debian packages; a packaging change made once in the AUR tree
+flows to both Arch and Debian users.

--- a/docs/packaging/auto-update.md
+++ b/docs/packaging/auto-update.md
@@ -1,0 +1,250 @@
+# Auto-Update Mechanisms
+
+Skywire can keep itself up to date in three independent ways. They are
+**not** mutually exclusive layers of one system — they are three separate
+mechanisms shipped by three separate packages, each appropriate to a
+different deployment style. Pick the one that matches how you run skywire;
+running more than one at once is redundant and can fight over the binary.
+
+| Mechanism | Package | Unit(s) | Cadence | Updates by | Best for |
+|-----------|---------|---------|---------|-----------|----------|
+| **1. unattended-upgrades** | `skyrepo` | apt's `apt-daily-upgrade.timer` | apt periodic (≈daily) | reinstalling the `skywire-bin` **`.deb`** from the Skycoin apt repo | Debian/Armbian boards installed from the apt repo |
+| **2. source auto-update** | `skywire-autoupdate` | `skywire-update.service` + `.timer` | daily (`+` up to 1 h jitter) | `go install github.com/skycoin/skywire@<commit>` → `/opt/skywire/bin/skywire` | nodes that build from source and track the rolling release |
+| **3. docker auto-pull** | `skywire-docker-autopull` | `skywire-docker-autopull.service` + `.timer` | every 5 min | `docker pull` + `docker compose up -d --force-recreate` | container deployments |
+
+All three ultimately track the same **rolling release**: CI advances the
+`skywire-commit` branch to the latest commit on `develop` for which every
+platform's tests passed, and warms the Go module proxy so that commit is
+installable worldwide. See [Skywire Auto-Update (rolling release / CI)](https://github.com/skycoin/skywire/blob/develop/AUTO_UPDATE.md)
+for how the `skywire-commit` branch and the `:test` Docker tag are produced.
+
+---
+
+## 1. unattended-upgrades (Debian / apt)
+
+This is the lightest-touch option: it uses stock Debian
+[`unattended-upgrades`](https://wiki.debian.org/UnattendedUpgrades) to
+reinstall the `skywire-bin` package whenever a newer `.deb` is published to
+the Skycoin apt repository. Nothing skywire-specific runs — apt does the work
+on its normal daily schedule.
+
+Everything here is shipped by the **`skyrepo`** package, which registers the
+apt repository and drops in the opt-in configuration.
+
+### What `skyrepo` installs
+
+`skyrepo` writes the apt source list to `/etc/apt/sources.list.d/skycoin.list`
+and installs the signing key. The repository is mirrored at three hostnames
+(any one works):
+
+```
+deb http://deb.skywire.skycoin.com   sid main
+deb http://deb.theskywirenetwork.net sid main
+deb http://deb.skywire.dev           sid main
+```
+
+It also ships **example** opt-in files under
+`/usr/share/doc/skyrepo/examples/` (they are *not* copied into
+`/etc/apt/apt.conf.d/` automatically — you opt in):
+
+`52unattended-upgrades-skycoin` — extends unattended-upgrades to cover the
+Skycoin origin:
+
+```
+// Extend unattended-upgrades to cover the Skycoin apt repository.
+// Merges with Allowed-Origins from /etc/apt/apt.conf.d/50unattended-upgrades.
+// Origin metadata (per `apt-cache policy`):
+//   o=skycoin, l=skycoin, n=sid, c=main
+Unattended-Upgrade::Origins-Pattern {
+    "origin=skycoin,codename=sid";
+};
+```
+
+`99skycoin-periodic` — turns apt's periodic timers on (needed on Armbian,
+whose `02-armbian-periodic` disables them by default):
+
+```
+APT::Periodic::Enable "1";
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+```
+
+`skycoin-refresh-before-upgrade.conf` — a systemd drop-in that forces an
+`apt-get update` immediately before the daily upgrade so a freshly-published
+`.deb` isn't missed:
+
+```
+[Service]
+ExecStartPre=-/usr/bin/apt-get update
+```
+
+The `skyrepo` post-install script activates that drop-in (copying it under
+`/etc/systemd/system/apt-daily-upgrade.service.d/` and running
+`systemctl daemon-reload`) **only if** you have opted in by placing
+`52unattended-upgrades-skycoin` in `/etc/apt/apt.conf.d/`.
+
+### Enable it
+
+```bash
+sudo apt install skyrepo unattended-upgrades
+sudo cp /usr/share/doc/skyrepo/examples/52unattended-upgrades-skycoin /etc/apt/apt.conf.d/
+sudo cp /usr/share/doc/skyrepo/examples/99skycoin-periodic          /etc/apt/apt.conf.d/
+sudo systemctl restart apt-daily-upgrade.timer   # re-reads the drop-in
+```
+
+Verify the origin is covered:
+
+```bash
+apt-cache policy skywire-bin
+sudo unattended-upgrade --dry-run --debug 2>&1 | grep -i skycoin
+```
+
+!!! note "First-boot installer, not the updater"
+    `skyrepo` also ships `install-skywire.service` (a one-shot that runs
+    `apt reinstall skywire-bin` on first boot, then disables itself). That is a
+    provisioning helper — it is separate from the recurring unattended-upgrades
+    path described here.
+
+---
+
+## 2. Source auto-update — `skywire-autoupdate`
+
+The **`skywire-autoupdate`** package (depends on `skywire-bin` and `go`)
+rebuilds skywire from source on a daily timer, following the rolling release.
+It installs `/usr/bin/skywire-update` plus a service and timer.
+
+`skywire-update.service`:
+
+```ini
+[Unit]
+Description=Skywire auto-updater
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/skywire-update
+```
+
+`skywire-update.timer`:
+
+```ini
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=3600
+Persistent=true
+```
+
+### What `/usr/bin/skywire-update` does
+
+1. Sources `/etc/skywire.conf` for its settings (`SKYENV`).
+2. Resolves the target commit from `UPDATE_CHANNEL` (default `stable` = the
+   latest CI-tested commit, resolved with
+   `go run github.com/skycoin/skywire/cmd/skywire-commit@skywire-commit`
+   using `GOPROXY=direct`; also accepts `develop`, `latest`, or an explicit
+   `<commit-hash>`).
+3. Compares that target to the running binary (`skywire -b`) and exits early
+   if nothing changed.
+4. Builds as the unprivileged `skywire-build` user (home
+   `/var/lib/skywire-build`) with `go install github.com/skycoin/skywire@<target>`
+   (`GOFLAGS=-trimpath`), installs the result to `/opt/skywire/bin/skywire`.
+5. Runs `skywire autoconfig`, then `systemctl restart skywire` (plus anything
+   in `RESTART_SERVICES`) if the service is active.
+6. Prunes the Go build/module caches on exit.
+
+Tunable knobs in `/etc/skywire.conf`: `UPDATE_CHANNEL`, `GOPROXY_MODE`,
+`MODCACHE_CAP_MB`, `RESTART_SERVICES`.
+
+### Enable it
+
+The package's install hook already creates the `skywire-build` user (adding it
+to the `docker` group if present) and runs
+`systemctl enable --now skywire-update.timer`. To manage it:
+
+```bash
+systemctl status  skywire-update.timer     # is it scheduled?
+systemctl start   skywire-update.service    # force an update now
+journalctl -u     skywire-update.service -f # watch a run
+systemctl disable --now skywire-update.timer # stop auto-updating
+```
+
+!!! info "Companion docker updater in the same package"
+    `skywire-autoupdate` **also** ships `skywire-docker-update.service` /
+    `.timer` (every 30 min), which resolves the CI-tested commit, does
+    `docker pull skycoin/skywire:<sha>`, retags it `:test`, and recreates the
+    compose stack. It is **not enabled by default**. Do not confuse it with the
+    separately-packaged `skywire-docker-autopull` below — they are two
+    different docker auto-updaters.
+
+---
+
+## 3. Docker auto-pull — `skywire-docker-autopull`
+
+For container deployments, the **`skywire-docker-autopull`** package (its own
+package — depends on `docker` and `docker-compose`) watches the published
+image and recreates the stack when it changes. The source unit
+`docker-autopull.service` is installed **renamed** as
+`skywire-docker-autopull.service`:
+
+```ini
+[Unit]
+Description=Skywire Docker image auto-pull
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/skywire-docker-autopull
+StandardOutput=journal
+StandardError=journal
+```
+
+`skywire-docker-autopull.timer` runs every five minutes:
+
+```ini
+[Timer]
+OnCalendar=*:0/5
+Persistent=true
+```
+
+### What `/usr/bin/skywire-docker-autopull` does
+
+1. `IMAGE="${DOCKER_IMAGE:-skycoin/skywire:test}"`; compose stack lives in
+   `DEPLOY_DIR` / `COMPOSE_DIR`.
+2. `docker pull "$IMAGE"` and compare the image ID to what is running — exit if
+   unchanged.
+3. Smoke-test the new image (`docker run --rm "$IMAGE" --help`), then
+   `docker compose up -d --force-recreate` and `docker image prune -f`.
+
+### Enable it
+
+The package's post-install runs
+`systemctl enable --now skywire-docker-autopull.timer`. To manage it:
+
+```bash
+systemctl status skywire-docker-autopull.timer
+systemctl start  skywire-docker-autopull.service    # force a pull now
+journalctl -u    skywire-docker-autopull.service -f
+systemctl disable --now skywire-docker-autopull.timer
+```
+
+---
+
+## Which one am I running?
+
+```bash
+# apt-based (mechanism 1)
+systemctl status apt-daily-upgrade.timer
+ls /etc/apt/apt.conf.d/ | grep -i skycoin
+
+# source auto-update (mechanism 2)
+systemctl status skywire-update.timer
+
+# docker auto-pull (mechanism 3)
+systemctl status skywire-docker-autopull.timer
+```
+
+If more than one timer is enabled and active, disable all but the one that
+matches your install method — otherwise an apt reinstall, a source rebuild,
+and a container recreate can each clobber the others' binary.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,10 @@ nav:
           - vpn/README.md
           - vpn/client.md
           - vpn/router.md
+  - Packaging & Updates:
+      - packaging/README.md
+      - Auto-Update: packaging/auto-update.md
+      - AUR Packages: packaging/aur-packages.md
   - Specs: specs/index.md
   - Glossary: glossary.md
   - Rewards: rewards/index.md


### PR DESCRIPTION
## What

Adds a **Packaging & Updates** section to the docs site
(https://skycoin.github.io/skywire/) covering how installed nodes update
themselves and how skywire is packaged for Linux.

### `packaging/auto-update.md` — the three auto-update mechanisms

Documents each with verbatim systemd unit files, the config each package
ships, and enable/disable/check commands:

1. **apt `unattended-upgrades`** — via the `skyrepo` package (apt source list +
   opt-in `52unattended-upgrades-skycoin` / `99skycoin-periodic` /
   refresh-before-upgrade drop-in). Reinstalls the `skywire-bin` `.deb` on apt's
   daily schedule.
2. **Source auto-update** — the `skywire-autoupdate` package's
   `skywire-update.service` + `.timer` (daily), which does
   `go install github.com/skycoin/skywire@<CI-tested-commit>` and restarts the
   service.
3. **Docker auto-pull** — the `skywire-docker-autopull` package's
   `skywire-docker-autopull.service` + `.timer` (every 5 min), which pulls
   `skycoin/skywire:test` and recreates the compose stack.

It explicitly clarifies that **`docker-autopull.service` is its own package**
(`skywire-docker-autopull`), *not* part of `skywire-autoupdate` — and
distinguishes it from the separate `skywire-docker-update` unit that
`skywire-autoupdate` *does* ship (30-min, CI-commit retag). A comparison table
and a "which one am I running?" section help operators avoid running two at
once.

### `packaging/aur-packages.md`

The two AUR pkgbases — `skywire-bin` (prebuilt binary) and `skywire`
(from-source, musl-static) — plus `skyrepo`, and the variant PKGBUILDs
(`git`, `deb`, `dev`, `autoupdate`, `docker-autopull`, `systray-git`) that also
produce the auto-update packages and the Debian `.deb`s published to the apt
repo.

### Wiring

`packaging/README.md` section index + a `Packaging & Updates` entry in
`mkdocs.yml`'s nav.

## Validation

Local `mkdocs build` (mkdocs-material 9.5 + awesome-pages, same as CI) — exit 0,
all three pages render under `site/packaging/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)