### PR TITLE
feat(skychat/dm): delete-for-everyone wire type + controller support

### DIFF
--- a/pkg/skychat/dm/controller.go
+++ b/pkg/skychat/dm/controller.go
@@ -106,6 +106,11 @@ type Config struct {
 	// Receipts are consumed here — they are never surfaced as chat lines.
 	// Nil = the app doesn't track delivery status.
 	OnReceipt func(peer, id, kind string)
+	// OnDelete is called for an inbound chat-delete: the peer asks us to drop
+	// (tombstone) a message THEY sent us, identified by its envelope id. Like a
+	// receipt it is consumed here, never surfaced as a chat line; the app
+	// replaces the message with a "deleted" placeholder. Nil = deletes ignored.
+	OnDelete func(peer, id string)
 	// StaleAckWindow bounds how long a RequestAck send waits for the peer's
 	// chat-ack before concluding the cached conn is half-open and evicting it,
 	// so the next send redials. A live peer acks in well under a second; this
@@ -356,6 +361,12 @@ func (c *Controller) readConn(conn *message.Conn) {
 		if kind, id := receiptKind(payload); kind != "" && c.cfg.OnReceipt != nil {
 			c.cfg.OnReceipt(peer.Hex(), id, kind)
 		}
+		// A chat-delete asks us to tombstone a message the peer sent us. Reported
+		// then consumed (decodeInbound returns empty for it, so it never surfaces
+		// as a chat line).
+		if id := deleteID(payload); id != "" && c.cfg.OnDelete != nil {
+			c.cfg.OnDelete(peer.Hex(), id)
+		}
 		text, ackID, replyTo, msgID := c.decodeInbound(payload)
 		if ackID != "" {
 			if b, mErr := (message.Envelope{Type: message.TypeAck, ID: ackID}).Marshal(); mErr == nil {
@@ -559,6 +570,18 @@ func (c *Controller) SendRaw(ctx context.Context, pk cipher.PubKey, payload []by
 	return lastErr
 }
 
+// SendDelete sends a delete-for-everyone command for the message id to pk over a
+// cached-or-dialed conn. On the peer, OnDelete fires and the message is
+// tombstoned. Best-effort like a receipt — a peer that's offline simply never
+// applies it (the sender's own copy is deleted locally by the caller).
+func (c *Controller) SendDelete(ctx context.Context, pk cipher.PubKey, id string) error {
+	b, err := (message.Envelope{Type: message.TypeDelete, ID: id}).Marshal()
+	if err != nil {
+		return err
+	}
+	return c.SendRaw(ctx, pk, b)
+}
+
 func (c *Controller) evict(pk cipher.PubKey, conn *message.Conn) {
 	c.mu.Lock()
 	if c.conns[pk] == conn {
@@ -679,6 +702,10 @@ func (c *Controller) decodeInbound(payload []byte) (text, ackID, replyTo, msgID 
 			// that bubble from "received" to "read". Handled here rather than
 			// falling through, or the raw JSON would show up as a chat line.
 			return "", "", "", ""
+		case message.TypeDelete:
+			// A delete-for-everyone command. Consumed here (reported via OnDelete
+			// in readConn); never surfaced as a chat line.
+			return "", "", "", ""
 		case message.TypeMsg:
 			ack := ""
 			if env.Ack && env.ID != "" {
@@ -703,6 +730,15 @@ func receiptKind(payload []byte) (kind, id string) {
 		return env.Type, env.ID
 	}
 	return "", ""
+}
+
+// deleteID reports the target id of an inbound chat-delete frame, or "".
+func deleteID(payload []byte) string {
+	env, ok := message.ParseEnvelope(payload)
+	if !ok || env.Type != message.TypeDelete || env.ID == "" {
+		return ""
+	}
+	return env.ID
 }
 
 func newID() string {

--- a/pkg/skychat/dm/controller_test.go
+++ b/pkg/skychat/dm/controller_test.go
@@ -218,6 +218,49 @@ func TestController_ServeAndStats(t *testing.T) {
 	}
 }
 
+func TestController_DeleteForEveryone(t *testing.T) {
+	hub := newMemHub()
+	pkA, pkB := mustPK(t), mustPK(t)
+	var gotPeer, gotID string
+	var mu sync.Mutex
+	done := make(chan struct{}, 1)
+	ctrlB := New(Config{
+		Client: &memClient{hub, pkB}, Networks: []appnet.Type{appnet.TypeDmsg},
+		OnEvent: func(Event) {},
+		OnDelete: func(peer, id string) {
+			mu.Lock()
+			gotPeer, gotID = peer, id
+			mu.Unlock()
+			select {
+			case done <- struct{}{}:
+			default:
+			}
+		},
+	})
+	ctrlA := New(Config{Client: &memClient{hub, pkA}, Networks: []appnet.Type{appnet.TypeDmsg}, OnEvent: func(Event) {}})
+	_ = ctrlB.Start(context.Background())                      //nolint
+	_ = ctrlA.Start(context.Background())                      //nolint
+	t.Cleanup(func() { _ = ctrlA.Close(); _ = ctrlB.Close() }) //nolint
+
+	const targetID = "msg-abc-123"
+	if err := ctrlA.SendDelete(context.Background(), pkB, targetID); err != nil {
+		t.Fatalf("SendDelete: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnDelete not called within deadline")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPeer != pkA.Hex() {
+		t.Errorf("delete peer = %s, want %s", gotPeer, pkA.Hex())
+	}
+	if gotID != targetID {
+		t.Errorf("delete id = %s, want %s", gotID, targetID)
+	}
+}
+
 func TestController_NoTransportDialErrors(t *testing.T) {
 	// A controller with no Client (native --standalone): a send with no cached
 	// conn must error cleanly, not panic.

--- a/pkg/skychat/message/message.go
+++ b/pkg/skychat/message/message.go
@@ -156,6 +156,13 @@ const (
 	TypeMsg  = "chat-msg"
 	TypeAck  = "chat-ack"
 	TypeRead = "chat-read"
+	// TypeDelete is a delete-for-everyone command: {"type":"chat-delete","id":"<hex>"}.
+	// The sender asks the recipient to drop (tombstone) the message with that id
+	// — the id the sender minted for it (chat-msg ID). It carries no body and is
+	// consumed like a receipt, never surfaced as a chat line; the recipient's app
+	// replaces the message with a "deleted" placeholder. additive + backward-
+	// compatible (a peer predating it ignores the unknown type).
+	TypeDelete = "chat-delete"
 )
 
 // Marshal encodes the envelope as its JSON wire bytes.
@@ -175,7 +182,7 @@ func ParseEnvelope(payload []byte) (env Envelope, ok bool) {
 		return Envelope{}, false
 	}
 	switch env.Type {
-	case TypeMsg, TypeAck, TypeRead:
+	case TypeMsg, TypeAck, TypeRead, TypeDelete:
 		return env, true
 	}
 	return Envelope{}, false


### PR DESCRIPTION
## What

Adds the **delete-for-everyone** half of the DM control features (read-receipts / delivery-ticks already landed on develop).

- **`message.TypeDelete`** (`chat-delete`, `{type,id}`) — a delete command carrying the target message's envelope id. Recognized by `ParseEnvelope`; additive + backward-compatible (a peer predating it ignores the unknown type).
- **Controller**:
  - `Config.OnDelete(peer, id)` — fires for an inbound `chat-delete` (the peer asks us to tombstone a message they sent), consumed like a receipt and never surfaced as a chat line.
  - `SendDelete(ctx, pk, id)` — marshals + `SendRaw`s a `chat-delete` over the cached or freshly-dialed conn.
  - `decodeInbound` + `deleteID` consume the frame on the read path.

## Validation

`go test ./pkg/skychat/dm/ ./pkg/skychat/message/` — `A.SendDelete(id)` → `B`'s `OnDelete` fires with `(A's PK, id)` over the in-memory transport pair; builds native + `GOOS=js`.

Foundation; the native app, wasm visor, and both UIs wire onto it next. Part of the DM control-feature set (#3596).

🤖 Generated with [Claude Code](https://claude.com/claude-code)