### PR TITLE
fix(wasmhv): duplicate Go/TinyGo variant selector inside the embedded chat iframe

### DIFF
--- a/pkg/wasmhv/hv-boot.js
+++ b/pkg/wasmhv/hv-boot.js
@@ -517,6 +517,13 @@
   // the SAME PK — the A/B test harness. Lives here (not Angular) so it works in the
   // served PWA and under --harness alike, with no UI rebuild.
   function injectVariantToggle() {
+    // Only on the TOP-level page. When the app is iframed at ?embed=1 (the ☰
+    // chat/log WinBox windows host the Angular tab that way), this boot script
+    // runs inside the frame too — without this guard the Go/TinyGo selector
+    // renders a second time inside the chat iframe. The toggle belongs to the
+    // one shared visor, so one instance on the outermost page is correct.
+    try { if (window.top !== window.self) { return; } } catch (e) { return; } // cross-origin frame → treat as embedded
+    if ((location.hash || '').indexOf('embed=1') >= 0) { return; }
     try {
       fetch('wasm-variants.json', { cache: 'no-store' }).then(function (r) { return r.json(); }).then(function (info) {
         var avail = (info && info.available) || [];


### PR DESCRIPTION
The ☰ chat/log WinBox windows host the Angular tab at `?embed=1` (via #3641/#3642), so `hv-boot.js` boots inside that iframe as well — and `injectVariantToggle()` rendered a **second** Go/TinyGo variant selector inside the chat iframe, on top of the one already on the HV desktop (operator-reported: "the selector … is in two places").

The toggle switches the **one shared visor's** toolchain, so exactly one instance belongs — on the outermost page. Skip injection when framed (`window.top !== window.self`) or when the URL carries `embed=1` (same guard the taskbar already uses). A cross-origin frame access throws → treated as embedded and skipped.

`hv-boot.js` is `go:embed`'d and served static (not part of the wasm blob), so this ships with the binary; no blob re-embed.