### PR TITLE
fix(appserver): reflection-free gob RPC on js (unwedge the TinyGo wasm-visor)

### DIFF
--- a/pkg/app/appserver/proc.go
+++ b/pkg/app/appserver/proc.go
@@ -186,7 +186,13 @@ func (p *Proc) InjectConn(conn net.Conn) bool {
 func (p *Proc) AwaitConn() bool {
 	<-p.connCh
 	rpcS := rpc.NewServer()
-	if err := rpcS.RegisterName(p.conf.ProcKey.String(), p.rpcGW); err != nil {
+	// registerIngressRPC is build-tagged: native registers the gateway via
+	// gobrpc/net-rpc's reflection-based RegisterName, while the TinyGo build
+	// registers each method as a reflection-free gobrpc HandleFunc — TinyGo's
+	// runtime reflect can't enumerate/invoke methods (reflect.Type.Method), so
+	// the reflection path panics and wedges the in-process app the browser
+	// wasm-visor launches. Same mechanism gobrpc uses for the visor edge RPC.
+	if err := registerIngressRPC(rpcS, p.conf.ProcKey.String(), p.rpcGW); err != nil {
 		panic(err)
 	}
 

--- a/pkg/app/appserver/proc_ingress_rpc_native.go
+++ b/pkg/app/appserver/proc_ingress_rpc_native.go
@@ -1,0 +1,15 @@
+//go:build !tinygo
+
+// Package appserver pkg/app/appserver/proc_ingress_rpc_native.go c2-vis-appsvc
+package appserver
+
+import (
+	rpc "github.com/skycoin/skywire/pkg/gobrpc"
+)
+
+// registerIngressRPC registers the ingress gateway on the native build using
+// gobrpc's (stdlib net/rpc) reflection-based RegisterName. See the TinyGo
+// variant for why the browser build needs a reflection-free registration.
+func registerIngressRPC(s *rpc.Server, name string, gw *RPCIngressGateway) error {
+	return s.RegisterName(name, gw)
+}

--- a/pkg/app/appserver/proc_ingress_rpc_tinygo.go
+++ b/pkg/app/appserver/proc_ingress_rpc_tinygo.go
@@ -1,0 +1,154 @@
+//go:build tinygo
+
+// Package appserver pkg/app/appserver/proc_ingress_rpc_tinygo.go c2-vis-appsvc
+package appserver
+
+import (
+	"encoding/gob"
+
+	"github.com/skycoin/skywire/pkg/app/appnet"
+	rpc "github.com/skycoin/skywire/pkg/gobrpc"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// registerIngressRPC registers each RPCIngressGateway method as a reflection-free
+// gobrpc HandleFunc. TinyGo's runtime reflect can't enumerate methods
+// (reflect.Type.Method) or invoke them (reflect.Value.Call), so gobrpc's
+// reflection-based RegisterName panics under TinyGo — wedging the in-process app
+// the browser wasm-visor launches (skychat etc.). Each handler decodes exactly
+// one gob argument value and calls the concrete method; the wire format is
+// identical to the reflection path, so the app-side gobrpc client is unchanged.
+// This mirrors how gobrpc registers the visor edge RPC on TinyGo.
+func registerIngressRPC(s *rpc.Server, name string, gw *RPCIngressGateway) error {
+	h := func(method string, fn rpc.HandlerFunc) { s.HandleFunc(name+"."+method, fn) }
+
+	h("SetDetailedStatus", func(dec *gob.Decoder) (interface{}, error) {
+		var a string
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetDetailedStatus(&a, &r)
+	})
+	h("SetOTP", func(dec *gob.Decoder) (interface{}, error) {
+		var a string
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetOTP(&a, &r)
+	})
+	h("SetConnectionDuration", func(dec *gob.Decoder) (interface{}, error) {
+		var a int64
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetConnectionDuration(a, &r)
+	})
+	h("SetError", func(dec *gob.Decoder) (interface{}, error) {
+		var a string
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetError(&a, &r)
+	})
+	h("SetAppPort", func(dec *gob.Decoder) (interface{}, error) {
+		var a routing.Port
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetAppPort(a, &r)
+	})
+	h("Dial", func(dec *gob.Decoder) (interface{}, error) {
+		var a appnet.Addr
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r DialResp
+		return &r, gw.Dial(&a, &r)
+	})
+	h("DialWithOptions", func(dec *gob.Decoder) (interface{}, error) {
+		var a DialOptionsReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r DialResp
+		return &r, gw.DialWithOptions(&a, &r)
+	})
+	h("Listen", func(dec *gob.Decoder) (interface{}, error) {
+		var a appnet.Addr
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r uint16
+		return &r, gw.Listen(&a, &r)
+	})
+	h("Accept", func(dec *gob.Decoder) (interface{}, error) {
+		var a uint16
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r AcceptResp
+		return &r, gw.Accept(&a, &r)
+	})
+	h("Write", func(dec *gob.Decoder) (interface{}, error) {
+		var a WriteReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r WriteResp
+		return &r, gw.Write(&a, &r)
+	})
+	h("Read", func(dec *gob.Decoder) (interface{}, error) {
+		var a ReadReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r ReadResp
+		return &r, gw.Read(&a, &r)
+	})
+	h("CloseConn", func(dec *gob.Decoder) (interface{}, error) {
+		var a uint16
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.CloseConn(&a, &r)
+	})
+	h("CloseListener", func(dec *gob.Decoder) (interface{}, error) {
+		var a uint16
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.CloseListener(&a, &r)
+	})
+	h("SetDeadline", func(dec *gob.Decoder) (interface{}, error) {
+		var a DeadlineReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetDeadline(&a, &r)
+	})
+	h("SetReadDeadline", func(dec *gob.Decoder) (interface{}, error) {
+		var a DeadlineReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetReadDeadline(&a, &r)
+	})
+	h("SetWriteDeadline", func(dec *gob.Decoder) (interface{}, error) {
+		var a DeadlineReq
+		if err := dec.Decode(&a); err != nil {
+			return nil, err
+		}
+		var r struct{}
+		return &r, gw.SetWriteDeadline(&a, &r)
+	})
+	return nil
+}


### PR DESCRIPTION
## Problem
The TinyGo wasm-visor renders the HV UI but its in-browser visor **wedges inside the HV SharedWorker** (`status()` hangs). The go variant boots fine in the same worker, and the *same* tinygo blob boots on the main thread — so it's tinygo-in-worker specific.

**Root cause (captured live via CDP):**
```
panic: unimplemented: (reflect.Type).Method()
  at (*appserver.Proc).startInProcess → AwaitConn → Register
```
`gobrpc` already ships a reflection-free RPC server for TinyGo (#3220), but the **app-server's in-process RPC was never migrated to it** — `Proc.AwaitConn` still calls `RegisterName(gateway)`, the reflection path. Under TinyGo, runtime reflect can't enumerate methods (`reflect.Type.Method`), so it panics the moment the visor launches an in-process app (skychat), trapping the goroutine and wedging the worker.

## Fix (mirrors gobrpc's edge-RPC pattern, build-tagged)
- **`proc_ingress_rpc_native.go`** (`!tinygo`): `RegisterName(gateway)` — unchanged reflection dispatch on native (gobrpc == stdlib net/rpc there).
- **`proc_ingress_rpc_tinygo.go`** (`tinygo`): each of the gateway's ~18 methods registered as a reflection-free **`gobrpc.HandleFunc`** (decode one gob arg → call the concrete method). Wire format identical, so the app-side gobrpc **client is unchanged**.
- `AwaitConn` calls `registerIngressRPC()`; native behavior untouched.

## Verification
`go build` native **and** `-tags tinygo` (GOOS=js) clean; `golangci-lint` clean (native); existing `RPCIngress` client/gateway tests pass on the native path. The tinygo-blob re-embed (which makes this take effect in-browser) + a live worker-boot check are a release-time step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzckVqHX624RpdEWcvVosA