### PR TITLE
fix(reward-uptime): heartbeat delivery + bounded backfill (v1.3.89 ~30% uptime regression)

### DIFF
--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -117,11 +117,49 @@ const expectedHeartbeatsPerDay = float64(24*60*60) / float64(90) // 960
 
 // RecordHeartbeat records a visor heartbeat for uptime tracking.
 // Each heartbeat increments the daily counter and updates the version/last_seen.
+// maxHeartbeatBackfillSlots caps how many missed 5-minute slots a single
+// heartbeat backfills (see backfillStartSlot / RecordHeartbeat). 6 slots =
+// 30 minutes: generous enough to cover a burst of dropped heartbeat ticks on a
+// visor that was actually up, but small enough that a genuine longer absence is
+// not credited.
+const maxHeartbeatBackfillSlots = 6
+
+// backfillStartSlot returns the first timeline slot a heartbeat at `now` should
+// set, given the previous heartbeat time (`prev`, valid only when prevSeen>0).
+// Normally that is just the current slot, but heartbeat DELIVERY is flaky (the
+// visor's 5-min ticker drops ticks when its TPD auth contends with transport
+// re-registration under load), so a continuously-up visor may only land a
+// heartbeat every few slots. A heartbeat now plus one a short while ago means
+// the visor was up across the gap, so backfill the missed slots — BOUNDED by
+// maxHeartbeatBackfillSlots, and only within the same day (the timeline bitmap
+// is per-day). A larger gap is treated as a real absence and NOT credited. This
+// is what makes recorded uptime robust to under-delivery instead of collapsing
+// to ~30%.
+func backfillStartSlot(now, prev time.Time, prevSeen int64) int64 {
+	curSlot := currentTimelineSlot(now)
+	if prevSeen <= 0 || prev.Format("2006-01-02") != now.Format("2006-01-02") {
+		return curSlot
+	}
+	if prevSlot := currentTimelineSlot(prev); prevSlot < curSlot && curSlot-prevSlot <= maxHeartbeatBackfillSlots {
+		return prevSlot + 1 // prevSlot was already set by the earlier heartbeat
+	}
+	return curSlot
+}
+
 func (s *redisStore) RecordHeartbeat(ctx context.Context, pk cipher.PubKey, version string) error {
 	now := time.Now().UTC()
 	date := now.Format("2006-01-02")
 	pkHex := pk.Hex()
 	key := uptimeKey(pkHex, date)
+	tlKey := uptimeTimelineKey(pkHex, date)
+	curSlot := currentTimelineSlot(now)
+
+	// Set the current slot, plus any bounded backfill of slots missed since the
+	// previous heartbeat (flaky delivery — see backfillStartSlot).
+	startSlot := curSlot
+	if prevSeen, err := s.client.HGet(ctx, key, "last_seen").Int64(); err == nil {
+		startSlot = backfillStartSlot(now, time.Unix(prevSeen, 0).UTC(), prevSeen)
+	}
 
 	pipe := s.client.Pipeline()
 
@@ -137,9 +175,12 @@ func (s *redisStore) RecordHeartbeat(ctx context.Context, pk cipher.PubKey, vers
 	pipe.SAdd(ctx, uptimeOnlineKey(date), pkHex)
 	pipe.Expire(ctx, uptimeOnlineKey(date), 8*24*time.Hour)
 
-	// Set the current 5-minute slot in the timeline bitmap.
-	tlKey := uptimeTimelineKey(pkHex, date)
-	pipe.SetBit(ctx, tlKey, currentTimelineSlot(now), 1)
+	// Set the current 5-minute slot (plus any bounded backfill) in the timeline
+	// bitmap. SetBit is idempotent, so concurrent heartbeats for the same PK are
+	// harmless.
+	for slot := startSlot; slot <= curSlot; slot++ {
+		pipe.SetBit(ctx, tlKey, slot, 1)
+	}
 	pipe.Expire(ctx, tlKey, 8*24*time.Hour)
 
 	if _, err := pipe.Exec(ctx); err != nil {

--- a/pkg/transport-discovery/store/redis_uptime_backfill_test.go
+++ b/pkg/transport-discovery/store/redis_uptime_backfill_test.go
@@ -1,0 +1,57 @@
+// Package store pkg/transport-discovery/store/redis_uptime_backfill_test.go c4-tpd-uptime
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBackfillStartSlot covers the bounded heartbeat-backfill decision that
+// makes recorded uptime robust to flaky heartbeat delivery (the v1.3.89
+// ~30%-uptime regression). A heartbeat at `now` should backfill the timeline
+// bitmap from just after the previous heartbeat's slot, but only within
+// maxHeartbeatBackfillSlots and the same day.
+func TestBackfillStartSlot(t *testing.T) {
+	// A fixed reference time well inside a day: 12:30 UTC → slot 12*12 + 30/5 = 150.
+	base := time.Date(2026, 7, 28, 12, 30, 0, 0, time.UTC)
+	if got := currentTimelineSlot(base); got != 150 {
+		t.Fatalf("precondition: currentTimelineSlot(base) = %d, want 150", got)
+	}
+
+	cases := []struct {
+		name    string
+		prev    time.Time
+		prevOK  bool  // prevSeen > 0
+		wantSet int64 // expected first slot to set
+	}{
+		{"no prior heartbeat today", time.Time{}, false, 150},
+		{"same slot (2 heartbeats in one slot)", base.Add(-1 * time.Minute), true, 150},
+		{"one slot ago (healthy 5-min cadence)", base.Add(-5 * time.Minute), true, 150},       // prevSlot 149 → start 150
+		{"gap of 3 slots (dropped ticks) → backfill", base.Add(-15 * time.Minute), true, 148}, // prevSlot 147 → start 148
+		{"gap == cap (30 min) → backfill", base.Add(-30 * time.Minute), true, 145},            // prevSlot 144 → start 145
+		{"gap just over cap (35 min) → no backfill", base.Add(-35 * time.Minute), true, 150},  // prevSlot 143, gap 7 > 6
+		{"long outage (2h) → no backfill", base.Add(-2 * time.Hour), true, 150},               // real absence, not credited
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var prevSeen int64
+			if c.prevOK {
+				prevSeen = c.prev.Unix()
+			}
+			if got := backfillStartSlot(base, c.prev, prevSeen); got != c.wantSet {
+				t.Errorf("backfillStartSlot = %d, want %d", got, c.wantSet)
+			}
+		})
+	}
+}
+
+// TestBackfillStartSlot_CrossDay: a heartbeat just after midnight must not
+// backfill into the previous day's bitmap (the timeline key is per-day).
+func TestBackfillStartSlot_CrossDay(t *testing.T) {
+	now := time.Date(2026, 7, 28, 0, 5, 0, 0, time.UTC) // slot 1
+	prev := time.Date(2026, 7, 27, 23, 55, 0, 0, time.UTC)
+	if got := backfillStartSlot(now, prev, prev.Unix()); got != currentTimelineSlot(now) {
+		t.Errorf("cross-day backfillStartSlot = %d, want %d (no cross-day backfill)", got, currentTimelineSlot(now))
+	}
+}

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -53,7 +53,14 @@ func initSystemSurvey(_ context.Context, v *Visor, log *logging.Logger) error {
 }
 
 func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
-	const tickDuration = 5 * time.Minute
+	const (
+		tickDuration = 5 * time.Minute
+		// heartbeatSendTimeout bounds one heartbeat round so a slow or blocked
+		// send (the TPD auth can contend with transport re-registration under
+		// deployment load) can never stall the ticker and drop the next slot's
+		// heartbeat. Kept well under tickDuration so rounds never overlap.
+		heartbeatSendTimeout = 2 * time.Minute
+	)
 
 	// Resolve both targets. The standalone uptime-tracker URL may be absent
 	// (the tracker is decommissioned fleet-wide); the TPD heartbeat URL is the
@@ -98,14 +105,11 @@ func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
 			return
 		}
 
-		ticker := time.NewTicker(tickDuration)
-		v.pushCloseStack("uptime_tracker", func() error {
-			ticker.Stop()
-			return nil
-		})
-
-		for range ticker.C {
-			c := context.Background()
+		// sendHeartbeats fires one heartbeat round, bounded by heartbeatSendTimeout
+		// so a hung send can't run forever.
+		sendHeartbeats := func() {
+			c, cancel := context.WithTimeout(context.Background(), heartbeatSendTimeout)
+			defer cancel()
 			if ut != nil {
 				if err := ut.UpdateVisorUptime(c, v.conf.Version); err != nil {
 					log.WithError(err).Warn("Failed to update visor uptime (standalone tracker).")
@@ -126,6 +130,37 @@ func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
 					v.isUptimeTrackerHealthy.set()
 				}
 			}
+		}
+
+		ticker := time.NewTicker(tickDuration)
+		v.pushCloseStack("uptime_tracker", func() error {
+			ticker.Stop()
+			return nil
+		})
+
+		// Run each round in its own goroutine so a slow send never delays the
+		// ticker and drops the next slot's heartbeat — the tick-dropping that
+		// collapsed recorded uptime to ~30% for heartbeat-dependent visors. The
+		// semaphore skips a round when the previous one is still in flight so a
+		// wedged send can't pile up goroutines.
+		sem := make(chan struct{}, 1)
+		runRound := func() {
+			select {
+			case sem <- struct{}{}:
+				go func() {
+					defer func() { <-sem }()
+					sendHeartbeats()
+				}()
+			default:
+			}
+		}
+
+		// Fire immediately: a (re)started visor should register presence in the
+		// current slot instead of forfeiting the first full tick — every restart
+		// was silently losing 5 minutes of uptime.
+		runRound()
+		for range ticker.C {
+			runRound()
 		}
 	}()
 


### PR DESCRIPTION
## Problem (urgent — reward-affecting)

~half the fleet (v1.3.89-dominated) is recording **~30% uptime while actually up**, so it falls below the **75%** reward threshold → **no rewards**. Confirmed on a continuously-up visor recording 29.90%. The 25–35% cluster is 439/783 visors; the ≥75% (reward-eligible) group is dominated by *older* versions.

## Root cause: heartbeat UNDER-DELIVERY (not the server)

- The visor's 5-min uptime ticker (`init_services.go`) ran the send **inline**. A slow/blocked send — the TPD auth contends with the ~90s transport re-registration through the shared httpauth nonce (#3570), aggravated by TPD-host load — makes `time.Ticker` **drop ticks** → missed slots.
- Server `RecordHeartbeat` was correct (idempotent `SETBIT` of the current slot) but set **one slot per landed heartbeat**, so sparse delivery mapped 1:1 to sparse uptime.
- Transport-hub visors stayed at 100% only because their frequent re-registration *also* records slots; heartbeat-dependent / low-transport visors collapsed to ~30%. This is the fragility #3563 (restored the dedicated heartbeat) + #3570 (shared the nonce) exposed.

## Fix

**Visor side** (`pkg/visor/init_services.go`)
- Run each heartbeat round in its **own goroutine, bounded by a 2-min timeout**, so a slow send can never stall the ticker and drop the next slot (1-slot semaphore prevents goroutine pile-up).
- **Fire an immediate heartbeat on start** — restarts were forfeiting the first 5-min tick every time.

**Server side** (`pkg/transport-discovery/store/redis_store.go`)
- `RecordHeartbeat` now **backfills** timeline slots from the previous heartbeat to now, **bounded** to `maxHeartbeatBackfillSlots` (6 = 30 min) and same-day only — so flaky delivery still records a continuously-up visor at ~100%, while a genuine longer absence is **not** credited. Decision extracted to the pure, unit-tested `backfillStartSlot`.

## Tests / checks
- `TestBackfillStartSlot` (+ cross-day): no-prev / same-slot / healthy-cadence / dropped-ticks-backfill / cap-boundary / over-cap-no-credit / cross-day — all pass.
- `go build` + `go vet` + `golangci-lint` clean on both packages; existing visor tests pass.

## Rollout note
Deploy the TPD (server backfill) + ship the visor fix in the release. The reward uptime threshold can be temporarily lowered as a stopgap for already-affected days; rewards are forward-only so past days need explicit recalculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzckVqHX624RpdEWcvVosA