### PR TITLE
perf(autoconnect): dial public visors concurrently (native + wasm)

### DIFF
--- a/cmd/wasm-visor/autoconnect_js.go
+++ b/cmd/wasm-visor/autoconnect_js.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall/js"
 	"time"
 
@@ -47,6 +48,12 @@ const (
 	// participation — so it can carry/relay routes like a first-class node, not
 	// just hold a handful of links.
 	autoconnectMaxDirect = 32
+	// autoconnectDialConcurrency bounds how many direct dials run at once. Each
+	// dialDirect blocks up to ~25s per carrier (AR resolve + WT/WS handshake), so
+	// dialing SEQUENTIALLY made the first transport take ~26s when an early target
+	// was slow/dead. Dialing concurrently makes it ~the fastest single dial. Bounded
+	// so a browser tab doesn't open dozens of QUIC handshakes at once.
+	autoconnectDialConcurrency = 8
 	// WebRTC (NAT-traversing DataChannel over dmsg) is reserved on a SEPARATE,
 	// smaller budget for peers no direct carrier can reach (NAT'd / WT-less
 	// visors). Kept apart so WebRTC — heavier, and something ANY visor can accept
@@ -149,29 +156,68 @@ func wsAutoconnectOnce(ctx context.Context, sdPK cipher.PubKey, ar *arDmsg, self
 	addedDirect := 0
 	skippedCooldown := 0
 	var directFailed []cipher.PubKey
+	// Dial the eligible public visors CONCURRENTLY (bounded): a single slow or
+	// dead target no longer blocks the rest for its full ~25s timeout, so the
+	// first transports land in ~the fastest dial instead of the sum of the
+	// misses. mu guards the shared counters + maps across the dial goroutines
+	// (dialDirect's own table writes are individually thread-safe). Each
+	// goroutine recovers its own panic so one bad AR reply can't crash the tab.
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, autoconnectDialConcurrency)
 	for i := range services {
-		if directPeers >= autoconnectMaxDirect {
-			break
-		}
 		pk := services[i].Addr.PubKey()
-		if pk == selfPK || haveDirect[pk] {
+		if pk == selfPK {
 			continue
 		}
+		mu.Lock()
+		over := directPeers >= autoconnectMaxDirect
+		dup := haveDirect[pk]
+		cooled := false
 		if ts, bad := autoconnectFailed[pk]; bad {
 			if time.Since(ts) < autoconnectFailCooldown {
-				skippedCooldown++
-				continue
+				cooled = true
+			} else {
+				delete(autoconnectFailed, pk)
 			}
-			delete(autoconnectFailed, pk)
 		}
-		if dialDirect(ctx, ar, pk, services[i].Addr.Port(), https) {
-			directPeers++
-			addedDirect++
-			delete(autoconnectFailed, pk)
-		} else {
-			directFailed = append(directFailed, pk)
+		mu.Unlock()
+		if over {
+			break
 		}
+		if dup {
+			continue
+		}
+		if cooled {
+			mu.Lock()
+			skippedCooldown++
+			mu.Unlock()
+			continue
+		}
+		port := services[i].Addr.Port()
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(pk cipher.PubKey, port uint16) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			defer func() {
+				if r := recover(); r != nil {
+					vlog(fmt.Sprintf("ws-autoconnect: dial recovered panic: %v", r))
+				}
+			}()
+			ok := dialDirect(ctx, ar, pk, port, https)
+			mu.Lock()
+			if ok {
+				directPeers++
+				addedDirect++
+				delete(autoconnectFailed, pk)
+			} else {
+				directFailed = append(directFailed, pk)
+			}
+			mu.Unlock()
+		}(pk, port)
 	}
+	wg.Wait()
 
 	// --- Pass 2: WebRTC to the peers no direct carrier reached. ---
 	// Today those are NAT'd / WT-less "public" visors; the same mechanism is how

--- a/pkg/transport/network/stcp/pktable.go
+++ b/pkg/transport/network/stcp/pktable.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 )
@@ -23,6 +24,11 @@ type PKTable interface {
 }
 
 type memoryTable struct {
+	// mu guards entries/reverse: SetAddr is called at runtime from the
+	// autoconnect dialer, which now dials targets CONCURRENTLY — without this
+	// two dials writing different entries would race on the maps (the reason
+	// parallel autoconnect dialing was previously avoided).
+	mu      sync.RWMutex
 	entries map[cipher.PubKey]string
 	reverse map[string]cipher.PubKey
 }
@@ -90,23 +96,31 @@ func NewTableFromFile(path string) (PKTable, error) {
 
 // Addr obtains the address associated with the given public key.
 func (mt *memoryTable) Addr(pk cipher.PubKey) (string, bool) {
+	mt.mu.RLock()
+	defer mt.mu.RUnlock()
 	addr, ok := mt.entries[pk]
 	return addr, ok
 }
 
 // PubKey obtains the public key associated with the given public key.
 func (mt *memoryTable) PubKey(addr string) (cipher.PubKey, bool) {
+	mt.mu.RLock()
+	defer mt.mu.RUnlock()
 	pk, ok := mt.reverse[addr]
 	return pk, ok
 }
 
 // SetAddr associates a public key with an address at runtime.
 func (mt *memoryTable) SetAddr(pk cipher.PubKey, addr string) {
+	mt.mu.Lock()
+	defer mt.mu.Unlock()
 	mt.entries[pk] = addr
 	mt.reverse[addr] = pk
 }
 
 // Count returns the number of entries within the PKTable implementation.
 func (mt *memoryTable) Count() int {
+	mt.mu.RLock()
+	defer mt.mu.RUnlock()
 	return len(mt.entries)
 }

--- a/pkg/transport/network/stcp/pktable_test.go
+++ b/pkg/transport/network/stcp/pktable_test.go
@@ -5,6 +5,7 @@ package stcp
 import (
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,6 +67,46 @@ func TestSetAddr(t *testing.T) {
 	gotPK, ok := mt.PubKey("127.0.0.1:3000")
 	assert.True(t, ok)
 	assert.Equal(t, pk, gotPK)
+}
+
+// TestMemoryTableConcurrentAccess is the regression for the race that
+// previously blocked parallel autoconnect dialing: the wasm-visor's WS dial
+// table (a memoryTable) is written by concurrent dial goroutines while other
+// goroutines read it. Run under `-race`, this fails if the table's maps are
+// touched without the guarding mutex. It asserts no crash/race, not a specific
+// final state (interleaving is nondeterministic).
+func TestMemoryTableConcurrentAccess(t *testing.T) {
+	mt := NewTable(map[cipher.PubKey]string{})
+
+	const workers = 16
+	pks := make([]cipher.PubKey, workers)
+	addrs := make([]string, workers)
+	for i := 0; i < workers; i++ {
+		pk, _ := cipher.GenerateKeyPair()
+		pks[i] = pk
+		addrs[i] = "127.0.0.1:" + string(rune('0'+i%10)) + "000"
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				mt.SetAddr(pks[i], addrs[i])
+				_, _ = mt.Addr(pks[i])
+				_, _ = mt.PubKey(addrs[i])
+				_ = mt.Count()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Every writer's entry must be resolvable after the storm.
+	for i := 0; i < workers; i++ {
+		_, ok := mt.Addr(pks[i])
+		assert.True(t, ok, "entry %d missing after concurrent writes", i)
+	}
 }
 
 // TestNewTableFromFile verifies a well-formed table file is parsed into a

--- a/pkg/visor/visorcore/autoconnect.go
+++ b/pkg/visor/visorcore/autoconnect.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"math/big"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -54,14 +55,37 @@ func (c *Connector) ConnectToVisors(
 	currentCount int,
 	trackAll bool, // if true, add to result even on failure (for phase 1 → phase 2 handoff)
 ) (result ConnectPhaseResult, err error) {
+	// Dial the targets CONCURRENTLY (bounded). Each target costs a dmsg probe
+	// (up to HandshakeTimeout) plus a SaveTransport (up to perAttemptTransportTimeout,
+	// 30s), so dialing them sequentially made one slow/dead peer stall the whole
+	// phase for its full timeout — the measured cause of ~26s to the first
+	// autoconnect transport. A bounded worker pool overlaps the waits so the phase
+	// finishes in ~the slowest single dial rather than their sum, while the
+	// semaphore keeps a visor from opening dozens of handshakes at once.
+	//
+	// The read-only inputs (existingByPK, sudphCapable) are dialed without a lock;
+	// mu guards the mutated result (Count/Connected) and the budget read. The budget
+	// (maxCount) is still honored, but because successes register asynchronously the
+	// stop point can overshoot by up to dialConcurrency-1 in-flight dials — a couple
+	// of extra transports is harmless (and mildly beneficial for path diversity).
+	var (
+		mu sync.Mutex
+		wg sync.WaitGroup
+	)
+	sem := make(chan struct{}, dialConcurrency)
+
 	for _, pk := range ShufflePubKeys(targets) {
 		select {
 		case <-ctx.Done():
+			wg.Wait()
 			return result, context.Canceled
 		default:
 		}
 
-		if currentCount+result.Count >= maxCount {
+		mu.Lock()
+		reached := currentCount+result.Count >= maxCount
+		mu.Unlock()
+		if reached {
 			break
 		}
 
@@ -72,7 +96,9 @@ func (c *Connector) ConnectToVisors(
 		// Skip if we already have this transport type to this visor
 		if existingByPK[pk][tpType] {
 			if trackAll {
+				mu.Lock()
 				result.Connected = append(result.Connected, pk)
+				mu.Unlock()
 			}
 			continue
 		}
@@ -81,58 +107,81 @@ func (c *Connector) ConnectToVisors(
 		if tpType == tptypes.SUDPH && sudphCapable != nil {
 			if _, ok := sudphCapable[pk]; !ok {
 				if trackAll {
+					mu.Lock()
 					result.Connected = append(result.Connected, pk)
+					mu.Unlock()
 				}
 				continue
 			}
 		}
 
-		// Skip visors behind the same NAT
-		if c.ClientPublicIP != "" {
-			if sameLAN := c.isSameLAN(ctx, pk, tpType); sameLAN {
-				c.Log.WithField("pk", pk).Debugln("Skipping same-LAN visor")
-				continue
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(pk cipher.PubKey) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			// Recover per-dial so one bad AR reply / dial panic can't take down
+			// the whole autoconnect loop.
+			defer func() {
+				if r := recover(); r != nil {
+					c.Log.WithField("pk", pk).Errorf("autoconnect dial recovered panic: %v", r)
+				}
+			}()
+
+			// Skip visors behind the same NAT
+			if c.ClientPublicIP != "" {
+				if sameLAN := c.isSameLAN(ctx, pk, tpType); sameLAN {
+					c.Log.WithField("pk", pk).Debugln("Skipping same-LAN visor")
+					return
+				}
 			}
-		}
 
-		logger := c.Log.WithField("pk", pk).WithField("type", string(tpType))
+			logger := c.Log.WithField("pk", pk).WithField("type", string(tpType))
 
-		// Probe the candidate on dmsg port 136 before attempting SUDPH
-		// transports (which need DMSG for signaling). Skip the probe for
-		// STCPR — it uses direct TCP and doesn't depend on DMSG. The old
-		// blanket probe was filtering out visors reachable via STCPR but
-		// with broken DMSG paths, reducing public visor transport counts.
-		if tpType != tptypes.STCPR && c.DmsgC != nil {
-			probeCtx, probeCancel := context.WithTimeout(ctx, dmsg.HandshakeTimeout)
-			reachable := c.DmsgC.Probe(probeCtx, pk, skyenv.DmsgAwaitSetupPort)
-			probeCancel()
-			if !reachable {
-				logger.Debug("Skipping visor: dmsg probe failed (unreachable)")
+			// Probe the candidate on dmsg port 136 before attempting SUDPH
+			// transports (which need DMSG for signaling). Skip the probe for
+			// STCPR — it uses direct TCP and doesn't depend on DMSG. The old
+			// blanket probe was filtering out visors reachable via STCPR but
+			// with broken DMSG paths, reducing public visor transport counts.
+			if tpType != tptypes.STCPR && c.DmsgC != nil {
+				probeCtx, probeCancel := context.WithTimeout(ctx, dmsg.HandshakeTimeout)
+				reachable := c.DmsgC.Probe(probeCtx, pk, skyenv.DmsgAwaitSetupPort)
+				probeCancel()
+				if !reachable {
+					logger.Debug("Skipping visor: dmsg probe failed (unreachable)")
+					if trackAll {
+						mu.Lock()
+						result.Connected = append(result.Connected, pk)
+						mu.Unlock()
+					}
+					return
+				}
+			}
+
+			logger.Debugln("Trying to add transport")
+
+			if err := c.tryEstablishTransport(ctx, pk, tpType, logger); err != nil {
+				if isContextError(err) {
+					logger.WithError(err).Debugln("Transport creation canceled (shutdown)")
+				} else {
+					logger.WithError(err).Warnln("Failed to add transport")
+				}
 				if trackAll {
+					mu.Lock()
 					result.Connected = append(result.Connected, pk)
+					mu.Unlock()
 				}
-				continue
+				return
 			}
-		}
 
-		logger.Debugln("Trying to add transport")
-
-		if err := c.tryEstablishTransport(ctx, pk, tpType, logger); err != nil {
-			if isContextError(err) {
-				logger.WithError(err).Debugln("Transport creation canceled (shutdown)")
-			} else {
-				logger.WithError(err).Warnln("Failed to add transport")
-			}
-			if trackAll {
-				result.Connected = append(result.Connected, pk)
-			}
-			continue
-		}
-
-		result.Count++
-		result.Connected = append(result.Connected, pk)
+			mu.Lock()
+			result.Count++
+			result.Connected = append(result.Connected, pk)
+			mu.Unlock()
+		}(pk)
 	}
 
+	wg.Wait()
 	return result, nil
 }
 
@@ -162,6 +211,12 @@ func ShufflePubKeys(keys []cipher.PubKey) []cipher.PubKey {
 // webrtc awaitConn) honors ctx, so a bounded per-attempt deadline lets a stuck
 // dial return DeadlineExceeded and the loop advances to the next target/tick.
 const perAttemptTransportTimeout = 30 * time.Second
+
+// dialConcurrency bounds how many autoconnect dials run at once within a single
+// ConnectToVisors phase. Chosen to overlap the per-target waits (dmsg probe +
+// 30s SaveTransport) without letting a visor open an unbounded number of
+// simultaneous transport handshakes.
+const dialConcurrency = 8
 
 // tryEstablishTransport attempts to establish a transport of the specified type to the given public key, and return error.
 func (c *Connector) tryEstablishTransport(ctx context.Context, pk cipher.PubKey, netType tptypes.Type, logger *logrus.Entry) error {


### PR DESCRIPTION
## Problem

Both the native visor and the browser wasm-visor dialed autoconnect targets **sequentially**. Each target costs a dmsg reachability probe plus a `SaveTransport` bounded at 25–30s, so a single slow or dead peer stalled the whole pass for its full per-target timeout. Measuring wasm-visor boot showed this directly: SD returned the public-visor list in <1s, but the **first transport didn't land for ~26s** because an early target in the list was unreachable and blocked the loop.

## Change

Dial with a **bounded worker pool (8 concurrent)** in both visors, so the per-target waits overlap and a pass finishes in roughly the slowest single dial instead of the sum of the misses. The dial budget (`maxCount` / `autoconnectMaxDirect`) is still honored; because successes register asynchronously the stop point can overshoot by up to `concurrency-1` in-flight dials, which only adds a little extra path diversity.

### The race the previous dev avoided

Parallel dialing was previously avoided because the wasm WS dial table (`stcp.memoryTable`) had **unguarded maps** — concurrent `SetAddr`/`Addr` from dial goroutines would race. This fixes the root cause rather than working around it:

- **`pkg/transport/network/stcp/pktable.go`** — `memoryTable` gets a `sync.RWMutex` guarding `Addr`/`PubKey`/`SetAddr`/`Count`. New regression test hammers it from 16 goroutines under `-race`.
- **`pkg/visor/visorcore/autoconnect.go`** — `ConnectToVisors` runs each target's probe+dial in a bounded pool; the result counters/slice are mutex-guarded and each dial has its own `recover` so one bad AR reply can't crash the loop. Read-only inputs (`existingByPK`, `sudphCapable`) are read without the lock.
- **`cmd/wasm-visor/autoconnect_js.go`** — the WS/WT direct-dial loop uses the same bounded pool + guarded shared state.

## Testing

- `go test -race` on `pkg/transport/network/stcp` (incl. new concurrent-access test) and `pkg/visor/visorcore` — pass.
- `go build` native + `GOOS=js GOARCH=wasm go build` wasm — pass.
- `golangci-lint` on changed packages — clean.