### PR TITLE
feat(skychat): delete-for-everyone in the native app + wasm visor

### DIFF
--- a/cmd/apps/skychat/commands/dmstatus.go
+++ b/cmd/apps/skychat/commands/dmstatus.go
@@ -37,6 +37,10 @@ import (
 const (
 	dmStatusReceived = "received"
 	dmStatusRead     = "read"
+	// dmStatusDeleted flags a message deleted for everyone: the browser replaces
+	// the bubble with a "this message was deleted" placeholder. Broadcast on
+	// both ends — the deleter's own UI and, via OnDelete, the recipient's.
+	dmStatusDeleted = "deleted"
 )
 
 // staleAckWindow bounds how long a non-blocking receipts send waits for the
@@ -88,6 +92,47 @@ func sendReadReceipt(ctx context.Context, peer cipher.PubKey, id string) error {
 // id): the recipient's UI reports which inbound messages from pk it has now
 // displayed, and we send a chat-read envelope per id back to that peer so the
 // original sender's bubbles advance to "read".
+// deleteHandler serves POST /delete {pk, id}: the operator deletes their own
+// message for everyone. Sends a chat-delete to the peer (their UI tombstones it
+// via OnDelete) and broadcasts a dm-status "deleted" locally so the deleter's
+// own bubble tombstones immediately.
+func deleteHandler(ctx context.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "POST only", http.StatusMethodNotAllowed)
+			return
+		}
+		var body struct {
+			PK string `json:"pk"`
+			ID string `json:"id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		peer, err := parsePK(body.PK)
+		if err != nil {
+			http.Error(w, "invalid pk: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(body.ID) == "" {
+			http.Error(w, "missing id", http.StatusBadRequest)
+			return
+		}
+		if chatCtrl == nil {
+			http.Error(w, "chat controller not ready", http.StatusServiceUnavailable)
+			return
+		}
+		if err := chatCtrl.SendDelete(ctx, peer, body.ID); err != nil {
+			appLog("skychat: delete %s to %s failed: %v", body.ID, peer, err)
+			// Still tombstone locally — the operator's intent is recorded even if
+			// the peer is currently unreachable (they can't receive the delete).
+		}
+		broadcastDMStatus(body.ID, dmStatusDeleted, peer.Hex())
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 func readReceiptHandler(ctx context.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/cmd/apps/skychat/commands/skychat.go
+++ b/cmd/apps/skychat/commands/skychat.go
@@ -797,6 +797,11 @@ func RunSkychat(ctx context.Context, args []string) error {
 				broadcastDMStatus(id, dmStatusRead, peer)
 			}
 		},
+		// A peer deleted (for everyone) a message they sent us — tombstone it in
+		// our UI via the same dm-status channel.
+		OnDelete: func(peer, id string) {
+			broadcastDMStatus(id, dmStatusDeleted, peer)
+		},
 		StaleAckWindow: staleAckWindow,
 		Log:            func(f string, a ...interface{}) { appLog(f, a...) },
 	})
@@ -871,6 +876,7 @@ func RunSkychat(ctx context.Context, args []string) error {
 	mux.HandleFunc("/thumb/", requireAuthFunc(thumbnailHandler))
 	mux.HandleFunc("/request-file", requireAuthFunc(requestFileHandler(ctx)))
 	mux.HandleFunc("/read-receipt", requireAuthFunc(readReceiptHandler(ctx)))
+	mux.HandleFunc("/delete", requireAuthFunc(deleteHandler(ctx)))
 	mux.HandleFunc("/notify-capable", requireAuthFunc(notifyCapableHandler))
 	registerPairHTTPHandlers(ctx, mux)
 	registerGroupHTTPHandlers(mux)

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -164,6 +164,7 @@ func main() {
 		"skychatSend":       js.FuncOf(jsSkychatSend),
 		"skychatMessages":   js.FuncOf(jsSkychatMessages),
 		"skychatHistory":    js.FuncOf(jsSkychatHistory),
+		"skychatDelete":     js.FuncOf(jsSkychatDelete),
 		// File sharing (in-process, over the encrypted transport) — see filexfer_js.go.
 		"skychatSendFile": js.FuncOf(jsSkychatSendFile),
 		"skychatFile":     js.FuncOf(jsSkychatFile),

--- a/cmd/wasm-visor/skychat_js.go
+++ b/cmd/wasm-visor/skychat_js.go
@@ -51,6 +51,10 @@ type chatMsg struct {
 	// native app, so a reply sent from either side shows its quote on the other.
 	ReplyTo string `json:"reply_to,omitempty"`
 
+	// Deleted marks a message deleted-for-everyone: the page renders a "this
+	// message was deleted" placeholder and the text is blanked in the projection.
+	Deleted bool `json:"deleted,omitempty"`
+
 	// File attachment fields (Telegram-style: a file is a message). Set only on
 	// file events; empty on plain chat. On a received file (Out=false) FileID
 	// keys the in-memory blob the page fetches via skychatFile(id) to download.
@@ -80,7 +84,21 @@ var (
 	fileMeta   = map[string]chatMsg{}
 	chatClient *app.Client
 	chatCtrl   *dm.Controller // shared 1:1 DM core (pkg/skychat/dm): conns, read loop, envelopes, send
+	// deletedChat holds the ids of messages deleted-for-everyone (by us or the
+	// peer). storeToChatMsg tombstones them on projection. Not persisted — a
+	// live-only tombstone, symmetric with the native app's dm-status "deleted".
+	deletedChat = map[string]struct{}{}
 )
+
+// markChatDeleted tombstones the message with the given id (guarded by chatMu).
+func markChatDeleted(id string) {
+	if id == "" {
+		return
+	}
+	chatMu.Lock()
+	deletedChat[id] = struct{}{}
+	chatMu.Unlock()
+}
 
 // chatHistoryLimits bounds the in-browser transcript. Unlike a public-facing
 // persistent store this is our OWN sent/received messages, not an abuse
@@ -160,7 +178,11 @@ func storeToChatMsg(rec history.Message) chatMsg {
 	}
 	if rec.ID != "" {
 		chatMu.Lock()
-		if fm, ok := fileMeta[rec.ID]; ok {
+		if _, del := deletedChat[rec.ID]; del {
+			m.Deleted = true
+			m.Text = ""
+			m.IsFile = false
+		} else if fm, ok := fileMeta[rec.ID]; ok {
 			m.IsFile = true
 			m.FileID = fm.FileID
 			m.FileName = fm.FileName
@@ -200,6 +222,11 @@ func runBrowserSkychat(ctx context.Context, _ []string) error {
 				TS: ev.TS.UnixMilli(), Out: ev.Dir == "out", ReplyTo: ev.ReplyTo,
 			})
 			vlog(fmt.Sprintf("skychat: %s %s: %q", ev.Dir, shortPK(ev.Peer), ev.Text))
+		},
+		// A peer deleted (for everyone) a message they sent us — tombstone it.
+		OnDelete: func(peer, id string) {
+			markChatDeleted(id)
+			vlog(fmt.Sprintf("skychat: %s deleted message %s", shortPK(peer), id))
 		},
 		Log: func(format string, args ...interface{}) { vlog(fmt.Sprintf(format, args...)) },
 	})
@@ -282,6 +309,29 @@ func jsSkychatSend(_ js.Value, args []js.Value) interface{} {
 	}
 	return promise(func() (interface{}, error) {
 		return nil, sendChat(pkHex, text, network, replyTo)
+	})
+}
+
+// jsSkychatDelete(peerPkHex, id) → Promise<null>. Deletes the message for
+// everyone: sends a chat-delete to the peer (their app tombstones it via
+// OnDelete) and tombstones our own copy immediately (best-effort — if the send
+// fails because the peer is offline, our copy is still marked deleted).
+func jsSkychatDelete(_ js.Value, args []js.Value) interface{} {
+	if len(args) < 2 {
+		return js.Global().Get("Error").New("skychatDelete(peerPkHex, id)")
+	}
+	pkHex, id := args[0].String(), args[1].String()
+	return promise(func() (interface{}, error) {
+		if chatCtrl == nil {
+			return nil, fmt.Errorf("skychat not started yet")
+		}
+		var pk cipher.PubKey
+		if err := pk.Set(pkHex); err != nil {
+			return nil, fmt.Errorf("bad peer pk: %w", err)
+		}
+		err := chatCtrl.SendDelete(context.Background(), pk, id)
+		markChatDeleted(id)
+		return nil, err
 	})
 }
 


### PR DESCRIPTION
## What

Wires the `chat-delete` controller support (#3612) into both visors. **Backend only** — the UI delete affordance + tombstone rendering are deferred to coordinate with the in-flight skychat UI work (the SPA + Angular component), to avoid churning those files under active development.

**Native** (`cmd/apps/skychat`):
- `POST /delete {pk, id}` → `chatCtrl.SendDelete` + `broadcastDMStatus(id, "deleted", peer)` so the deleter's own bubble tombstones immediately.
- controller `OnDelete` → `broadcastDMStatus(id, "deleted", peer)`: a peer deleting a message they sent us tombstones it on our side, via the same `dm-status` channel receipts/ticks already use.
- new `dmStatusDeleted = "deleted"`.

**wasm** (`cmd/wasm-visor`):
- `skychatDelete(pk, id)` binding → `chatCtrl.SendDelete` + local tombstone.
- controller `OnDelete` → `markChatDeleted`; a `deletedChat` id-set tombstones the message in `storeToChatMsg` (blanks text, sets `Deleted`). Live-only, symmetric with the native `dm-status "deleted"` (not persisted across reload — same scope as receipts).

## Validation

`make check` clean (golangci-lint **0 issues**, vet ok); `go test ./cmd/apps/skychat/commands/ ./pkg/skychat/...` pass; wasm builds under `GOOS=js`.

Completes the delete-for-everyone feature at the API/controller level. UI is a coordinated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)