### PR TITLE
fix(transport): WalkTransports callback ran under tm.mx (silent wedge) + lock-stall watchdog

### DIFF
--- a/pkg/transport/lock_watchdog.go
+++ b/pkg/transport/lock_watchdog.go
@@ -1,0 +1,76 @@
+// Package transport pkg/transport/lock_watchdog.go c1-net-transport
+package transport
+
+import (
+	"runtime"
+	"time"
+)
+
+// Lock-watchdog tunables. The probe tries to acquire tm.mx (read side) on a
+// timer; if it cannot within lockStallThreshold the manager's lock is stuck,
+// so the watchdog logs LOUDLY with a full goroutine dump (the holder's stack)
+// and keeps warning until the lock frees. This turns the transport-manager
+// wedge — one goroutine leaking tm.mx and freezing the whole management
+// surface — from a SILENT hang into an actionable ERROR log, the same
+// loud-not-silent principle applied to other deadlock classes in this tree.
+const (
+	lockWatchdogInterval = 30 * time.Second
+	lockStallThreshold   = 20 * time.Second
+)
+
+// serveLockWatchdog periodically probes tm.mx and screams if it is stuck.
+// Started as one of the Serve goroutines; exits on ctx cancel.
+func (tm *Manager) serveLockWatchdog(done <-chan struct{}) {
+	t := time.NewTicker(lockWatchdogInterval)
+	defer t.Stop()
+	stalledSince := time.Time{}
+	for {
+		select {
+		case <-done:
+			return
+		case <-t.C:
+		}
+		if held, waited := tm.lockProbe(lockStallThreshold); held {
+			if stalledSince.IsZero() {
+				stalledSince = time.Now().Add(-waited)
+			}
+			tm.Logger.Errorf(
+				"transport-manager lock STUCK for >%s (since ~%s): a holder of tm.mx has not released it — "+
+					"the transport map is frozen and every reader/writer is blocked behind it. Dumping goroutines:\n%s",
+				time.Since(stalledSince).Round(time.Second), stalledSince.Format(time.RFC3339), goroutineDump())
+		} else if !stalledSince.IsZero() {
+			tm.Logger.Warnf("transport-manager lock recovered after ~%s", time.Since(stalledSince).Round(time.Second))
+			stalledSince = time.Time{}
+		}
+	}
+}
+
+// lockProbe reports whether tm.mx could NOT be read-acquired within timeout.
+// It never blocks the caller past timeout: the acquire runs in a throwaway
+// goroutine (which stays parked on the lock if it is genuinely stuck — one
+// leaked goroutine is an acceptable price for the diagnostic, and it unparks
+// and exits the moment the lock frees).
+func (tm *Manager) lockProbe(timeout time.Duration) (stuck bool, waited time.Duration) {
+	got := make(chan struct{})
+	start := time.Now()
+	go func() {
+		tm.mx.RLock()
+		tm.mx.RUnlock() //nolint:staticcheck // acquire+release is the probe
+		close(got)
+	}()
+	select {
+	case <-got:
+		return false, time.Since(start)
+	case <-time.After(timeout):
+		return true, timeout
+	}
+}
+
+// goroutineDump returns all current goroutine stacks (like SIGQUIT), bounded
+// so a hub visor with thousands of goroutines can't produce an unbounded log
+// line. The holder of the stuck lock is in here — that is the whole point.
+func goroutineDump() []byte {
+	buf := make([]byte, 1<<20) // 1 MiB cap
+	n := runtime.Stack(buf, true)
+	return buf[:n]
+}

--- a/pkg/transport/lock_watchdog_test.go
+++ b/pkg/transport/lock_watchdog_test.go
@@ -1,0 +1,104 @@
+// Package transport pkg/transport/lock_watchdog_test.go c1-net-transport
+package transport
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestLockProbe_DetectsHeldLock: while a writer holds tm.mx, lockProbe reports
+// stuck; once released it reports free. This is the primitive the watchdog
+// keys off to turn a silent transport-manager wedge into a loud log.
+func TestLockProbe_DetectsHeldLock(t *testing.T) {
+	tm := &Manager{}
+
+	// Free lock: probe returns quickly, not stuck.
+	if stuck, _ := tm.lockProbe(500 * time.Millisecond); stuck {
+		t.Fatal("lockProbe reported a free lock as stuck")
+	}
+
+	// Hold the write lock and confirm the probe times out (stuck).
+	tm.mx.Lock()
+	released := make(chan struct{})
+	go func() {
+		<-released
+		tm.mx.Unlock()
+	}()
+	if stuck, _ := tm.lockProbe(300 * time.Millisecond); !stuck {
+		close(released)
+		t.Fatal("lockProbe did not detect a held write lock")
+	}
+
+	// Release and confirm recovery.
+	close(released)
+	// The probe goroutine from the stuck call is parked on RLock; it drains
+	// once we release. Give the scheduler a beat, then a fresh probe is free.
+	time.Sleep(50 * time.Millisecond)
+	if stuck, _ := tm.lockProbe(500 * time.Millisecond); stuck {
+		t.Fatal("lockProbe still reports stuck after the lock was released")
+	}
+}
+
+// TestWalkTransports_CallbackRunsUnlocked is the regression for the wedge:
+// WalkTransports must NOT hold tm.mx while running the caller's callback, so a
+// callback that touches the manager (or panics, or blocks) can't freeze it.
+// The callback here acquires the write lock — which would deadlock instantly
+// if WalkTransports still held the read lock.
+func TestWalkTransports_CallbackRunsUnlocked(t *testing.T) {
+	tm := &Manager{tps: map[uuid.UUID]*ManagedTransport{}}
+	// Two entries so the snapshot loop iterates more than once.
+	tm.tps[uuid.New()] = &ManagedTransport{}
+	tm.tps[uuid.New()] = &ManagedTransport{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tm.WalkTransports(func(_ *ManagedTransport) bool {
+			// If WalkTransports held RLock here, this Lock would block forever.
+			tm.mx.Lock()
+			tm.mx.Unlock() //nolint:staticcheck
+			return true
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WalkTransports held tm.mx during the callback (write-lock deadlock) — the wedge regression")
+	}
+}
+
+// TestWalkTransports_PanicDoesNotLeakLock: a callback panic must not leave
+// tm.mx read-locked. After a recovered panic, a writer must still be able to
+// acquire the lock promptly.
+func TestWalkTransports_PanicDoesNotLeakLock(t *testing.T) {
+	tm := &Manager{tps: map[uuid.UUID]*ManagedTransport{}}
+	tm.tps[uuid.New()] = &ManagedTransport{}
+
+	func() {
+		defer func() { recover() }() //nolint:errcheck // deliberately swallow the test panic
+		tm.WalkTransports(func(_ *ManagedTransport) bool {
+			panic("boom")
+		})
+	}()
+
+	// The write lock must be acquirable — if the panic leaked an RLock this
+	// probe times out.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	got := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		tm.mx.Lock()
+		tm.mx.Unlock() //nolint:staticcheck
+		close(got)
+	}()
+	select {
+	case <-got:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a panicking WalkTransports callback leaked tm.mx (read lock never released)")
+	}
+	wg.Wait()
+}

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -173,12 +173,13 @@ func (tm *Manager) Serve(ctx context.Context) {
 	// for cleanup, reconnect, re-registration, deferred deletion, and
 	// transport-maintenance goroutines (the latter replaces what used
 	// to be 2 goroutines per ManagedTransport)
-	tm.wg.Add(5)
+	tm.wg.Add(6)
 	go tm.cleanupTransports(ctx)
 	go tm.runReconnectPersistent(ctx)
 	go tm.runReRegisterTransports(ctx)
 	go tm.runDeferredDeletions(ctx)
 	go tm.runTransportMaintenance(ctx)
+	go func() { defer tm.wg.Done(); tm.serveLockWatchdog(ctx.Done()) }()
 	tm.Logger.Debug("transport manager is serving.")
 }
 
@@ -1361,14 +1362,28 @@ func (tm *Manager) Transport(id uuid.UUID) *ManagedTransport {
 }
 
 // WalkTransports ranges through all transports.
+//
+// The caller's walk callback is arbitrary code, so it runs OUTSIDE tm.mx over
+// a snapshot — the same pattern recordAllTransportLogs/pingAllTransports use.
+// Running it under RLock was a latent freeze: a callback that panicked (and
+// got recovered upstream — e.g. an HTTP handler's recovery middleware) leaked
+// the read lock, and a slow callback held it, blocking every transport writer
+// (acceptTransport, SaveTransport) and — via RWMutex writer-preference — every
+// subsequent reader. That is the transport-manager wedge: one stuck holder,
+// the whole management surface frozen with no log line.
 func (tm *Manager) WalkTransports(walk func(tp *ManagedTransport) bool) {
 	tm.mx.RLock()
+	snapshot := make([]*ManagedTransport, 0, len(tm.tps))
 	for _, tp := range tm.tps {
+		snapshot = append(snapshot, tp)
+	}
+	tm.mx.RUnlock()
+
+	for _, tp := range snapshot {
 		if ok := walk(tp); !ok {
 			break
 		}
 	}
-	tm.mx.RUnlock()
 }
 
 // Local returns Manager.config.PubKey


### PR DESCRIPTION
## The bug
A native visor was found **wedged**: HV UI, route calculation, the autoconnector, `AddTransport` — the entire management surface frozen, **no log line**. A goroutine dump showed **one leaked hold of `transport.Manager.mx`** and ~15 readers/writers queued behind it.

## Root cause
`WalkTransports` ranged the transport map with `tm.mx` **RLocked** and invoked the **caller's callback inside the critical section**. That callback is arbitrary code:
- a **panic** (recovered upstream by an HTTP handler's recovery middleware — hence *no log*) leaked the read lock;
- a **slow/blocking** callback held it;

either way, RWMutex writer-preference then froze every subsequent reader behind the queued writer. It's the odd one out — `recordAllTransportLogs`/`pingAllTransports` already snapshot-then-release.

## Fix
1. **`WalkTransports` snapshots under the lock and runs the callback unlocked** (matching its siblings). A panicking or blocking callback can no longer touch `tm.mx`.
2. **`serveLockWatchdog`** — a `Serve` goroutine that probes `tm.mx` every 30s and, if it can't acquire within 20s, logs an **ERROR with a full goroutine dump** (the holder's stack) and keeps warning until it frees. This turns the whole *class* of transport-manager wedge from a silent hang into an actionable log — the same loud-not-silent principle used elsewhere in this tree.

## Tests (race-clean)
`lockProbe` detects a held lock and recovers; `WalkTransports` runs its callback unlocked (a callback that takes the write lock would deadlock if it still held RLock); a panicking callback does not leak the lock.

Found live during wasm↔native demo testing; preserved goroutine dumps confirmed the leaked-`mx` pattern.