### PR TITLE
fix(skychat): eslint errors in the Angular skychat component (unblock ui CI)

### DIFF
--- a/static/skywire-manager-src/src/app/components/pages/node/skychat/skychat.component.ts
+++ b/static/skywire-manager-src/src/app/components/pages/node/skychat/skychat.component.ts
@@ -362,6 +362,7 @@ return {
           this.cdr.markForCheck();
         }
       }
+
       return;
     }
     const msg: ChatMessage = {
@@ -543,7 +544,7 @@ return {
       fetch(this.proxyUrl('delete'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pk, id: m.id }),
+        body: JSON.stringify({ pk: pk, id: m.id }),
       }).catch(() => {});
     }
     m.deleted = true;


### PR DESCRIPTION
The delete-UI + dm-status follow-ups (#3614, #3615) failed the CI **`ui` job** (`make lint-ui` / eslint) — I ran `npm run build` locally but not `npm run lint`. Two style errors:

- missing blank line before a `return` (`padding-line-between-statements`)
- a `pk` object shorthand where the config wants longform (`object-shorthand`)

Both source-only; the shipped bundle is functionally unchanged. `npm run lint` now passes across the whole UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)