### PR TITLE
feat(skychat/dm): Serve (inject conns), Stats counters, nil-transport safety

### DIFF
--- a/pkg/skychat/dm/controller.go
+++ b/pkg/skychat/dm/controller.go
@@ -121,9 +121,37 @@ type Controller struct {
 	ackMu      sync.Mutex
 	ackWaiters map[string]chan struct{}
 
+	statsMu sync.Mutex
+	stats   Stats
+
 	closeOnce sync.Once
 	done      chan struct{}
 	wg        sync.WaitGroup
+}
+
+// Stats is a snapshot of the controller's message counters, for a status probe.
+type Stats struct {
+	InboundMsgs    int64
+	OutboundMsgs   int64
+	InboundDrops   int64 // conn read errors (peer/transport dropped)
+	OutboundFails  int64 // sends that failed even after retry + fallback
+	OutboundRetry  int64 // stale-cached-conn writes rescued by a redial+retry
+	OutboundFallbk int64 // sends rescued by the alternate network
+	LastRxAt       time.Time
+	LastTxAt       time.Time
+}
+
+// Stats returns a snapshot of the message counters.
+func (c *Controller) Stats() Stats {
+	c.statsMu.Lock()
+	defer c.statsMu.Unlock()
+	return c.stats
+}
+
+func (c *Controller) bump(f func(*Stats)) {
+	c.statsMu.Lock()
+	f(&c.stats)
+	c.statsMu.Unlock()
 }
 
 // New builds a Controller. It does not open any connection until Start.
@@ -194,10 +222,29 @@ func (c *Controller) acceptLoop(lis net.Listener) {
 	}
 }
 
+// Serve runs an already-established conn (whose RemoteAddr() reports an
+// appnet.Addr) through the same cache + read loop as a dialed/accepted conn.
+// It exists for transports the Client seam doesn't cover — the native app's
+// TCP-direct entry points hand their handshaked conn here. Blocks until the
+// conn closes (the caller decides whether to run it in a goroutine), mirroring
+// the pre-extraction handleConn call it replaces.
+func (c *Controller) Serve(conn net.Conn) {
+	fc := message.NewConn(conn)
+	if raddr, ok := conn.RemoteAddr().(appnet.Addr); ok {
+		c.mu.Lock()
+		c.conns[raddr.PubKey] = fc
+		c.mu.Unlock()
+	}
+	c.readConn(fc)
+}
+
 // dialAndCache dials pk at addr (through DialRetry if configured), wraps the
 // conn in framing, caches it by PK, and starts its read loop. The read loop's
 // lifetime is the peer connection, not any request.
 func (c *Controller) dialAndCache(ctx context.Context, pk cipher.PubKey, addr appnet.Addr) (*message.Conn, error) {
+	if c.cfg.Client == nil {
+		return nil, errors.New("skychat/dm: no transport configured (dial unavailable)")
+	}
 	var raw net.Conn
 	dial := func() error {
 		cc, err := c.cfg.Client.Dial(addr)
@@ -277,6 +324,7 @@ func (c *Controller) readConn(conn *message.Conn) {
 	for {
 		payload, err := conn.ReadFrame()
 		if err != nil {
+			c.bump(func(s *Stats) { s.InboundDrops++ })
 			return
 		}
 		if c.cfg.PreHandleFrame != nil && c.cfg.PreHandleFrame(peer, payload) {
@@ -294,6 +342,7 @@ func (c *Controller) readConn(conn *message.Conn) {
 			continue // ack-only / empty — nothing to surface
 		}
 		peerHex := peer.Hex()
+		c.bump(func(s *Stats) { s.InboundMsgs++; s.LastRxAt = time.Now().UTC() })
 		c.persist(history.Message{
 			Peer: peerHex, From: peerHex, Outgoing: false,
 			Text: text, Timestamp: time.Now().UTC(), ID: msgID, ReplyTo: replyTo,
@@ -358,6 +407,7 @@ func (c *Controller) Send(ctx context.Context, pk cipher.PubKey, netType appnet.
 		if newConn, derr := c.dialAndCache(ctx, pk, addr); derr == nil {
 			if werr := newConn.WriteFrameDeadline(wire, writeTimeout); werr == nil {
 				conn, err = newConn, nil
+				c.bump(func(s *Stats) { s.OutboundRetry++ })
 			} else {
 				c.evict(pk, newConn)
 				err = werr
@@ -372,14 +422,18 @@ func (c *Controller) Send(ctx context.Context, pk cipher.PubKey, netType appnet.
 		if fbConn, alt := c.tryNetworkFallback(ctx, pk, netType); fbConn != nil {
 			if werr := fbConn.WriteFrameDeadline(wire, writeTimeout); werr == nil {
 				res.Network, err = alt, nil
+				c.bump(func(s *Stats) { s.OutboundFallbk++ })
 			} else {
 				c.evict(pk, fbConn)
 			}
 		}
 		if err != nil {
+			c.bump(func(s *Stats) { s.OutboundFails++ })
 			return res, err
 		}
 	}
+
+	c.bump(func(s *Stats) { s.OutboundMsgs++; s.LastTxAt = time.Now().UTC() })
 
 	c.persist(history.Message{
 		Peer: pk.Hex(), Outgoing: true, Text: text,

--- a/pkg/skychat/dm/controller_test.go
+++ b/pkg/skychat/dm/controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/message"
 )
 
 // --- in-memory transport ----------------------------------------------------
@@ -190,6 +191,41 @@ func TestController_AckRoundTrip(t *testing.T) {
 	}
 	if !res.Acked {
 		t.Error("WaitAck send should be acked by a live peer")
+	}
+}
+
+func TestController_ServeAndStats(t *testing.T) {
+	// Serve injects an already-established conn (the TCP-direct shape): a
+	// framed conn whose RemoteAddr reports an appnet.Addr. A frame written to
+	// the other end should surface as an inbound event and bump InboundMsgs.
+	pkPeer := mustPK(t)
+	rec := &recorder{}
+	ctrl := New(Config{Networks: []appnet.Type{appnet.TypeDmsg}, OnEvent: rec.on})
+	t.Cleanup(func() { _ = ctrl.Close() })
+
+	near, far := net.Pipe()
+	// far is what Serve reads; give it a RemoteAddr carrying the peer PK.
+	go ctrl.Serve(memConn{Conn: far, raddr: appnet.Addr{Net: appnet.TypeDmsg, PubKey: pkPeer, Port: chatPort}})
+
+	// Write a plain-text frame from the near end (peer -> us).
+	go func() { _ = message.WriteFrame(near, []byte("injected hello")) }()
+	in := waitFor(t, rec, func(e Event) bool { return e.Text == "injected hello" && e.Dir == "in" })
+	if in.Peer != pkPeer.Hex() {
+		t.Errorf("served-conn peer = %s, want %s", in.Peer, pkPeer.Hex())
+	}
+	if s := ctrl.Stats(); s.InboundMsgs != 1 {
+		t.Errorf("InboundMsgs = %d, want 1", s.InboundMsgs)
+	}
+}
+
+func TestController_NoTransportDialErrors(t *testing.T) {
+	// A controller with no Client (native --standalone): a send with no cached
+	// conn must error cleanly, not panic.
+	pk := mustPK(t)
+	ctrl := New(Config{Networks: []appnet.Type{appnet.TypeDmsg}, OnEvent: func(Event) {}})
+	t.Cleanup(func() { _ = ctrl.Close() })
+	if _, err := ctrl.Send(context.Background(), pk, appnet.TypeDmsg, "hi", SendOpts{}); err == nil {
+		t.Error("send with no transport + no cached conn should error")
 	}
 }
 


### PR DESCRIPTION
## What

Additive `dm.Controller` capabilities the native app needs to migrate onto it (the wasm consumer in #3609 didn't need these):

- **`Serve(conn)`** runs an already-established conn — one whose `RemoteAddr()` reports an `appnet.Addr` — through the same cache + read loop as a dialed/accepted conn. The native TCP-direct entry points (which today register into the shared `conns` map and call `handleConn` over a handshaked noise-TCP conn) will hand their conn here.
- **`Stats()`** exposes the message counters the native `/status` endpoint reports (inbound/outbound, drops, retries, fallbacks, last rx/tx); the controller now tracks them across `readConn` + `Send`.
- **nil-`Client` safety**: `dialAndCache` errors cleanly when there's no transport (native `--standalone`: no `app.Client`, reachable only via `Serve`'d TCP-direct conns) instead of panicking.

Existing behavior is unchanged.

## Validation

`go test ./pkg/skychat/dm/` (native + builds under `GOOS=js`): `Serve` surfaces an injected conn's frame and bumps `InboundMsgs`; a no-transport send errors rather than panics. Plus the existing send/receive, reply, ack round-trip.

Prep for the native-app migration onto the controller (#3596).

🤖 Generated with [Claude Code](https://claude.com/claude-code)