### PR TITLE
fix(skyroute): deterministic ErrNoMux via yamux Ping liveness probe

### DIFF
--- a/pkg/skyroute/pool.go
+++ b/pkg/skyroute/pool.go
@@ -266,6 +266,15 @@ func openWithTimeout(ctx context.Context, sess *yamux.Session, d time.Duration) 
 	}
 	ch := make(chan res, 1)
 	go func() {
+		// A yamux round-trip is the definitive liveness probe: the far-end's yamux
+		// layer auto-answers the ping, so a destination not running a mux server (or
+		// a dead route) fails here. Open() alone is unreliable — it returns a stream
+		// optimistically before a dead session is noticed, which surfaced as a flaky
+		// ErrNoMux-vs-nil race under -race.
+		if _, perr := sess.Ping(); perr != nil {
+			ch <- res{nil, perr}
+			return
+		}
 		c, err := sess.Open()
 		ch <- res{c, err}
 	}()


### PR DESCRIPTION
## Problem

`TestPool_NoMuxFallbackAndNegativeCache` in `pkg/skyroute` is flaky under `-race` (fails a few runs in 30 — CI-red on `develop`): it expects `ErrNoMux` but sometimes gets `nil`.

## Root cause

`openWithTimeout` probes mux liveness with `yamux.Session.Open()`, which returns a stream **optimistically** — before yamux's recv loop notices the far end is dead. Against a destination that doesn't serve the mux forwarding port (or a dead route), `Open()` races: sometimes it returns the (dead) stream with `err == nil` instead of failing, so `ErrNoMux` — and the negative-cache entry that lets callers fall back cheaply — never happens.

This is a real correctness bug, not just a test artifact: in production the same race hands a caller a dead mux stream instead of falling back to a 1:1 dial.

## Fix

Probe with a yamux **round-trip** (`Session.Ping`) before `Open()`. The far end's yamux layer auto-answers pings, so a non-mux destination fails the ping deterministically. Costs:
- Dead `net.Pipe` (the test) → the ping's write fails immediately → test stays fast.
- Dead route (production) → bounded by the existing `firstStreamTimeout` (12s).
- Live mux far end → one extra round-trip before the first stream (negligible; only on cold open, not on the reused-session hot path).

## Verification

- `go test ./pkg/skyroute/ -run TestPool_NoMuxFallbackAndNegativeCache -race -count=50` → 50/50 pass (was ~3/30 failing).
- `go test ./pkg/skyroute/ -race -count=5` (full package) → green; reuse + idle-TTL-reclaim tests unaffected.
- `golangci-lint run pkg/skyroute/...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzckVqHX624RpdEWcvVosA