### PR TITLE
feat(skychat): migrate the native app onto the shared pkg/skychat/dm controller

### DIFF
--- a/cmd/apps/skychat/commands/cxo_tcp.go
+++ b/cmd/apps/skychat/commands/cxo_tcp.go
@@ -288,10 +288,9 @@ func startCXOGroup(ctx context.Context) error {
 // surfaceCXOInbound pushes a message received from a subscribed CXO feed
 // onto the SSE hub, mirroring handleConn's inbound clientMsg shape.
 func surfaceCXOInbound(senderPK, text string) {
-	counterMu.Lock()
-	inboundMsgCount++
-	lastRxAt = time.Now().UTC()
-	counterMu.Unlock()
+	if chatCtrl != nil {
+		chatCtrl.NoteInbound()
+	}
 
 	hub.publishEvent(chatEvent{
 		ID:        newEventID(),

--- a/cmd/apps/skychat/commands/filexfer.go
+++ b/cmd/apps/skychat/commands/filexfer.go
@@ -62,10 +62,7 @@ func downloadsDir() (string, error) {
 // live conn exists) — the "already established a chat" half of the auto-accept
 // policy. Group membership is handled by the group path (filexfer_group.go).
 func isEstablishedPeer(pk cipher.PubKey) bool {
-	connsMu.Lock()
-	_, ok := conns[pk]
-	connsMu.Unlock()
-	return ok
+	return chatCtrl != nil && chatCtrl.HasConn(pk)
 }
 
 // fileDialFunc opens a fresh transfer stream to peer on the file port, trying

--- a/cmd/apps/skychat/commands/framedconn_writedeadline_test.go
+++ b/cmd/apps/skychat/commands/framedconn_writedeadline_test.go
@@ -19,6 +19,7 @@ package commands
 
 import (
 	"errors"
+	"github.com/skycoin/skywire/pkg/skychat/message"
 	"net"
 	"sync"
 	"testing"
@@ -37,7 +38,7 @@ func TestFramedConn_WriteFrameDeadline_TimesOutOnStalledPeer(t *testing.T) {
 	defer srvSide.Close() //nolint:errcheck,gosec
 	// Don't drain srvSide — that's the whole point.
 
-	c := newFramedConn(cliSide)
+	c := message.NewConn(cliSide)
 
 	const timeout = 100 * time.Millisecond
 	start := time.Now()
@@ -96,7 +97,7 @@ func TestFramedConn_WriteFrameDeadline_DeadlineResetForNextCaller(t *testing.T) 
 	srv := <-accepted
 	defer srv.Close() //nolint:errcheck,gosec
 
-	c := newFramedConn(cli)
+	c := message.NewConn(cli)
 
 	// First call: timeout immediately by setting the deadline to a
 	// past instant. Pre-fix the deadline would not get reset after
@@ -196,7 +197,7 @@ func TestFramedConn_WriteFrameDeadline_SetsAndResets(t *testing.T) {
 	defer cli.Close() //nolint:errcheck,gosec
 
 	rc := &recordingConn{Conn: cli}
-	c := newFramedConn(rc)
+	c := message.NewConn(rc)
 
 	// Short timeout — the Write will time out (net.Pipe honors
 	// deadlines via pipeDeadline) since srv isn't being drained.

--- a/cmd/apps/skychat/commands/pairing.go
+++ b/cmd/apps/skychat/commands/pairing.go
@@ -35,14 +35,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -578,51 +576,10 @@ func sendPairControl(ctx context.Context, peerPK cipher.PubKey, msgType string) 
 	if err != nil {
 		return err
 	}
-	conn, err := dialOrReusePeerConn(ctx, peerPK)
-	if err != nil {
-		return err
-	}
-	return conn.WriteFrame(body)
-}
-
-// dialOrReusePeerConn returns a live framed connection to peerPK,
-// dialing over skynet (or dmsg as fallback) if none exists. Mirrors
-// what messageHandler does but doesn't take the HTTP request
-// context's shape.
-func dialOrReusePeerConn(ctx context.Context, peerPK cipher.PubKey) (*framedConn, error) {
-	connsMu.Lock()
-	conn, ok := conns[peerPK]
-	connsMu.Unlock()
-	if ok {
-		return conn, nil
-	}
-
-	var lastErr error
-	for _, netType := range []appnet.Type{appnet.TypeSkynet, appnet.TypeDmsg} {
-		addr := appnet.Addr{Net: netType, PubKey: peerPK, Port: 1}
-		var dialed net.Conn
-		err := r.Do(ctx, func() error {
-			c, dialErr := appCl.Dial(addr)
-			if dialErr != nil {
-				return dialErr
-			}
-			dialed = c
-			return nil
-		})
-		if err == nil && dialed != nil {
-			fc := newFramedConn(dialed)
-			connsMu.Lock()
-			conns[peerPK] = fc
-			connsMu.Unlock()
-			go handleConn(fc) //nolint:gosec
-			return fc, nil
-		}
-		lastErr = err
-	}
-	if lastErr == nil {
-		lastErr = errors.New("pairing: no network type succeeded")
-	}
-	return nil, lastErr
+	// Pair-control frames ride the shared DM controller's conns (dial/reuse +
+	// raw write, trying skynet then dmsg). The inbound side is consumed by the
+	// controller's PreHandleFrame hook → handlePairControlFrame.
+	return chatCtrl.SendRaw(ctx, peerPK, body)
 }
 
 // parsePK parses a hex-encoded public key and returns a cipher.PubKey.

--- a/cmd/apps/skychat/commands/sendack.go
+++ b/cmd/apps/skychat/commands/sendack.go
@@ -1,146 +1,28 @@
 // Package commands cmd/apps/skychat/commands/sendack.go c4-app-chat
 //
-// chat-msg / chat-ack envelope: opt-in peer-receipt acknowledgment.
+// The chat-msg / chat-ack envelope, the per-id ack-waiter map, and the inbound
+// envelope decode all moved into the shared controller (pkg/skychat/dm) when
+// the DM core was extracted — the native app now calls dm.Controller.Send with
+// a WaitAck duration instead of registering waiters itself, and the controller
+// routes inbound chat-ack envelopes to those waiters internally.
 //
-// Wire format (JSON-encoded payload inside a normal framed frame):
-//
-//	chat-msg: {"type":"chat-msg","id":"<hex>","body":"...","ack":true}
-//	chat-ack: {"type":"chat-ack","id":"<hex>"}
-//
-// Backward compat: when --wait is NOT used, the sender writes the
-// plain-text body as before (no envelope). Old peers + new peers see
-// the same plaintext message. The envelope is OPT-IN at the sender
-// — when --wait is set, the sender wraps in chat-msg and waits for
-// chat-ack with the matching id. An old peer that receives a
-// chat-msg envelope will surface the entire JSON as chat text (ugly,
-// but the agent-coordination use case is all-post-2510 peers anyway).
-//
-// Why not always envelope: it would force every existing human-user
-// chat to look at JSON on old visors during the staggered roll.
-// Opt-in keeps the wire byte-identical for default sends, the same
-// as it has been since #2504.
-//
-// chat-ack is sent back over the same framed conn the chat-msg came
-// in on (writeMu protects the framing). The sender's handleConn
-// recognizes the inbound chat-ack and routes it to a waiter map
-// keyed by id. The /message HTTP handler holds the request open
-// until either: the ack arrives, the deadline fires, or the conn
-// dies.
-
+// What remains here is the HTTP-layer clamp for the /message handler's wait_ms
+// parameter, which bounds how long a --wait request may block the controller's
+// ack channel.
 package commands
 
-import (
-	"sync"
-	"time"
+import "time"
 
-	"github.com/skycoin/skywire/pkg/skychat/message"
-)
-
-// chatEnvelope / chatTypeMsg / chatTypeAck alias the shared skychat wire types
-// (pkg/skychat/message) so this file's ack routing and the envelope construction
-// in skychat.go keep their familiar local names while the on-the-wire shape lives
-// in exactly one place.
-type chatEnvelope = message.Envelope
-
-const (
-	chatTypeMsg = message.TypeMsg
-	chatTypeAck = message.TypeAck
-)
-
-// ackWaiters routes an inbound chat-ack envelope back to the
-// /message HTTP handler that's waiting for it. Keyed by event id;
-// value is a one-shot channel that fires on receipt.
-//
-// Lifetime: the /message handler registers the waiter before writing
-// the chat-msg frame, deregisters it before returning regardless of
-// outcome. A spurious ack (one nobody is waiting for) is silently
-// dropped — that handles late acks after a timeout cleanly.
-var (
-	ackWaitersMu sync.Mutex
-	ackWaiters   = map[string]chan struct{}{}
-)
-
-// registerAckWaiter adds a one-shot channel for the given id. Returns
-// the channel + an unregister func the caller MUST invoke (typically
-// via defer) regardless of whether the wait succeeded or timed out.
-func registerAckWaiter(id string) (<-chan struct{}, func()) {
-	ch := make(chan struct{}, 1)
-	ackWaitersMu.Lock()
-	ackWaiters[id] = ch
-	ackWaitersMu.Unlock()
-	return ch, func() {
-		ackWaitersMu.Lock()
-		delete(ackWaiters, id)
-		ackWaitersMu.Unlock()
-	}
-}
-
-// deliverAck signals any waiter registered for id. No-op if no
-// waiter exists (late ack / unsolicited ack). Idempotent.
-func deliverAck(id string) {
-	ackWaitersMu.Lock()
-	ch, ok := ackWaiters[id]
-	ackWaitersMu.Unlock()
-	if !ok {
-		return
-	}
-	select {
-	case ch <- struct{}{}:
-	default:
-		// already signaled
-	}
-}
-
-// tryHandleChatEnvelope attempts to parse payload as a chat-msg or
-// chat-ack envelope. Returns (handled=true, body=...) if it's a
-// chat-msg the caller should surface as a normal chat message after
-// optionally sending an ack back. Returns (handled=true, body="")
-// if it's a chat-ack (consumed internally, no surfacing). Returns
-// (handled=false, _) for anything else — caller falls through to
-// the legacy plain-text path.
-//
-// Envelope recognition is conservative: must start with '{', valid
-// JSON, type field matches a known chat-* value. Anything else is
-// "not an envelope" so plain-text JSON-looking chat (e.g. someone
-// typing literal {} into a chat window) still reaches its peer.
-func tryHandleChatEnvelope(payload []byte, peerPKHex string, sendAck func(id string)) (handled bool, body string, id string, replyTo string) {
-	env, ok := message.ParseEnvelope(payload)
-	if !ok {
-		return false, "", "", ""
-	}
-	switch env.Type {
-	case chatTypeMsg:
-		if env.Ack && env.ID != "" && sendAck != nil {
-			// Best-effort: a failed ack write is logged by the
-			// caller's sendAck implementation; we still surface the
-			// message so the recipient sees it.
-			sendAck(env.ID)
-		}
-		// env.ReplyTo (a quoted-reply's target id) rides the shared codec; the
-		// caller surfaces it as the inbound event's ReplyToID so the recipient
-		// sees the thread, not just the sender.
-		return true, env.Body, env.ID, env.ReplyTo
-	case chatTypeAck:
-		if env.ID != "" {
-			deliverAck(env.ID)
-		}
-		// Consumed; nothing to surface to the chat UI.
-		return true, "", env.ID, ""
-	}
-	_ = peerPKHex // reserved for future per-peer ack policy / rate-limit
-	return false, "", "", ""
-}
-
-// chatAckTimeoutFloor / chatAckTimeoutCeiling clamp the wait_ms
-// parameter on /message. Lower bound prevents zero-wait misuse;
-// upper bound bounds resource consumption on a held HTTP request.
+// chatAckTimeoutFloor / chatAckTimeoutCeiling clamp the wait_ms parameter on
+// /message. Lower bound prevents zero-wait misuse; upper bound bounds resource
+// consumption on a held HTTP request.
 const (
 	chatAckTimeoutFloor   = 100 * time.Millisecond
 	chatAckTimeoutCeiling = 60 * time.Second
 )
 
-// clampAckWait normalizes a caller-supplied wait_ms into the
-// allowed range. Zero / negative / unset → floor; over-ceiling → ceiling.
+// clampAckWait normalizes a caller-supplied wait_ms into the allowed range.
+// Zero / negative / unset → floor; over-ceiling → ceiling.
 func clampAckWait(d time.Duration) time.Duration {
 	if d < chatAckTimeoutFloor {
 		return chatAckTimeoutFloor

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -36,8 +36,8 @@ import (
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/netutil"
 	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skychat/dm"
 	"github.com/skycoin/skywire/pkg/skychat/history"
-	"github.com/skycoin/skywire/pkg/skychat/message"
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -57,109 +57,6 @@ var r = netutil.NewRetrier(nil, 50*time.Millisecond, netutil.DefaultMaxBackoff, 
 // routes, where a VStream can split one Write across several Reads at arbitrary
 // boundaries — a 600-byte message arrived as two chat entries. The length-prefixed
 // frame fixed that; old unframed binaries can't talk to framed ones.
-type framedConn = message.Conn
-
-func newFramedConn(c net.Conn) *framedConn { return message.NewConn(c) }
-
-// messageWriteTimeout bounds a single WriteFrame call from the
-// /message HTTP handler. Picked above the typical successful-send
-// latency (low-ms) and below the operator-facing default ack budget
-// (5–10 s), so a slow peer hits the deadline well before the caller
-// gives up on the HTTP request entirely.
-//
-// Pre-fix the chat-app had no per-write deadline anywhere — a peer
-// whose underlying transport stalled (e.g. dmsg session half-dead
-// because the peer's visor was crashlooping) would pin the
-// /message handler's goroutine indefinitely on the inner
-// c.Conn.Write(). The hung handler held c.writeMu, so every
-// subsequent send on the SAME conn queued behind it. Worse,
-// observed cross-peer wedge: a single Beta-send hang at 20:20Z
-// preceded every subsequent /message request — to Alpha, Beta,
-// any peer — timing out at the HTTP context-deadline (~30 s) for
-// hours afterward. Bounding the inner Write lets the handler
-// surface a clean timeout, the writeMu releases, and the next
-// caller's send is freed.
-const messageWriteTimeout = 5 * time.Second
-
-// dialAndCache dials the peer at addr (using the package retrier),
-// wraps the raw conn in framing, registers it in the conns cache,
-// and starts the read loop. Used both from the cache-miss path in
-// messageHandler and from the redial-after-stale-write path. The
-// receive loop's lifetime is the underlying peer connection, not
-// the calling HTTP request — req.Context() cancel must NOT tear it
-// down, so we deliberately pass a long-lived context (the handler's
-// ctx, scoped to the whole app run).
-func dialAndCache(ctx context.Context, pk cipher.PubKey, addr appnet.Addr) (*framedConn, error) {
-	var raw net.Conn
-	err := r.Do(ctx, func() error {
-		c, dialErr := appCl.Dial(addr)
-		if dialErr != nil {
-			return dialErr
-		}
-		raw = c
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	conn := newFramedConn(raw)
-	connsMu.Lock()
-	conns[pk] = conn
-	connsMu.Unlock()
-	go handleConn(conn) //nolint:gosec // G118: long-lived conn, not request-scoped
-	return conn, nil
-}
-
-// tryNetworkFallback is the last-resort dial used by messageHandler
-// when the primary network's send (cached + redial+retry) failed.
-// Dials the OTHER network (skynet ↔ dmsg) once, caches the conn on
-// success, and returns it for the caller to write through.
-//
-// Returns (nil, _) when:
-//   - the alternate network isn't enabled in this chat-app run (the
-//     operator passed --skynet=false or --dmsg=false at launch)
-//   - the alternate-network dial itself fails (peer doesn't listen
-//     there, transport down, etc.)
-//
-// On success, also returns the appnet.Addr used so the caller can
-// label the fallback in logs / counters and update its local
-// netType state. The caller is responsible for the WriteFrame +
-// per-leg accounting; this helper only opens the conn.
-//
-// Implementation deliberately does NOT consult the cache for the
-// alternate network: by definition the primary network's cached
-// conn just failed; the alternate's cache is independent and may be
-// stale too. A fresh dial is the safest bet on a fallback path.
-// (We do still register the new conn in the conns map by PK, which
-// means the next /message to the same PK will find this conn —
-// per-conn caching is keyed by PK only, not by netType, so the
-// fallback "wins" until the operator's next chat-app restart or a
-// stale-write evicts it.)
-func tryNetworkFallback(ctx context.Context, pk cipher.PubKey, currentNet appnet.Type) (*framedConn, appnet.Addr) {
-	var altNet appnet.Type
-	switch currentNet {
-	case appnet.TypeSkynet:
-		altNet = appnet.TypeDmsg
-		if !useDmsg {
-			return nil, appnet.Addr{}
-		}
-	case appnet.TypeDmsg:
-		altNet = appnet.TypeSkynet
-		if !useSkynet {
-			return nil, appnet.Addr{}
-		}
-	default:
-		return nil, appnet.Addr{}
-	}
-	altAddr := appnet.Addr{Net: altNet, PubKey: pk, Port: 1}
-	conn, err := dialAndCache(ctx, pk, altAddr)
-	if err != nil {
-		chatLog.Debugf("Network-fallback dial %s → %s failed: %v", currentNet, altNet, err)
-		return nil, altAddr
-	}
-	return conn, altAddr
-}
-
 var (
 	addr     string
 	portless bool
@@ -172,9 +69,8 @@ var (
 	// handlers + SSE pumps + accept loops use chatLog to avoid the
 	// nil-deref crash class on standalone.
 	chatLog   logrus.FieldLogger
-	hub       *sseHub                       // SSE broadcast registry; see sse.go-like helpers below
-	conns     map[cipher.PubKey]*framedConn // Chat connections
-	connsMu   sync.Mutex
+	hub       *sseHub        // SSE broadcast registry; see sse.go-like helpers below
+	chatCtrl  *dm.Controller // shared 1:1 DM core (pkg/skychat/dm): conns, read loop, envelopes, send
 	appPort   uint16
 	useSkynet bool
 	useDmsg   bool
@@ -214,57 +110,17 @@ var (
 	// all of them since they're updated in lockstep with sse hub
 	// activity (well-bounded contention). counterMu is held only
 	// during the assignment, never spanning I/O.
-	counterMu        sync.Mutex
-	startedAt        = time.Now()
-	lastRxAt         time.Time // most recent inbound chat message (incl. self-loop)
-	lastSendAt       time.Time // most recent successful outgoing send
-	inboundMsgCount  uint64
-	outboundMsgCount uint64
-	inboundDropCount uint64 // ReadFrame errors / unparseable frames on the inbound path
-
-	// outboundFailCount is the # of /message requests where the
-	// write to the peer conn could not be delivered — counts the
-	// failure that finally surfaces to the HTTP caller, after the
-	// in-handler redial+retry path has already given up.
-	//
-	// outboundRetryCount is how many /message requests took the
-	// redial-after-stale-conn path. A healthy steady state has this
-	// ~= 0; a non-zero rate means peers' transports are flapping
-	// (or visor restarts are tearing them down) and the in-handler
-	// retry is masking the symptom. Operators with retry > 0 and
-	// fail == 0 means "we papered over the flap"; retry > 0 and
-	// fail > 0 means "the retry isn't winning".
-	outboundFailCount  uint64
-	outboundRetryCount uint64
+	// counterMu guards the SSE-hub drop counter below. The DM message
+	// counters (in/out, drops, retries, fallbacks, last rx/tx) now live in
+	// the dm.Controller and are read via chatCtrl.Stats() in /status.
+	counterMu sync.Mutex
+	startedAt = time.Now()
 
 	// sseDropCount counts messages the SSE hub dropped because a
 	// subscriber's per-client buffer was full at broadcast time.
-	// Each drop is a message that one listener never saw — climbs
-	// when a CLI listener stalls (terminal scrollback paused) or
-	// a browser tab is backgrounded long enough to drift behind
-	// sseSubscriberBufSize. Surfaced in /status so operators can
-	// tell "my listener missed N msgs" without log-scraping.
+	// Surfaced in /status so operators can tell "my listener missed N
+	// msgs" without log-scraping.
 	sseDropCount uint64
-
-	// outboundFallbackCount is how many /message requests succeeded
-	// only after falling over from the primary network (skynet by
-	// default) to the alternate (dmsg, and vice versa).
-	//
-	// Skychat listens on BOTH networks by default, so a peer who
-	// receives on one can usually be reached on the other. When the
-	// chosen network's WriteFrame fails after the redial+retry path
-	// exhausts itself, the handler dials the alternate network once
-	// and writes again before surfacing the failure. Successful
-	// rescues increment this counter; full failures (both networks
-	// dead) still increment outboundFailCount as usual.
-	//
-	// Operators with outbound_fallback_count > 0 are seeing the
-	// chosen-network path break often enough to need the safety
-	// net. Persistent non-zero rate is a signal to investigate the
-	// primary network (route flap, dmsg server churn) — the
-	// fallback is rescuing user-visible delivery but at the cost of
-	// an extra dial per affected message.
-	outboundFallbackCount uint64
 )
 
 // frameProtoVersion is the on-the-wire protocol version this chat
@@ -863,13 +719,43 @@ func RunSkychat(ctx context.Context, args []string) error {
 		port = routing.Port(appPort)
 	}
 
-	conns = make(map[cipher.PubKey]*framedConn)
-
+	// The 1:1 DM path — per-peer framed conns, listen/accept + read loops, the
+	// chat-msg/chat-ack/quoted-reply envelope handling, and the send path
+	// (ack-wait, stale-conn redial-retry, cross-network fallback) — is the
+	// shared pkg/skychat/dm.Controller, the same core the wasm visor uses.
+	// Persistence goes through historyStore (whitelist/rate/cap guardrails
+	// still apply); every surfaced message (inbound + the outbound mirror) is
+	// published to the SSE hub via OnEvent; pair-control frames are intercepted
+	// by PreHandleFrame; dials keep the app's retrier. In --standalone (appCl
+	// nil) there's no transport to dial or listen on — the controller is still
+	// created (so TCP-direct conns can be Serve'd into it), just not Started.
+	var nets []appnet.Type
 	if useSkynet {
-		go listenLoop(appnet.TypeSkynet, port)
+		nets = append(nets, appnet.TypeSkynet)
 	}
 	if useDmsg {
-		go listenLoop(appnet.TypeDmsg, port)
+		nets = append(nets, appnet.TypeDmsg)
+	}
+	var dmClient dm.Client
+	if appCl != nil {
+		dmClient = appCl
+	}
+	chatCtrl = dm.New(dm.Config{
+		Client:    dmClient,
+		Store:     historyStore,
+		Networks:  nets,
+		Port:      port,
+		OnEvent:   onChatEvent,
+		DialRetry: func(dctx context.Context, fn func() error) error { return r.Do(dctx, fn) },
+		PreHandleFrame: func(peer cipher.PubKey, payload []byte) bool {
+			return handlePairControlFrame(context.Background(), peer, payload)
+		},
+		Log: func(f string, a ...interface{}) { appLog(f, a...) },
+	})
+	if len(nets) > 0 && !standalone && appCl != nil {
+		if err := chatCtrl.Start(ctx); err != nil {
+			appLog("skychat: dm controller start: %v", err)
+		}
 	}
 	// TCP-direct entry point — independent of useSkynet/useDmsg.
 	// Operator opts in via --tcp-listen / --tcp-peer; nil-effect
@@ -1010,143 +896,6 @@ func RunSkychat(ctx context.Context, args []string) error {
 	return nil
 }
 
-func listenLoop(netType appnet.Type, appPort routing.Port) {
-	l, err := appCl.Listen(netType, appPort)
-	if err != nil {
-		appLog("Error listening network %v on port %d: %v", netType, appPort, err)
-		appCl.SetErrorOrLog(err)
-		return
-	}
-
-	appLog("Listening on %s network, port %d", netType, appPort)
-
-	for {
-		appCl.Log().Debugf("Accepting skychat conn on %s...", netType)
-		conn, err := l.Accept()
-		if err != nil {
-			appLog("Failed to accept conn on %s: %v", netType, err)
-			return
-		}
-		appCl.Log().Debugf("Accepted skychat conn on %s", netType)
-
-		raddr := conn.RemoteAddr().(appnet.Addr)
-		fc := newFramedConn(conn)
-		connsMu.Lock()
-		conns[raddr.PubKey] = fc
-		connsMu.Unlock()
-		appLog("Accepted skychat conn on %s from %s via %s", conn.LocalAddr(), raddr.PubKey, netType)
-
-		go handleConn(fc)
-	}
-}
-
-func handleConn(conn *framedConn) {
-	raddr := conn.RemoteAddr().(appnet.Addr)
-	for {
-		payload, err := conn.ReadFrame()
-		if err != nil {
-			appLog("Failed to read packet: %v", err)
-			counterMu.Lock()
-			inboundDropCount++
-			counterMu.Unlock()
-			connsMu.Lock()
-			delete(conns, raddr.PubKey)
-			connsMu.Unlock()
-			return
-		}
-
-		// First, try the pair-control envelope. Recognized types
-		// (pair-invite / pair-ack) are consumed here and not surfaced
-		// as chat messages; everything else falls through to the
-		// legacy plain-text path so the existing CI tests are
-		// unaffected.
-		if handlePairControlFrame(context.Background(), raddr.PubKey, payload) {
-			continue
-		}
-
-		peerPK := raddr.PubKey.Hex()
-
-		// Then try the chat-msg / chat-ack envelope. A chat-msg
-		// envelope (type=chat-msg, ack=true) → unwrap body, send
-		// chat-ack back, surface body as a normal chat message.
-		// A chat-ack envelope (type=chat-ack) → consumed internally
-		// to satisfy a waiting /message --wait request, NOT surfaced
-		// to the SSE stream. Plain-text bodies fall through to the
-		// legacy path unchanged.
-		envHandled, envBody, envMsgID, envReplyTo := tryHandleChatEnvelope(payload, peerPK, func(id string) {
-			ackEnv := chatEnvelope{Type: chatTypeAck, ID: id}
-			ackBytes, mErr := json.Marshal(ackEnv)
-			if mErr != nil {
-				appLog("chat-ack marshal failed: %v", mErr)
-				return
-			}
-			if wErr := conn.WriteFrame(ackBytes); wErr != nil {
-				appLog("chat-ack write to %s failed: %v", peerPK, wErr)
-			}
-		})
-		var text string
-		if envHandled {
-			if envBody == "" {
-				// chat-ack consumed — nothing to surface.
-				continue
-			}
-			text = envBody
-		} else {
-			text = string(payload)
-		}
-
-		counterMu.Lock()
-		inboundMsgCount++
-		lastRxAt = time.Now().UTC()
-		counterMu.Unlock()
-
-		// Persist (best-effort, never blocks ephemeral path).
-		persistMessage(history.Message{
-			Peer:      peerPK,
-			From:      peerPK,
-			Outgoing:  false,
-			Text:      text,
-			Timestamp: time.Now().UTC(),
-			ID:        envMsgID,   // message's own id (empty for plain messages)
-			ReplyTo:   envReplyTo, // quoted-reply target — persisted so the thread survives a reload
-		})
-
-		// Include the network field so listen --net can filter
-		// inbound just as it can filter outbound. Without this, SSE
-		// events for incoming messages carry no transport tag and any
-		// consumer-side --net filter drops them all.
-		//
-		// "dir" is a string ("in"|"out"|... future "relay"|"group-in"|
-		// "group-out") rather than an "outgoing" bool so the schema
-		// stays extensible as group / relay flows land without a
-		// breaking wire-version bump.
-		//
-		// "id" is a stable per-event identifier. Pre-#65-ack: no one
-		// consumes it; post-#65-ack: send --wait references it to
-		// correlate inbound chat-ack envelopes back to the originating
-		// send without a separate schema bump. Today it's just a UUID
-		// so consumers can already use it for log correlation / dedup.
-		// "len" is the body byte length, surfaced for size-debug
-		// without forcing consumers to count after a json round-trip.
-		// Key the inbound event by the message's own envelope id when it
-		// carries one, so a later reply's reply_to_id can resolve to it. Plain
-		// (pre-envelope) messages have no id — fall back to a fresh event id.
-		inEventID := envMsgID
-		if inEventID == "" {
-			inEventID = newEventID()
-		}
-		hub.publishEvent(chatEvent{
-			ID:        inEventID,
-			Channel:   channelDM,
-			Transport: string(raddr.Net),
-			Dir:       "in",
-			From:      peerPK,
-			Text:      text,
-			ReplyToID: envReplyTo, // quoted-reply target, threaded from the wire (shared codec)
-		})
-	}
-}
-
 func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 
@@ -1248,290 +997,33 @@ func messageHandler(ctx context.Context) func(w http.ResponseWriter, rreq *http.
 			chatLog.Infof("Self-send via %s on port %d", netType, addr.Port)
 		}
 
-		// cached tells the write path whether the conn came from
-		// the cache (worth a redial+retry on stale-conn write
-		// errors) or from a fresh dial below (write failure on a
-		// fresh dial means the path is really broken — retrying is
-		// unlikely to help and just doubles the surfaced latency).
-		connsMu.Lock()
-		conn, cached := conns[pk]
-		connsMu.Unlock()
-
-		if !cached {
-			// In --standalone mode appCl is nil — dialAndCache would
-			// panic on appCl.Dial(). Skynet/dmsg listenLoops are off
-			// in standalone (see RunSkychat above), so the only way
-			// /message can reach a peer is through an already-cached
-			// TCP-direct conn (populated by --tcp-peer outbound or
-			// --tcp-listen accept). Surface a clean 503 with the
-			// fix-it-yourself hint instead of a panic.
-			if appCl == nil {
-				http.Error(w,
-					fmt.Sprintf("standalone mode: no cached tcp-direct conn to %s "+
-						"(use --tcp-peer to establish a persistent outbound, "+
-						"or 'skywire cli skychat send --via tcp://<pk>@host:port' to dial directly)", pk),
-					http.StatusServiceUnavailable)
-				return
-			}
-			var err error
-			conn, err = dialAndCache(ctx, pk, addr)
-			if err != nil {
-				if isSelf {
-					chatLog.WithError(err).Errorf("Self-dial via %s failed", netType)
-				} else {
-					chatLog.WithError(err).Warnf("Dial to %s via %s failed", pk, netType)
-				}
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
+		// Deliver through the shared DM controller (pkg/skychat/dm): it (re)uses a
+		// cached conn, writes with a deadline, redial-retries a stale cached conn,
+		// falls back to the alternate network, persists, and surfaces the outbound
+		// mirror via OnEvent → publishEvent. For a wait_ms send it wraps a chat-msg
+		// envelope and blocks on the peer's chat-ack.
+		opt := dm.SendOpts{ReplyTo: data.ReplyTo}
+		if data.WaitMS > 0 {
+			opt.WaitAck = clampAckWait(time.Duration(data.WaitMS) * time.Millisecond)
 		}
-
-		// Build the on-the-wire payload. Default is plain text (back-
-		// compat with every binary that has shipped to date). When
-		// wait_ms is set, we wrap in a chat-msg envelope with a fresh
-		// id, register an ack-waiter, and after the write blocks the
-		// HTTP request on the ack channel up to wait_ms.
-		wirePayload := []byte(data.Message)
-		var ackID string
-		var ackCh <-chan struct{}
-		var unregisterAck func()
-		var ackWait time.Duration
-		// Wrap in a chat-msg envelope when the caller wants an ack
-		// (wait_ms) OR is sending a quoted reply (reply_to). A default
-		// send with neither stays plain-text so the wire is byte-identical
-		// for ordinary chat and pre-envelope peers. The ack-waiter is only
-		// registered for wait_ms sends; a reply-only send sets Ack:false so
-		// the peer doesn't ack and this handler doesn't block.
-		wantAck := data.WaitMS > 0
-		if wantAck || data.ReplyTo != "" {
-			ackID = newEventID()
-			env := chatEnvelope{Type: chatTypeMsg, ID: ackID, Body: data.Message, Ack: wantAck, ReplyTo: data.ReplyTo}
-			eb, mErr := json.Marshal(env)
-			if mErr != nil {
-				http.Error(w, mErr.Error(), http.StatusInternalServerError)
-				return
-			}
-			wirePayload = eb
-			if wantAck {
-				ackWait = clampAckWait(time.Duration(data.WaitMS) * time.Millisecond)
-				ackCh, unregisterAck = registerAckWaiter(ackID)
-				defer unregisterAck()
-			}
+		res, sErr := chatCtrl.Send(ctx, pk, netType, data.Message, opt)
+		if sErr != nil {
+			http.Error(w, sErr.Error(), http.StatusBadRequest)
+			return
 		}
-
-		// Write the framed payload. On a *cached* conn, a write
-		// failure usually means the underlying transport went stale
-		// between sends (peer visor restart, route churn) — the
-		// frame is lost AND every subsequent send would also fail
-		// until something kicks the cache. To get the operator out
-		// of that hole inside the same request, we redial + retry
-		// exactly once when the first attempt was on a cached conn.
-		// A fresh-dial write failure isn't retried (a second dial
-		// of the same network in the same handler tick won't help).
-		writeStart := time.Now()
-		err := conn.WriteFrameDeadline(wirePayload, messageWriteTimeout)
-		if err != nil && cached {
-			// Stale-conn auto-retry: a cached conn whose underlying
-			// transport has gone stale (peer chat-app restart,
-			// transient transport fault) used to lose the caller's
-			// CURRENT message — handler returned 400, operator had
-			// to retry from CLI/UI. Now we delete the stale entry
-			// (pointer-eq guarded so we don't clobber a fresh conn
-			// installed by a concurrent handler), dial fresh via
-			// dialAndCache, and retry the WriteFrame ONCE. Only on a
-			// second failure do we surface the error to the caller.
-			// Fresh-dial write failures (cached==false branch below)
-			// are NOT retried — a same-network second dial in the
-			// same handler tick won't help and just doubles latency.
-			connsMu.Lock()
-			if conns[pk] == conn {
-				delete(conns, pk)
-			}
-			connsMu.Unlock()
-
-			chatLog.Debugf("Stale-conn write to %s via %s: %v — redialing", pk, netType, err)
-			newConn, derr := dialAndCache(ctx, pk, addr)
-			if derr != nil {
-				counterMu.Lock()
-				outboundFailCount++
-				counterMu.Unlock()
-				http.Error(w, fmt.Sprintf("redial after write %v: %v", err, derr), http.StatusBadRequest)
-				return
-			}
-			if werr := newConn.WriteFrameDeadline(wirePayload, messageWriteTimeout); werr != nil {
-				connsMu.Lock()
-				if conns[pk] == newConn {
-					delete(conns, pk)
-				}
-				connsMu.Unlock()
-				counterMu.Lock()
-				outboundFailCount++
-				counterMu.Unlock()
-				http.Error(w, fmt.Sprintf("retry after %v: %v", err, werr), http.StatusBadRequest)
-				return
-			}
-			counterMu.Lock()
-			outboundRetryCount++
-			counterMu.Unlock()
-			conn = newConn
-			// Clear err so the post-retry block below doesn't double-
-			// report a failure on a now-successful retry.
-			err = nil
-		}
-		if err != nil {
-			connsMu.Lock()
-			if conns[pk] == conn {
-				delete(conns, pk)
-			}
-			connsMu.Unlock()
-			// Network fallback before surfacing the error to the
-			// caller. Skychat listens on BOTH skynet and dmsg by
-			// default (--skynet=true --dmsg=true), so a peer who
-			// receives on one will usually receive on the other.
-			// If the chosen network can't deliver, try the alternate
-			// in one last attempt: dial fresh, write once, on
-			// success continue to the normal mirror/ack/persist
-			// path. On second failure, surface the original error
-			// to the caller (the alternate's error is logged at
-			// debug but not exposed, to keep the public error
-			// stable across network-fallback fires/misses).
-			//
-			// Increment outboundFallbackCount on success so
-			// operators can see how often the fallback path is
-			// rescuing sends — a non-zero rate means the chosen
-			// network is unreliable enough that callers should
-			// reconsider the default, or the operator should fix
-			// the transport / route to the peer on that network.
-			fallbackOK := false
-			if fbConn, fbAddr := tryNetworkFallback(ctx, pk, netType); fbConn != nil {
-				if werr := fbConn.WriteFrameDeadline(wirePayload, messageWriteTimeout); werr == nil {
-					counterMu.Lock()
-					outboundFallbackCount++
-					counterMu.Unlock()
-					// Successful fallback write — conn / netType
-					// would-be-reassignments dropped because the
-					// caller doesn't read them after this point
-					// (the response is rendered from ackCh state,
-					// not the conn directly). Keeping fbAddr
-					// referenced under _ documents the intent.
-					_ = fbAddr
-					fallbackOK = true
-				} else {
-					connsMu.Lock()
-					if conns[pk] == fbConn {
-						delete(conns, pk)
-					}
-					connsMu.Unlock()
-					chatLog.Debugf("Network-fallback write to %s via %s also failed: %v",
-						pk, fbAddr.Net, werr)
-				}
-			}
-			if !fallbackOK {
-				counterMu.Lock()
-				outboundFailCount++
-				counterMu.Unlock()
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-		}
-
-		// Persist outgoing message (best-effort). ackID is the envelope id
-		// minted above for a reply/wait send (empty for a plain send); persisting
-		// it + ReplyTo keeps outgoing quoted-replies addressable and threaded
-		// across a reload, symmetric with the inbound path.
-		persistMessage(history.Message{
-			Peer:      pk.Hex(),
-			Outgoing:  true,
-			Text:      data.Message,
-			Timestamp: time.Now().UTC(),
-			ID:        ackID,
-			ReplyTo:   data.ReplyTo,
-		})
-
-		// If --wait was requested, block on the ack channel. The
-		// envelope was written above; the peer's chat-app, if it
-		// speaks the chat-msg envelope (i.e. is post-2026-05-12),
-		// recognizes it, persists the body, sends chat-ack back over
-		// the same conn, which our handleConn routes to deliverAck →
-		// our ackCh. Old peers see the JSON-encoded envelope as plain
-		// text and never ack; we time out cleanly.
-		if ackCh != nil {
-			timer := time.NewTimer(ackWait)
-			defer timer.Stop()
-			select {
-			case <-ackCh:
-				elapsed := time.Since(writeStart)
-				w.Header().Set("Content-Type", "application/json")
+		if data.WaitMS > 0 {
+			w.Header().Set("Content-Type", "application/json")
+			if res.Acked {
 				_ = json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
-					"acked": true,
-					"id":    ackID,
-					"ms":    elapsed.Milliseconds(),
+					"acked": true, "id": res.ID, "ms": res.Elapsed.Milliseconds(),
 				})
-			case <-timer.C:
-				w.Header().Set("Content-Type", "application/json")
+			} else {
 				w.WriteHeader(http.StatusGatewayTimeout)
 				_ = json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
-					"acked":  false,
-					"id":     ackID,
-					"reason": "timeout",
-					"ms":     ackWait.Milliseconds(),
+					"acked": false, "id": res.ID, "reason": "timeout", "ms": opt.WaitAck.Milliseconds(),
 				})
-			case <-req.Context().Done():
-				return
 			}
 		}
-
-		// Mirror the outgoing message into the SSE stream so headless
-		// listeners (skywire-cli skychat listen) see a complete
-		// transcript without having to scrape send invocations and
-		// merge by timestamp. The TUI's bidirectional view already
-		// renders both directions natively; this brings parity to the
-		// listen-on-the-CLI use case.
-		//
-		// IMPORTANT: dir="out" means "WriteFrame returned without
-		// error" — i.e. the framed payload was handed to the
-		// underlying skywire conn. It does NOT mean the peer's
-		// chat-app received or processed the message. Peer-app
-		// receipt-ack is a deferred protocol feature (msg-id +
-		// chat-ack envelope frame type); consumers should not treat
-		// dir:out as delivery confirmation.
-		//
-		// The "sender" field carries the RECIPIENT'S PK here (per-peer
-		// thread routing on the consumer's side stays keyed by the
-		// remote PK regardless of direction). dir distinguishes
-		// directionality (string, not bool, for extensibility — future
-		// relay/group flows can emit "relay" / "group-in" /
-		// "group-out" without a wire-schema bump).
-		// "to" is set on dir:out events so consumers can correlate
-		// outgoing mirrors back to a specific send. dir:in events
-		// don't need "to" (we're always the recipient).
-		// "from" stays as the visor's own PK so consumers can route
-		// by per-peer thread regardless of direction.
-		var myPK string
-		if appCl != nil {
-			myPK = appCl.Config().VisorPK.Hex()
-		}
-		// Use the ack id when --wait was used, so consumers correlate
-		// the outgoing mirror to a specific send by id.
-		mirrorID := ackID
-		if mirrorID == "" {
-			mirrorID = newEventID()
-		}
-		hub.publishEvent(chatEvent{
-			ID:        mirrorID,
-			Channel:   channelDM,
-			Transport: string(netType),
-			Dir:       "out",
-			From:      myPK,
-			To:        pk.Hex(),
-			Text:      data.Message,
-			ReplyToID: data.ReplyTo, // outbound mirror carries the quote so the sender's UI threads it too
-		})
-
-		counterMu.Lock()
-		outboundMsgCount++
-		lastSendAt = time.Now().UTC()
-		counterMu.Unlock()
 	}
 }
 
@@ -1819,13 +1311,15 @@ func historyPeersHandler(w http.ResponseWriter, _ *http.Request) {
 //	last_rx_ts           last successful inbound (RFC3339 / "" if none)
 //	last_send_ts         last successful outbound (RFC3339 / "" if none)
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
-	connsMu.Lock()
-	connCount := len(conns)
-	peers := make([]string, 0, connCount)
-	for pk := range conns {
-		peers = append(peers, pk.Hex())
+	var connCount int
+	var peers []string
+	if chatCtrl != nil {
+		connCount = chatCtrl.Conns()
+		peers = chatCtrl.Peers()
 	}
-	connsMu.Unlock()
+	if peers == nil {
+		peers = []string{}
+	}
 
 	var subscriberCount int
 	if hub != nil {
@@ -1840,25 +1334,21 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 		visorPKErr = "app client not initialized"
 	}
 
+	var st dm.Stats
+	if chatCtrl != nil {
+		st = chatCtrl.Stats()
+	}
 	counterMu.Lock()
-	inMsgs := inboundMsgCount
-	outMsgs := outboundMsgCount
-	inDrops := inboundDropCount
-	outFails := outboundFailCount
-	outRetries := outboundRetryCount
-	outFallbacks := outboundFallbackCount
 	sseDrops := sseDropCount
-	lastRx := lastRxAt
-	lastSend := lastSendAt
 	counterMu.Unlock()
 
 	rxStr := ""
-	if !lastRx.IsZero() {
-		rxStr = lastRx.UTC().Format(time.RFC3339Nano)
+	if !st.LastRxAt.IsZero() {
+		rxStr = st.LastRxAt.UTC().Format(time.RFC3339Nano)
 	}
 	sendStr := ""
-	if !lastSend.IsZero() {
-		sendStr = lastSend.UTC().Format(time.RFC3339Nano)
+	if !st.LastTxAt.IsZero() {
+		sendStr = st.LastTxAt.UTC().Format(time.RFC3339Nano)
 	}
 
 	status := map[string]interface{}{
@@ -1871,12 +1361,12 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 		"frame_proto_version":     frameProtoVersion,
 		"schema_version":          schemaVersion,
 		"app_uptime_sec":          int64(time.Since(startedAt).Seconds()),
-		"inbound_msg_count":       inMsgs,
-		"outbound_msg_count":      outMsgs,
-		"inbound_drop_count":      inDrops,
-		"outbound_fail_count":     outFails,
-		"outbound_retry_count":    outRetries,
-		"outbound_fallback_count": outFallbacks,
+		"inbound_msg_count":       st.InboundMsgs,
+		"outbound_msg_count":      st.OutboundMsgs,
+		"inbound_drop_count":      st.InboundDrops,
+		"outbound_fail_count":     st.OutboundFails,
+		"outbound_retry_count":    st.OutboundRetry,
+		"outbound_fallback_count": st.OutboundFallbk,
 		"sse_drop_count":          sseDrops,
 		"last_rx_ts":              rxStr,
 		"last_send_ts":            sendStr,
@@ -2004,6 +1494,38 @@ func collectGroupHealth() ([]groupHealth, string) {
 // persistMessage stores a message in the history backend if persistence is
 // enabled. Errors are logged at debug level; ephemeral delivery is never
 // blocked by persistence failure.
+// onChatEvent bridges the shared DM controller's surfaced messages (inbound +
+// the outbound mirror) into the SSE hub. Persistence and counters live in the
+// controller now, so this only fans the event out to /sse and /events. The
+// event id is the message's own envelope id when present (so a reply's
+// reply_to_id resolves to it), else a fresh id; an outbound mirror carries the
+// sender=self, to=peer shape the UI expects.
+func onChatEvent(ev dm.Event) {
+	id := ev.ID
+	if id == "" {
+		id = newEventID()
+	}
+	from, to := ev.Peer, ""
+	if ev.Dir == "out" {
+		from = ""
+		if appCl != nil {
+			from = appCl.Config().VisorPK.Hex()
+		}
+		to = ev.Peer
+	}
+	hub.publishEvent(chatEvent{
+		ID:        id,
+		Channel:   channelDM,
+		Transport: ev.Network,
+		Dir:       ev.Dir,
+		From:      from,
+		To:        to,
+		Text:      ev.Text,
+		ReplyToID: ev.ReplyTo,
+		Len:       len(ev.Text),
+	})
+}
+
 func persistMessage(msg history.Message) {
 	if historyStore == nil {
 		return

--- a/cmd/apps/skychat/commands/tcp_direct.go
+++ b/cmd/apps/skychat/commands/tcp_direct.go
@@ -216,12 +216,10 @@ func acceptTCPConn(
 	}
 
 	tdc := &tcpDirectConn{Conn: wrapped, rPK: rPK}
-	fc := newFramedConn(tdc)
-	connsMu.Lock()
-	conns[rPK] = fc
-	connsMu.Unlock()
 	appLog("skychat: tcp-direct conn accepted from %s", rPK)
-	handleConn(fc)
+	// Serve caches the conn (by its appnet.Addr RemoteAddr) and runs it through
+	// the shared DM read loop, exactly as the dmsg/skynet accept path does.
+	chatCtrl.Serve(tdc)
 }
 
 // runTCPPeerDialers spawns one persistent-dial goroutine per
@@ -286,17 +284,11 @@ func peerDialLoop(
 		backoff = tcpReconnectMin
 
 		tdc := &tcpDirectConn{Conn: conn, rPK: rPK}
-		fc := newFramedConn(tdc)
-		connsMu.Lock()
-		// If a prior conn (from accept side OR a previous loop iter)
-		// is still registered, supersede it. The old framedConn's
-		// handleConn will exit naturally on its next ReadFrame.
-		conns[rPK] = fc
-		connsMu.Unlock()
 		appLog("skychat: tcp-peer connected to %s@%s", rPK, addr)
-		// handleConn blocks until the peer disconnects (ReadFrame
-		// error). On return we'll loop and redial.
-		handleConn(fc)
+		// Serve supersedes any prior conn for this PK in the controller's cache
+		// and blocks until the peer disconnects (ReadFrame error); on return we
+		// loop and redial.
+		chatCtrl.Serve(tdc)
 		appLog("skychat: tcp-peer disconnected from %s@%s", rPK, addr)
 	}
 }

--- a/pkg/skychat/dm/controller.go
+++ b/pkg/skychat/dm/controller.go
@@ -459,6 +459,40 @@ func (c *Controller) Send(ctx context.Context, pk cipher.PubKey, netType appnet.
 	return res, nil
 }
 
+// SendRaw writes a pre-framed raw payload to pk over a cached or freshly-dialed
+// conn, trying each configured network in order. No envelope, persistence, or
+// surfacing — it's for out-of-band control frames (the native app's
+// pair-invite / pair-ack) whose inbound side is consumed by PreHandleFrame.
+func (c *Controller) SendRaw(ctx context.Context, pk cipher.PubKey, payload []byte) error {
+	c.mu.Lock()
+	conn := c.conns[pk]
+	c.mu.Unlock()
+	if conn != nil {
+		if err := conn.WriteFrameDeadline(payload, writeTimeout); err == nil {
+			return nil
+		}
+		c.evict(pk, conn)
+	}
+	var lastErr error
+	for _, n := range c.cfg.Networks {
+		fc, err := c.dialAndCache(ctx, pk, appnet.Addr{Net: n, PubKey: pk, Port: c.port})
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if werr := fc.WriteFrameDeadline(payload, writeTimeout); werr == nil {
+			return nil
+		} else { //nolint:revive
+			c.evict(pk, fc)
+			lastErr = werr
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("skychat/dm: no network to send raw frame")
+	}
+	return lastErr
+}
+
 func (c *Controller) evict(pk cipher.PubKey, conn *message.Conn) {
 	c.mu.Lock()
 	if c.conns[pk] == conn {
@@ -472,6 +506,32 @@ func (c *Controller) Conns() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.conns)
+}
+
+// HasConn reports whether a live cached connection to pk exists.
+func (c *Controller) HasConn(pk cipher.PubKey) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.conns[pk]
+	return ok
+}
+
+// NoteInbound records an inbound message that arrived outside the framed-conn
+// read loop (e.g. the native app's CXO feed path) so the /status counters stay
+// accurate for those transports too.
+func (c *Controller) NoteInbound() {
+	c.bump(func(s *Stats) { s.InboundMsgs++; s.LastRxAt = time.Now().UTC() })
+}
+
+// Peers returns the PK hexes of every cached peer connection (for /status).
+func (c *Controller) Peers() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, 0, len(c.conns))
+	for pk := range c.conns {
+		out = append(out, pk.Hex())
+	}
+	return out
 }
 
 // Close stops accept/read loops and closes every cached conn. Idempotent.


### PR DESCRIPTION
## What

Final step of the DM-controller extraction (#3596): the native skychat app now runs its 1:1 DM path on `dm.Controller` — the same core the wasm visor uses (#3609) — deleting ~400 lines of duplicated conn/read-loop/send/ack logic. **One shared DM controller; both visors on it.**

- `RunSkychat` builds one `Controller` (`Store`=historyStore, `Networks` from `useDmsg`/`useSkynet`, `DialRetry`=the app retrier, `PreHandleFrame`=pair-control interception, `OnEvent`=`onChatEvent`→SSE hub) and `Start`s it (skipped in `--standalone`/no-`appCl`, where only `Serve`'d TCP-direct conns flow).
- `messageHandler`'s ~250-line send-core (dial/write/retry/fallback/persist/mirror/ack) collapses to `chatCtrl.Send()`; the CXO `/pair` branch is untouched.
- `tcp_direct.go` injects its handshaked conn via `chatCtrl.Serve` (was `conns[pk]=fc; handleConn(fc)`); `pairing.go` sends pair-control frames via `chatCtrl.SendRaw`; `cxo_tcp.go` records inbound via `chatCtrl.NoteInbound`; `filexfer.go` checks liveness via `chatCtrl.HasConn`.
- `statusHandler` reads `chatCtrl.Stats()/Conns()/Peers()`. The DM counters, the `conns` map, and `dialAndCache`/`tryNetworkFallback`/`handleConn`/`listenLoop` are gone. `sendack.go` slims to the `wait_ms` clamp (ack machinery + envelope decode moved into the controller).

Persistence (whitelist/rate/cap via historyStore), quoted replies, peer-receipt ack, network fallback, and the `/status` counters are all preserved.

## Validation

- `go build ./...`, `go vet`, `go test ./cmd/apps/skychat/commands/ ./pkg/skychat/...` — all pass; gofmt clean.
- **Live** (native dmsg self-send loopback): `/sse` shows `dir:out` + `dir:in` carrying the same envelope id + `reply_to_id`; `/status` reports the controller's counters (`active_peer_conns:1, inbound:1, outbound:1` + timestamps).

⚠️ **TCP-direct** and **`--standalone`** were compile- and unit-verified (`Serve`/`HasConn`/nil-`Client` tests in #3610) but **not live-exercised** in this environment — worth a smoke-test on a TCP-direct/standalone node.

Completes #3596.

🤖 Generated with [Claude Code](https://claude.com/claude-code)