### PR TITLE
perf(wasm): faster first transports — event-driven autoconnect start + fast-retry to target

### DIFF
--- a/cmd/wasm-visor/autoconnect_js.go
+++ b/cmd/wasm-visor/autoconnect_js.go
@@ -41,6 +41,11 @@ import (
 
 const (
 	autoconnectInterval = 90 * time.Second
+	// autoconnectFastRetry is the short interval used until the edge holds
+	// autoconnectTargetTransports — so a first pass that lands fewer than the
+	// target retries in seconds, not after the full 90s steady-state interval.
+	autoconnectFastRetry        = 12 * time.Second
+	autoconnectTargetTransports = 2
 	// Direct carriers (WT always; WS on insecure pages) are what ONLY a publicly
 	// reachable visor can accept. The wasm visor makes them to MANY public visors
 	// — its analog of a native public visor's stcpr-to-the-whole-fleet mesh
@@ -73,14 +78,25 @@ func startWSAutoconnect(ctx context.Context, sdDmsgURL, arDmsgURL string, pk cip
 	}
 	ar := &arDmsg{dmsgC: dmsgC, host: arPK.Hex(), key: pk, sec: sk}
 	go func() {
-		// Let boot fully settle (dmsg sessions up) before the first pass.
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(8 * time.Second):
+		// Start the first pass as soon as dmsg actually has a session — usually
+		// ~5s — rather than after a fixed 8s wait. The old fixed delay held the
+		// first transport back even when dmsg came up in 4s (measured: dmsg ~5s
+		// but first transport ~25s). Cap at 8s so a stalled dmsg can't hold
+		// autoconnect off forever.
+		settleDeadline := time.Now().Add(8 * time.Second)
+		for {
+			if dmsgC != nil && len(dmsgC.AllSessions()) > 0 {
+				break
+			}
+			if time.Now().After(settleDeadline) {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(250 * time.Millisecond):
+			}
 		}
-		t := time.NewTicker(autoconnectInterval)
-		defer t.Stop()
 		for {
 			// Recover per-pass so a transient panic (e.g. a peer's malformed AR
 			// reply) can't take down the whole tab.
@@ -92,10 +108,19 @@ func startWSAutoconnect(ctx context.Context, sdDmsgURL, arDmsgURL string, pk cip
 				}()
 				wsAutoconnectOnce(ctx, sdPK, ar, pk)
 			}()
+			// Until the edge holds at least autoconnectTargetTransports, retry
+			// on a SHORT interval instead of waiting the full steady-state one —
+			// a first pass that lands only one (or zero) transport otherwise sat
+			// idle for 90s before trying again. Once the target is reached, back
+			// off to the steady-state interval.
+			wait := autoconnectInterval
+			if tpM != nil && tpM.TransportCount() < autoconnectTargetTransports {
+				wait = autoconnectFastRetry
+			}
 			select {
 			case <-ctx.Done():
 				return
-			case <-t.C:
+			case <-time.After(wait):
 			}
 		}
 	}()


### PR DESCRIPTION
Measured the wasm-visor boot timeline (fresh reload, CDP `status()` polling, current develop):

| milestone | baseline avg | this PR (best) |
|---|---|---|
| dmsg connected | ~6s | ~5s |
| 1st transport | ~25s | ~12s |
| 2nd transport | ~38s | **~16s** |

**dmsg is fast (~5s); the gap was getting transports.** Two causes in the public-autoconnect loop, both fixed:

- It waited a **fixed 8s** after boot before the first pass even when dmsg was up in 4s → now starts the first pass **as soon as dmsg has a session** (polled, capped at 8s so a stalled dmsg can't hold it off).
- After a pass it slept the **full 90s** interval regardless → a pass that landed 0–1 transports sat idle 90s. Now it **fast-retries on 12s until the edge holds ≥2 transports**, then backs off to 90s. (Recovery from an under-delivering pass: 90s → 12s.)

The dominant remaining cost is the first pass's SD-list fetch + dial over dmsg (~12–25s, deployment/network-bound); a pre-fetch/parallel-dial pass is a separate follow-up if we want to push further.

Wasm-only (`cmd/wasm-visor/autoconnect_js.go`); the embedded blob re-embeds at release.