### PR TITLE
test(dmsg,wasmhv): Tier A headless browser-edge regression gate + `mdisc check` wss health probe

### DIFF
--- a/.github/workflows/deployment-health.yml
+++ b/.github/workflows/deployment-health.yml
@@ -1,0 +1,31 @@
+# Scheduled deployment-health probe: every dmsg server's advertised wss front
+# must actually serve (correct DNS, valid TLS cert, 426 to a plain HTTP/1.1
+# GET). Browser/wasm visors can ONLY bootstrap over wss, so a broken front
+# silently shrinks the browser-reachable deployment — exactly what happened
+# 2026-07-30 (2 stale DNS records + 1 failed cert issuance, invisible until
+# client-side carrier fixes surfaced them). This job turns that class of
+# breakage into a red scheduled run instead of a support mystery.
+#
+# Uses the clearnet discovery mirror (a CI runner has no dmsg visor); operators
+# run the same probe locally with plain `skywire cli mdisc check` (dmsg-native).
+name: Deployment health
+
+on:
+  schedule:
+    - cron: '17 */6 * * *' # every 6 hours
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  dmsg-wss-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+      - name: Probe dmsg-server wss fronts
+        run: go run ./cmd/skywire cli mdisc check --url https://dmsgd.skywire.dev

--- a/cmd/skywire-cli/commands/mdisc/check.go
+++ b/cmd/skywire-cli/commands/mdisc/check.go
@@ -1,0 +1,203 @@
+// Package climdisc cmd/skywire-cli/commands/mdisc/check.go c2-ops-deployment
+//
+// `skywire cli mdisc check` — deployment health probe for the dmsg-server wss
+// fronts. A browser/wasm visor can ONLY bootstrap over wss (the seed entry
+// carries just AddressWS; WebTransport is a phase-2 trade-up whose ~2-week
+// self-signed cert can't be pinned in advance), so every server that
+// advertises an AddressWS must actually terminate it: correct DNS, valid TLS
+// certificate, and the WebSocket endpoint answering 426 Upgrade Required to a
+// plain HTTP/1.1 GET.
+//
+// This is the check that would have auto-caught the 2026-07-30 breakage where
+// three servers advertised wss fronts that didn't serve: two with stale DNS
+// pointing at a decommissioned shared proxy (dead :443) and one with a failed
+// cert issuance — all masked, before the carrier-capability fix, as futile
+// `dial tcp` errors on the client. Runs anywhere with clearnet https (CI
+// included): the server list comes from the discovery's /all_servers endpoint
+// and each probe is a plain HTTPS request.
+package climdisc
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+var (
+	checkTimeout  time.Duration
+	checkWarnOnly bool
+)
+
+func init() {
+	RootCmd.AddCommand(checkCmd)
+	checkCmd.Flags().StringVar(&mdURL, "url", getDeployment().DmsgDiscovery, "specify alternative DMSG discovery url")
+	checkCmd.Flags().DurationVar(&checkTimeout, "timeout", 15*time.Second, "per-server probe timeout")
+	checkCmd.Flags().BoolVar(&checkWarnOnly, "warn-only", false, "always exit 0 (report problems without failing)")
+}
+
+var checkCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Probe every dmsg server's advertised wss front (DNS, TLS cert, 426)",
+	Long: `Probe the health of every dmsg server registered in discovery.
+
+For each server entry:
+  - flags a missing AddressWS (the server is unreachable for browser/wasm
+    visors, which can only bootstrap over wss);
+  - resolves the wss host and warns when it doesn't cover the server's own
+    IP (a legitimate shared TLS front also looks like this — warning only —
+    but a STALE record pointing at a dead host is exactly how two servers
+    silently dropped off the browser-reachable set);
+  - performs a plain HTTP/1.1 GET of the endpoint with normal TLS
+    verification, expecting 426 Upgrade Required (what a healthy unified
+    dmsg-server WS front answers to a non-upgrade request).
+
+Exits nonzero if any ADVERTISED wss front fails its probe, so it can gate a
+scheduled CI job.`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		entries, err := fetchAllServersAny(cmd, mdURL)
+		if err != nil {
+			return fmt.Errorf("fetch %s/dmsg-discovery/all_servers: %w", mdURL, err)
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("discovery returned no dmsg servers")
+		}
+
+		failed := 0
+		for _, e := range entries {
+			if e.Server == nil {
+				continue
+			}
+			label := e.Static.String()[:8]
+			ws := e.Server.AddressWS
+			if ws == "" {
+				cmd.Printf("!  %s  %-21s  NO AddressWS — unreachable for browser/wasm visors\n", label, e.Server.Address)
+				continue
+			}
+			if warn := dnsMismatch(ws, e.Server.Address); warn != "" {
+				cmd.Printf("~  %s  %s\n", label, warn)
+			}
+			if perr := probeWS(ws, checkTimeout); perr != nil {
+				failed++
+				cmd.Printf("✗  %s  %-21s  %s: %v\n", label, e.Server.Address, ws, perr)
+				continue
+			}
+			cmd.Printf("✓  %s  %-21s  %s\n", label, e.Server.Address, ws)
+		}
+
+		cmd.Printf("%d servers, %d advertised wss fronts failing\n", len(entries), failed)
+		if failed > 0 && !checkWarnOnly {
+			return fmt.Errorf("%d dmsg server(s) advertise a wss front that does not serve", failed)
+		}
+		return nil
+	},
+}
+
+// fetchAllServersAny fetches the server list over whichever transport the
+// discovery URL calls for: a dmsg:// URL (the dmsg-only deployment default)
+// goes through the CLI's resolving fetch — same path the entries listing uses,
+// needs a reachable visor; an http(s):// URL is fetched directly, which is
+// what a CI box without a visor passes (e.g. --url https://dmsgd.skywire.dev).
+func fetchAllServersAny(cmd *cobra.Command, base string) ([]*disc.Entry, error) {
+	if strings.HasPrefix(base, "dmsg://") {
+		full := strings.TrimRight(base, "/") + "/dmsg-discovery/all_servers"
+		body := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirDMSGD, full), full, cacheFilesAge)
+		if strings.TrimSpace(body) == "" {
+			return nil, fmt.Errorf("empty response over dmsg (no reachable visor? pass --url https://<clearnet discovery>)")
+		}
+		var entries []*disc.Entry
+		if err := json.Unmarshal([]byte(body), &entries); err != nil {
+			return nil, err
+		}
+		return entries, nil
+	}
+	return fetchAllServers(base)
+}
+
+// fetchAllServers reads the discovery's full server list over plain https —
+// no dmsg client needed, so this runs on any CI box.
+func fetchAllServers(base string) ([]*disc.Entry, error) {
+	cl := &http.Client{Timeout: 30 * time.Second}
+	resp, err := cl.Get(strings.TrimRight(base, "/") + "/dmsg-discovery/all_servers")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	b, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	var entries []*disc.Entry
+	if err := json.Unmarshal(b, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// probeWS GETs the ws/wss endpoint as https/http over HTTP/1.1 (h2 rejects the
+// WS Upgrade header a unified server emits, and real browser WebSocket dials
+// are HTTP/1.1) with default TLS verification, expecting 426 Upgrade Required.
+func probeWS(wsURL string, timeout time.Duration) error {
+	httpURL := wsURL
+	switch {
+	case strings.HasPrefix(wsURL, "wss://"):
+		httpURL = "https://" + strings.TrimPrefix(wsURL, "wss://")
+	case strings.HasPrefix(wsURL, "ws://"):
+		httpURL = "http://" + strings.TrimPrefix(wsURL, "ws://")
+	}
+	cl := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// Force HTTP/1.1: an empty TLSNextProto disables h2 ALPN.
+			TLSNextProto:      map[string]func(string, *tls.Conn) http.RoundTripper{},
+			ForceAttemptHTTP2: false,
+		},
+	}
+	resp, err := cl.Get(httpURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusUpgradeRequired {
+		return fmt.Errorf("status %d, want 426 Upgrade Required", resp.StatusCode)
+	}
+	return nil
+}
+
+// dnsMismatch resolves the wss host and reports (as a warning string, "" for
+// ok) when none of its addresses is the server's own advertised IP. A shared
+// TLS front legitimately triggers this; a stale record pointing at a
+// decommissioned host is the failure mode it exists to surface.
+func dnsMismatch(wsURL, serverAddr string) string {
+	u, err := url.Parse(strings.Replace(strings.Replace(wsURL, "wss://", "https://", 1), "ws://", "http://", 1))
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	serverHost, _, err := net.SplitHostPort(serverAddr)
+	if err != nil {
+		serverHost = serverAddr
+	}
+	ips, err := net.LookupHost(u.Hostname())
+	if err != nil {
+		return fmt.Sprintf("wss host %s does not resolve: %v", u.Hostname(), err)
+	}
+	for _, ip := range ips {
+		if ip == serverHost {
+			return ""
+		}
+	}
+	return fmt.Sprintf("wss host %s resolves to %v — not the server's own address %s (shared front, or a stale record)", u.Hostname(), ips, serverHost)
+}

--- a/pkg/dmsg/dmsg/browser_edge_test.go
+++ b/pkg/dmsg/dmsg/browser_edge_test.go
@@ -1,0 +1,290 @@
+// Package dmsg pkg/dmsg/dmsg/browser_edge_test.go c1-net-dmsg
+//
+// Headless "browser edge" regression suite (Tier A of the wasm-visor test
+// plan): a wss-only dmsg client — the browser/wasm-visor profile
+// (Carriers=[ws], no raw TCP) — exercised against real in-process dmsg
+// servers, NO browser involved. Locks the on-demand rendezvous model the wasm
+// visor depends on:
+//
+//   - a peer is reached by opening an on-demand session to one of THAT peer's
+//     delegated servers over a carrier the client can actually dial;
+//   - a server the client CANNOT dial (tcp-only) fails cleanly and the dial
+//     moves on to the peer's next server — never a futile raw-TCP fallback
+//     (the #3634 regression: gating every TCP/QUIC fallback on hasCarrier);
+//   - ConnectToAllServers reports per-server results with capability-honest
+//     errors (the #3632 "connect to all servers" surface).
+//
+// The capability invariant asserted throughout: a Carriers=[ws] client NEVER
+// holds a session whose carrier is anything but ws — even when a server
+// advertises a perfectly reachable TCP endpoint (in these tests the TCP
+// listeners are real and dialable, which is exactly what made the old
+// Address!="" fallback a capability violation rather than a dead dial).
+package dmsg
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// testServer is one in-process dmsg server plus its discovery entry.
+type testServer struct {
+	pk    cipher.PubKey
+	srv   *Server
+	entry *disc.Entry
+}
+
+// startTestServer stands up a dmsg server on a loopback listener and posts its
+// discovery entry. withWS serves the unified TCP+WS single port (ServeWithWS)
+// and advertises AddressWS; otherwise it is a plain TCP-only server (no
+// AddressWS in the entry — undialable for a wss-only client BY CONTRACT, even
+// though the TCP listener itself is live and reachable).
+func startTestServer(t *testing.T, dc disc.APIClient, name string, withWS bool) *testServer {
+	t.Helper()
+	const maxSessions = 10
+
+	pk, sk := GenKeyPair(t, name)
+	srv := NewServer(pk, sk, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger(name))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	tcpAddr := lis.Addr().String()
+
+	entry := disc.NewServerEntry(pk, 0, tcpAddr, maxSessions)
+	if withWS {
+		entry.Server.AddressWS = "ws://" + tcpAddr + wsPath
+	}
+	require.NoError(t, entry.Sign(sk))
+	require.NoError(t, dc.PostEntry(context.Background(), entry))
+
+	go func() {
+		if withWS {
+			_ = srv.ServeWithWS(lis, tcpAddr, entry.Server.AddressWS) //nolint:errcheck
+		} else {
+			_ = srv.Serve(lis, tcpAddr) //nolint:errcheck
+		}
+	}()
+	t.Cleanup(func() { _ = srv.Close() }) //nolint:errcheck
+
+	select {
+	case <-srv.Ready():
+	case <-time.After(10 * time.Second):
+		t.Fatalf("server %s never became ready", name)
+	}
+	return &testServer{pk: pk, srv: srv, entry: entry}
+}
+
+// newPinnedClient builds a client with the given carriers, pre-establishes
+// sessions to exactly the given servers (EnsureSession before Serve, so the
+// maintenance loop sees MinSessions satisfied and dials nothing else), then
+// runs Serve so the client publishes its entry (delegated servers = pinned
+// set) and accepts streams.
+func newPinnedClient(t *testing.T, dc disc.APIClient, name string, carriers []string, pin ...*testServer) *Client {
+	t.Helper()
+	conf := DefaultConfig()
+	conf.MinSessions = 1
+	conf.Carriers = carriers
+	pk, sk := GenKeyPair(t, name)
+	c := NewClient(pk, sk, dc, conf)
+	c.SetLogger(logging.MustGetLogger(name))
+	for _, s := range pin {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := c.EnsureSession(ctx, s.entry)
+		cancel()
+		require.NoErrorf(t, err, "%s: EnsureSession to pinned server", name)
+	}
+	go c.Serve(context.Background())
+	t.Cleanup(func() { _ = c.Close() }) //nolint:errcheck
+	return c
+}
+
+// requireCarriersOnly asserts the capability invariant: every session the
+// client holds uses one of the allowed carriers.
+func requireCarriersOnly(t *testing.T, c *Client, allowed ...string) {
+	t.Helper()
+	ok := map[string]bool{}
+	for _, a := range allowed {
+		ok[a] = true
+	}
+	for _, s := range c.AllSessions() {
+		require.Truef(t, ok[s.Carrier()],
+			"capability violation: session to %s uses carrier %q (allowed: %v)",
+			s.RemotePK(), s.Carrier(), allowed)
+	}
+}
+
+// dialEventually dials A→B:port, retrying while B's entry propagates.
+func dialEventually(t *testing.T, a *Client, b cipher.PubKey, port uint16) *Stream {
+	t.Helper()
+	var st *Stream
+	require.Eventually(t, func() bool {
+		var err error
+		st, err = a.DialStream(context.TODO(), Addr{PK: b, Port: port})
+		return err == nil
+	}, 20*time.Second, 250*time.Millisecond, "DialStream never succeeded")
+	return st
+}
+
+// echoOnce round-trips a payload A→B over a fresh stream.
+func echoOnce(t *testing.T, st *Stream, lis *Listener) {
+	t.Helper()
+	defer st.Close() //nolint:errcheck
+	conn, err := lis.Accept()
+	require.NoError(t, err)
+	defer conn.Close() //nolint:errcheck
+	payload := cipher.RandByte(1024)
+	go func() { _, _ = st.Write(payload) }() //nolint:errcheck
+	got := make([]byte, len(payload))
+	_, err = io.ReadFull(conn, got)
+	require.NoError(t, err)
+	require.Equal(t, payload, got)
+}
+
+// TestBrowserEdge_RendezvousOverWS: a wss-only client bootstrapped to server
+// S1 reaches a peer delegated ONLY to server S2 by opening an on-demand WS
+// session to S2 — the exact reachability model a browser visor lives on (it
+// never "connects to all servers"; it rendezvouses per peer).
+func TestBrowserEdge_RendezvousOverWS(t *testing.T) {
+	dc := disc.NewMock(0)
+	s1 := startTestServer(t, dc, "srv1-ws", true)
+	s2 := startTestServer(t, dc, "srv2-ws", true)
+
+	peer := newPinnedClient(t, dc, "peer-native", nil, s2) // native carriers, on S2 only
+	edge := newPinnedClient(t, dc, "edge-wss", []string{CarrierWS}, s1)
+
+	const port = 8080
+	lis, err := peer.Listen(port)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	st := dialEventually(t, edge, peer.LocalPK(), port)
+	echoOnce(t, st, lis)
+
+	// The dial must have opened an on-demand session to S2 — over WS.
+	_, onS2 := edge.Session(s2.pk)
+	require.True(t, onS2, "edge should hold an on-demand session to the peer's delegated server")
+	requireCarriersOnly(t, edge, CarrierWS)
+	_ = s1
+}
+
+// TestBrowserEdge_NeverFallsBackToTCP (regression #3634): the peer's FIRST
+// delegated server is tcp-only (live, dialable TCP — but no wss). The
+// wss-only edge must fail that server cleanly and rendezvous via the peer's
+// second (unified) server, ending with ws-only sessions. Before the fix, the
+// carrier fallback dialed the tcp-only server's real TCP endpoint and
+// SUCCEEDED — a capability violation that in a real browser turned into a
+// futile `dial tcp` dead-end (dmsg error 202).
+func TestBrowserEdge_NeverFallsBackToTCP(t *testing.T) {
+	dc := disc.NewMock(0)
+	sTCP := startTestServer(t, dc, "srv-tcponly", false)
+	sWS := startTestServer(t, dc, "srv-unified", true)
+	sBoot := startTestServer(t, dc, "srv-boot", true)
+
+	peer := newPinnedClient(t, dc, "peer-native2", nil, sTCP, sWS)
+	edge := newPinnedClient(t, dc, "edge-wss2", []string{CarrierWS}, sBoot)
+
+	const port = 8081
+	lis, err := peer.Listen(port)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	// Pin the peer's delegated-server ORDER: tcp-only first, so the edge's
+	// rendezvous deterministically attempts the undialable server before the
+	// dialable one. Wait only for the peer's entry to EXIST (the client's
+	// initial publish may list just the first pinned session; its refresh
+	// interval is long), then overwrite it with the explicit two-server order —
+	// the manual entry is the source of truth for the dial under test.
+	require.Eventually(t, func() bool {
+		e, err := dc.Entry(context.Background(), peer.LocalPK())
+		return err == nil && e.Client != nil && len(e.Client.DelegatedServers) >= 1
+	}, 15*time.Second, 200*time.Millisecond, "peer entry never published")
+	e, err := dc.Entry(context.Background(), peer.LocalPK())
+	require.NoError(t, err)
+	e.Client.DelegatedServers = []cipher.PubKey{sTCP.pk, sWS.pk}
+	e.Sequence++
+	require.NoError(t, e.Sign(peer.LocalSK()))
+	require.NoError(t, dc.PutEntry(context.Background(), peer.LocalSK(), e))
+
+	st := dialEventually(t, edge, peer.LocalPK(), port)
+	echoOnce(t, st, lis)
+
+	// The invariant that failed before #3634: no session on any carrier but ws,
+	// and in particular NO session to the tcp-only server.
+	requireCarriersOnly(t, edge, CarrierWS)
+	_, onTCPOnly := edge.Session(sTCP.pk)
+	require.False(t, onTCPOnly, "wss-only edge must never hold a session to a tcp-only server")
+	_, onWS := edge.Session(sWS.pk)
+	require.True(t, onWS, "edge should have rendezvoused via the unified (ws) server")
+}
+
+// TestBrowserEdge_TCPOnlyPeerUnreachableCleanly: a peer delegated ONLY to a
+// tcp-only server is honestly unreachable for a wss-only edge — the dial
+// errors (rather than sneaking a TCP session) and the edge's session set stays
+// ws-only. This is the "surface a clear error so deployment problems are
+// visible" half of the fix: masking it as TCP kept 3 broken wss fronts hidden
+// in production.
+func TestBrowserEdge_TCPOnlyPeerUnreachableCleanly(t *testing.T) {
+	dc := disc.NewMock(0)
+	sTCP := startTestServer(t, dc, "srv-tcponly2", false)
+	sBoot := startTestServer(t, dc, "srv-boot2", true)
+
+	peer := newPinnedClient(t, dc, "peer-native3", nil, sTCP)
+	edge := newPinnedClient(t, dc, "edge-wss3", []string{CarrierWS}, sBoot)
+
+	const port = 8082
+	lis, err := peer.Listen(port)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	// Wait for the peer's entry (delegated=[sTCP]) so the dial fails on the
+	// carrier contract, not on entry propagation.
+	require.Eventually(t, func() bool {
+		e, eerr := dc.Entry(context.Background(), peer.LocalPK())
+		return eerr == nil && e.Client != nil && len(e.Client.DelegatedServers) == 1
+	}, 15*time.Second, 200*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	_, err = edge.DialStream(ctx, Addr{PK: peer.LocalPK(), Port: port})
+	require.Error(t, err, "wss-only edge must NOT reach a peer that is only on a tcp-only server")
+	requireCarriersOnly(t, edge, CarrierWS)
+	_, onTCPOnly := edge.Session(sTCP.pk)
+	require.False(t, onTCPOnly)
+}
+
+// TestBrowserEdge_ConnectToAllServers (#3632 surface): the one-shot
+// maximize-connectivity action honors the carrier contract per server — ws
+// servers connect over ws, the tcp-only server FAILS with a clear error
+// instead of silently connecting over a carrier the client doesn't have.
+func TestBrowserEdge_ConnectToAllServers(t *testing.T) {
+	dc := disc.NewMock(0)
+	s1 := startTestServer(t, dc, "ca-srv1-ws", true)
+	s2 := startTestServer(t, dc, "ca-srv2-ws", true)
+	s3 := startTestServer(t, dc, "ca-srv3-tcponly", false)
+
+	edge := newPinnedClient(t, dc, "edge-wss4", []string{CarrierWS}, s1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	res, err := edge.ConnectToAllServers(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, res.Total, "all discovery servers should be enumerated")
+	require.Equal(t, 1, res.AlreadyConnected)
+	require.Equal(t, 1, res.NewlyConnected, "only the second ws server is newly connectable")
+	require.Len(t, res.Failed, 1)
+	require.Contains(t, res.Failed, s3.pk, "the tcp-only server must FAIL for a wss-only client, not silently connect over tcp")
+
+	_, onS2 := edge.Session(s2.pk)
+	require.True(t, onS2)
+	requireCarriersOnly(t, edge, CarrierWS)
+}

--- a/pkg/dmsg/dmsgclient/fallback_disc_test.go
+++ b/pkg/dmsg/dmsgclient/fallback_disc_test.go
@@ -1,0 +1,99 @@
+// Package dmsgclient pkg/dmsg/dmsgclient/fallback_disc_test.go c1-net-dmsg
+//
+// Locks the fallbackDiscClient server-enumeration contract (the discovery half
+// of the wasm-visor 202-rendezvous fix): AllServers must PREFER the live
+// discovery — a seeded browser edge otherwise stays pinned to its 2 seed
+// servers forever and can never rendezvous with peers delegated elsewhere —
+// while AvailableServers stays on the direct (seed) client, because it is the
+// boot / session-maintenance path and must never block on a discovery that is
+// only reachable once dmsg is up.
+package dmsgclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// stubDisc implements only the EntryReader surface the tests exercise; the
+// embedded interface makes any un-stubbed call an explicit panic.
+type stubDisc struct {
+	disc.APIClient
+	all       []*disc.Entry
+	allErr    error
+	available []*disc.Entry
+}
+
+func (s *stubDisc) AllServers(context.Context) ([]*disc.Entry, error) { return s.all, s.allErr }
+func (s *stubDisc) AvailableServers(context.Context) ([]*disc.Entry, error) {
+	return s.available, nil
+}
+
+func serverEntries(n int) []*disc.Entry {
+	out := make([]*disc.Entry, n)
+	for i := range out {
+		pk, _ := cipher.GenerateKeyPair()
+		out[i] = &disc.Entry{Static: pk, Server: &disc.Server{Address: "127.0.0.1:1"}}
+	}
+	return out
+}
+
+func TestFallbackDisc_AllServersPrefersLiveDiscovery(t *testing.T) {
+	seeds := serverEntries(2)
+	live := serverEntries(9)
+	f := NewRegisteringFallbackDiscClient(
+		&stubDisc{all: seeds, available: seeds},
+		&stubDisc{all: live},
+		logging.MustGetLogger("test"),
+	)
+
+	got, err := f.AllServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 9, "AllServers must return the LIVE deployment set, not the 2 seeds")
+}
+
+func TestFallbackDisc_AllServersFallsBackToSeedsOnLiveFailure(t *testing.T) {
+	seeds := serverEntries(2)
+	f := NewRegisteringFallbackDiscClient(
+		&stubDisc{all: seeds, available: seeds},
+		&stubDisc{allErr: errors.New("discovery unreachable")},
+		logging.MustGetLogger("test"),
+	)
+
+	got, err := f.AllServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2, "on live-discovery failure the seed set keeps the client functional")
+}
+
+func TestFallbackDisc_AllServersFallsBackToSeedsOnEmptyLive(t *testing.T) {
+	seeds := serverEntries(2)
+	f := NewRegisteringFallbackDiscClient(
+		&stubDisc{all: seeds, available: seeds},
+		&stubDisc{all: nil},
+		logging.MustGetLogger("test"),
+	)
+
+	got, err := f.AllServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+}
+
+func TestFallbackDisc_AvailableServersStaysDirect(t *testing.T) {
+	seeds := serverEntries(2)
+	live := serverEntries(9)
+	f := NewRegisteringFallbackDiscClient(
+		&stubDisc{all: seeds, available: seeds},
+		&stubDisc{all: live, available: live},
+		logging.MustGetLogger("test"),
+	)
+
+	got, err := f.AvailableServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2, "AvailableServers is the boot path — it must answer from the direct/seed client without touching the live discovery")
+}

--- a/pkg/wasmhv/self_test.go
+++ b/pkg/wasmhv/self_test.go
@@ -155,3 +155,34 @@ func TestSelf_NodePageSubroutes(t *testing.T) {
 		t.Fatalf("runtime-logs since not threaded: got %d, want 42", gotSince)
 	}
 }
+
+// TestSelf_DmsgConnectAllRoute locks the "Connect to all servers" endpoint the
+// wasm core serves for the shared HV UI (it 404'd before #3632, so the button
+// errored on every browser visor): POST dispatches to the provider and returns
+// its result; other methods are rejected rather than silently no-oping.
+func TestSelf_DmsgConnectAllRoute(t *testing.T) {
+	pk := newSelfPK(t)
+	core := NewCore(pk, nil)
+	core.SetSelf(fakeSelf{pk: pk})
+
+	base := "/api/visors/" + pk.Hex()
+	status, body := core.ServeHTTP("POST", base+"/dmsg/connect-all", nil)
+	if status != 200 {
+		t.Fatalf("POST dmsg/connect-all status = %d (body %s)", status, body)
+	}
+	var res struct {
+		Total            *int `json:"total"`
+		AlreadyConnected *int `json:"already_connected"`
+		NewlyConnected   *int `json:"newly_connected"`
+	}
+	if err := json.Unmarshal(body, &res); err != nil {
+		t.Fatalf("connect-all body not the DmsgConnectAllResult shape: %v (%s)", err, body)
+	}
+	if res.Total == nil || res.AlreadyConnected == nil || res.NewlyConnected == nil {
+		t.Fatalf("connect-all result missing fields: %s", body)
+	}
+
+	if status, _ := core.ServeHTTP("GET", base+"/dmsg/connect-all", nil); status != 405 {
+		t.Fatalf("GET dmsg/connect-all status = %d, want 405", status)
+	}
+}


### PR DESCRIPTION
## Tier A of the wasm-visor testing plan

The browser profile — a **wss-only dmsg client** (`Carriers=[ws]`) — exercised **headlessly** against real in-process dmsg servers: no browser, ordinary `go test`, CI-gating. Locks everything the recent reachability campaign fixed:

**`pkg/dmsg/dmsg/browser_edge_test.go`** — 4 e2e regressions on the on-demand rendezvous model:
1. reach a peer delegated to a *different* server via an on-demand ws session;
2. **never fall back to TCP** — the peer's first delegated server is tcp-only and *live/dialable* (the pre-#3634 fallback would happily connect to it — the capability violation that showed up in browsers as futile `dial tcp` → `dmsg error 202`); the dial must skip it cleanly and rendezvous via the next server, ending with ws-only sessions;
3. a peer only on a tcp-only server is honestly unreachable (clear error, no sneaked tcp session);
4. `ConnectToAllServers` (#3632) honors the carrier contract per server (ws connect; tcp-only lands in `Failed`).

**`pkg/dmsg/dmsgclient/fallback_disc_test.go`** — `AllServers` prefers the **live** discovery (seeded edge must learn the whole deployment, not stay pinned to 2 seeds), seed-fallback on failure/empty; `AvailableServers` stays direct (boot path never blocks on a not-yet-reachable discovery).

**`pkg/wasmhv/self_test.go`** — the wasm core's `POST /dmsg/connect-all` route returns the `DmsgConnectAllResult` shape; `GET` → 405.

## `skywire cli mdisc check` + scheduled CI

The operator-requested probe that would have auto-caught the 2026-07-30 wss breakage (2 stale DNS records pointing at a dead shared proxy + 1 failed cert issuance). For every discovery server's advertised `AddressWS`: DNS cross-check vs the server's own address (warning — shared fronts are legitimate), then a plain **HTTP/1.1** GET with normal TLS verification expecting **426 Upgrade Required**; exits nonzero when an advertised front doesn't serve. `dmsg://` discovery URLs use the CLI's resolving fetch (local visor); `http(s)://` is fetched directly (CI). Scheduled workflow (`deployment-health.yml`, 6-hourly + manual) probes via the clearnet mirror.

**Live run against the deployment right now: `9 servers, 0 advertised wss fronts failing`** ✓

`golangci-lint` 0 issues; all suites green.