### PR TITLE
test(wasm): Tier B headless smoke — run the REAL wasm-visor blob under Node (no browser)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,6 +217,32 @@ jobs:
       - name: Compile-check js/wasm binaries
         run: make build-wasm
 
+  # Headless RUNTIME smoke of the real wasm-visor blob (Tier B of the
+  # wasm-visor test plan): Node ≥22 executes the compiled js/wasm binary via
+  # Go's wasm_exec.js — no browser — boots the visor against a loopback dmsg
+  # server started by the script, and asserts the browser-critical path: boot →
+  # ws dmsg session → dmsg_connected → the in-wasm hypervisor /api core
+  # answering. The compile-check above can't catch runtime-only breakage
+  # (boot-glue regressions, carrier selection, the /api dispatch); this does.
+  wasm-headless:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+          cache-dependency-path: go.sum
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Headless wasm-visor smoke (boot → dmsg(ws) → /api)
+        run: ./scripts/wasm-headless/run.sh
+
   # TinyGo lane. Several wasm binaries are ALSO built with TinyGo for the
   # embedded/browser targets (smaller output, no crypto/tls): the dmsg IoT
   # probe (wasip1), the tpviz/dmsg-wasm/wasm-visor browser edges (wasm), and

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,9 @@ tinygo-wasm-visor: ## Build the FULL browser WASM visor (dmsg+transport+router+a
 	cp ./pkg/wasmhv/worker.js ./build/wasm-visor/
 	@echo "built ./build/wasm-visor (TinyGo fork) — serve it: 'go run cmd/dmsg-wasm/serve.go -dir build/wasm-visor' then open http://localhost:8085/"
 
+test-wasm-headless: ## Tier B headless smoke: run the REAL compiled wasm-visor blob under Node (no browser) against a loopback dmsg server — boot → ws dmsg session → /api core. Needs node >= 22.
+	./scripts/wasm-headless/run.sh
+
 wasm-visor: ## Build the browser WASM visor edge with STANDARD Go js/wasm into build/wasm-visor-go — larger (~38MB) but full crypto/tls + net/http (https clearnet via skysocks). Does NOT touch the committed embed blob.
 	mkdir -p ./build/wasm-visor-go
 	GOOS=js GOARCH=wasm go build -buildvcs=false -ldflags="$(WASM_BUILDINFO) -s -w" -o ./build/wasm-visor-go/wasm-visor.wasm ./cmd/wasm-visor

--- a/scripts/wasm-headless/harness.mjs
+++ b/scripts/wasm-headless/harness.mjs
@@ -1,0 +1,78 @@
+// scripts/wasm-headless/harness.mjs — Tier B headless smoke of the REAL
+// compiled wasm-visor blob, no browser: Node (≥22, for the global WebSocket)
+// runs Go's wasm_exec.js, instantiates build/wasm-visor-go/wasm-visor.wasm,
+// boots the visor against a local dmsg server's ws:// seed, and asserts the
+// critical path the browser depends on: boot → wss/ws dmsg session →
+// dmsg_connected → the in-wasm hypervisor /api core answering.
+//
+// The ONLY browser global the critical path needs is WebSocket (native in
+// Node ≥22). Optional surfaces (WebTransport, WebRTC, localStorage) degrade
+// gracefully and are exercised by the in-browser CDP tests instead.
+//
+// Usage: node harness.mjs <wasm> <wasm_exec.js> <seedPkHex> <seedWsURL>
+// Exit 0 on success; 1 with diagnostics on failure/timeout.
+
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const [wasmPath, execPath, seedPk, seedWs] = process.argv.slice(2);
+if (!wasmPath || !execPath || !seedPk || !seedWs) {
+  console.error('usage: node harness.mjs <wasm> <wasm_exec.js> <seedPkHex> <seedWsURL>');
+  process.exit(2);
+}
+
+const BOOT_TIMEOUT_MS = 90_000;
+const die = (msg) => { console.error('FAIL:', msg); process.exit(1); };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// wasm_exec.js is a classic script that attaches `Go` to globalThis.
+vm.runInThisContext(fs.readFileSync(execPath, 'utf8'), { filename: 'wasm_exec.js' });
+
+const go = new globalThis.Go();
+const { instance } = await WebAssembly.instantiate(fs.readFileSync(wasmPath), go.importObject);
+go.run(instance).then(
+  () => console.error('note: wasm program exited'),
+  (e) => die(`wasm program crashed: ${e}`),
+);
+
+// The program registers globalThis.skywireVisor once its main() sets up.
+const deadline = Date.now() + BOOT_TIMEOUT_MS;
+while (typeof globalThis.skywireVisor?.boot !== 'function') {
+  if (Date.now() > deadline) die('skywireVisor.boot never appeared');
+  await sleep(100);
+}
+console.log('wasm loaded; skywireVisor API present');
+
+// Boot with a fresh key against the local seed; empty disc ⇒ the deployment
+// default is tried and degrades to seed-only (non-fatal) in this offline run.
+const pk = await globalThis.skywireVisor.boot('', seedPk, seedWs, '');
+console.log('booted as', pk);
+if (!/^[0-9a-f]{66}$/.test(String(pk))) die(`boot returned a non-PK: ${pk}`);
+
+// The critical-path assertion: a live dmsg session over the ws seed.
+for (;;) {
+  const st = globalThis.skywireVisor.status();
+  const o = typeof st === 'string' ? JSON.parse(st) : st;
+  if (o.dmsg_connected) {
+    console.log(`dmsg connected (${o.dmsg_sessions} session[s])`);
+    break;
+  }
+  if (Date.now() > deadline) die(`dmsg never connected: ${JSON.stringify(o)}`);
+  await sleep(250);
+}
+
+// And the in-wasm hypervisor core must answer /api.
+const dec = (b) => {
+  if (b == null) return '';
+  if (typeof b === 'string') return b;
+  try { return new TextDecoder().decode(b); } catch { return String(b); }
+};
+const about = await globalThis.skywireVisor.hvApi('GET', '/api/about', null);
+const aboutBody = dec(about?.body ?? about);
+let aboutObj;
+try { aboutObj = JSON.parse(aboutBody); } catch { die(`/api/about not JSON: ${aboutBody.slice(0, 120)}`); }
+if (!aboutObj.dmsg_connected) die(`/api/about reports dmsg_connected=false: ${aboutBody.slice(0, 200)}`);
+console.log('hvApi /api/about OK:', aboutBody.slice(0, 120));
+
+console.log('PASS: headless wasm-visor boot → dmsg(ws) → /api core');
+process.exit(0);

--- a/scripts/wasm-headless/localdmsg/main.go
+++ b/scripts/wasm-headless/localdmsg/main.go
@@ -1,0 +1,67 @@
+// Package main scripts/wasm-headless/localdmsg/main.go c3-vis-wasm
+//
+// Minimal self-contained dmsg server for the HEADLESS wasm-visor smoke test
+// (Tier B): one unified TCP+WS dmsg server on loopback with an in-memory
+// discovery, so the real compiled wasm-visor blob — running under Node, no
+// browser — has a ws:// seed to bootstrap against. Prints machine-readable
+// SEEDPK= / SEEDWS= lines followed by READY, then serves until stdin closes
+// (so the driving script's exit reaps it deterministically).
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+func main() {
+	dc := disc.NewMock(0)
+	pk, sk := cipher.GenerateKeyPair()
+
+	const maxSessions = 32
+	srv := dmsg.NewServer(pk, sk, dc, &dmsg.ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("localdmsg"))
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "listen:", err)
+		os.Exit(1)
+	}
+	tcpAddr := lis.Addr().String()
+	wsURL := "ws://" + tcpAddr + "/dmsg"
+
+	entry := disc.NewServerEntry(pk, 0, tcpAddr, maxSessions)
+	entry.Server.AddressWS = wsURL
+	if err := entry.Sign(sk); err != nil {
+		fmt.Fprintln(os.Stderr, "sign:", err)
+		os.Exit(1)
+	}
+	if err := dc.PostEntry(context.Background(), entry); err != nil {
+		fmt.Fprintln(os.Stderr, "post entry:", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		if err := srv.ServeWithWS(lis, tcpAddr, wsURL); err != nil {
+			fmt.Fprintln(os.Stderr, "serve:", err)
+		}
+	}()
+	<-srv.Ready()
+
+	fmt.Printf("SEEDPK=%s\n", pk.Hex())
+	fmt.Printf("SEEDWS=%s\n", wsURL)
+	fmt.Println("READY")
+
+	// Serve until the parent closes our stdin (or EOF) — deterministic reaping.
+	sc := bufio.NewScanner(os.Stdin)
+	for sc.Scan() {
+	}
+	_ = srv.Close() //nolint:errcheck
+}

--- a/scripts/wasm-headless/run.sh
+++ b/scripts/wasm-headless/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# scripts/wasm-headless/run.sh — drive the Tier B headless wasm-visor smoke:
+# build the std-Go wasm blob (if absent or STALE=1), start the loopback dmsg
+# server helper, run the Node harness against it, reap everything. Exit code =
+# harness verdict. Requires Node ≥22 (global WebSocket).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+WASM=build/wasm-visor-go/wasm-visor.wasm
+EXECJS=build/wasm-visor-go/wasm_exec.js
+if [[ ! -f $WASM || ! -f $EXECJS || ${STALE:-0} = 1 ]]; then
+  echo "== building wasm-visor (std Go) =="
+  make wasm-visor
+fi
+
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]')
+if (( NODE_MAJOR < 22 )); then
+  echo "node >= 22 required (global WebSocket); have $(node -v)" >&2
+  exit 2
+fi
+
+echo "== starting loopback dmsg server =="
+# Keep the helper's stdin open via a fifo; closing it (cleanup) stops the server.
+FIFO=$(mktemp -u)
+mkfifo "$FIFO"
+OUT=$(mktemp)
+ERR=$(mktemp)
+go run ./scripts/wasm-headless/localdmsg <"$FIFO" >"$OUT" 2>"$ERR" &
+SRV=$!
+exec 9>"$FIFO" # hold the write end open
+cleanup() { exec 9>&- || true; rm -f "$FIFO"; kill "$SRV" 2>/dev/null || true; }
+trap cleanup EXIT
+
+for _ in $(seq 1 100); do
+  grep -q '^READY$' "$OUT" 2>/dev/null && break
+  sleep 0.2
+done
+grep -q '^READY$' "$OUT" || { echo "localdmsg never became ready:"; cat "$OUT" "$ERR"; exit 1; }
+SEEDPK=$(grep '^SEEDPK=' "$OUT" | cut -d= -f2)
+SEEDWS=$(grep '^SEEDWS=' "$OUT" | cut -d= -f2-)
+echo "seed: $SEEDPK @ $SEEDWS"
+
+echo "== running Node harness =="
+node scripts/wasm-headless/harness.mjs "$WASM" "$EXECJS" "$SEEDPK" "$SEEDWS"


### PR DESCRIPTION
Tier B of the wasm-visor test plan: the compile-check lane can't catch **runtime-only** breakage in the browser edge (boot-glue regressions, carrier selection, `/api` dispatch). This job executes the **actual compiled js/wasm binary** headlessly:

- **`scripts/wasm-headless/localdmsg`** — self-contained loopback dmsg server (unified TCP+WS, in-memory discovery); prints `SEEDPK`/`SEEDWS`/`READY`, serves until stdin closes.
- **`scripts/wasm-headless/harness.mjs`** — Node ≥22 (global `WebSocket` is the *only* browser global the critical path needs) runs Go's `wasm_exec.js` + `wasm-visor.wasm`, calls `skywireVisor.boot` against the loopback seed, and asserts **boot → ws dmsg session → `dmsg_connected` → in-wasm hypervisor `/api` core answering**.
- **`make test-wasm-headless`** + a new **`wasm-headless`** CI job (setup-go + node 22).

Validated locally: the real blob boots under Node, joins dmsg over ws, starts the in-process skychat app, and serves `/api` — **PASS in ~30s**, twice.

Together with #3637 (Tier A native harness + wss deployment probe) this gives the wasm visor a layered regression gate: native logic tests (fast, gating) → real-blob runtime smoke (this) → the live-deployment wss probe (scheduled).