### PR TITLE
feat(transport): per-type transport-creation policy (disable direct p2p, keep dmsg)

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -47,6 +47,18 @@ type ManagerConfig struct {
 	//   N > 0 = deregister after N transports
 	//   N < 0 = never register
 	ARTransportLimit int
+	// NoDirectTransports, when true, refuses to CREATE (dial out) any DIRECT
+	// peer-to-peer transport (stcpr/sudph/stcp/squicr/swsr/swtr/webrtc). DMSG — a
+	// relay through a dmsg server, not a direct p2p link — is still created, so
+	// the visor keeps its always-available baseline and can still reach peers
+	// over existing transports/routes. Gates only OUTBOUND creation; inbound
+	// (accepted) transports are unaffected.
+	NoDirectTransports bool
+	// TransportCreateDeny is an advanced/testing per-type deny list: creating any
+	// type listed here is refused, INCLUDING dmsg (so a test can force a
+	// pure-direct or fully-offline visor). Applied on top of NoDirectTransports;
+	// stored normalized (aliases resolved). Empty (default) denies nothing.
+	TransportCreateDeny []types.Type
 }
 
 // RouteChecker is called before tearing down an existing transport for re-creation.
@@ -981,6 +993,13 @@ var ErrNotFound = errors.New("transport not found")
 // ErrUnknownNetwork occurs on attempt to use an unknown network type.
 var ErrUnknownNetwork = errors.New("unknown network type")
 
+// ErrTransportCreateDisabled is returned when creating (dialing out) a transport
+// of a given type is forbidden by the manager's transport-creation policy
+// (NoDirectTransports / TransportCreateDeny). It gates only OUTBOUND creation;
+// inbound (accepted) transports and reachability over existing transports/routes
+// are unaffected.
+var ErrTransportCreateDisabled = errors.New("transport creation disabled for this type by policy")
+
 // IsKnownNetwork returns true when netName is a known
 // network type that we are able to operate in.
 //
@@ -1108,9 +1127,41 @@ func (tm *Manager) SaveTransportWithOptions(ctx context.Context, remote cipher.P
 	}
 }
 
+// transportCreateDenied reports whether CREATING (dialing out) a transport of
+// netType is forbidden by the manager's transport-creation policy. dmsg is
+// exempt from NoDirectTransports (it is a relay, not direct p2p) but NOT from an
+// explicit TransportCreateDeny entry. Alias-aware via NormalizeType. This is the
+// single chokepoint that covers every creation path — autoconnect, the on-demand
+// route-setup hook, `tp add`, and `--direct` all funnel through saveTransportInternal.
+func (tm *Manager) transportCreateDenied(netType types.Type) bool {
+	nt := types.NormalizeType(netType)
+	if tm.Conf.NoDirectTransports && types.IsDirect(nt) {
+		return true
+	}
+	for _, d := range tm.Conf.TransportCreateDeny {
+		if types.NormalizeType(d) == nt {
+			return true
+		}
+	}
+	return false
+}
+
+// CanCreateTransport reports whether the manager is permitted to CREATE (dial
+// out) a transport of netType under the current transport-creation policy. It is
+// the exported, affirmative form of transportCreateDenied — callers that decide
+// what to dial (e.g. autoconnect phases) use it to skip types they'd only be
+// refused at the funnel, avoiding wasted dials and log noise.
+func (tm *Manager) CanCreateTransport(netType types.Type) bool {
+	return !tm.transportCreateDenied(netType)
+}
+
 func (tm *Manager) saveTransportInternal(ctx context.Context, remote cipher.PubKey, netType types.Type, label Label, opts SaveTransportOptions) (*ManagedTransport, error) {
 	if !tm.IsKnownNetwork(netType) {
 		return nil, ErrUnknownNetwork
+	}
+	if tm.transportCreateDenied(netType) {
+		tm.Logger.Debugf("Refusing to create %s transport to %s: disabled by transport-creation policy", netType, remote)
+		return nil, ErrTransportCreateDisabled
 	}
 
 	tpID := tm.tpIDFromPK(remote, netType)

--- a/pkg/transport/manager_create_gate_test.go
+++ b/pkg/transport/manager_create_gate_test.go
@@ -1,0 +1,63 @@
+// Package transport pkg/transport/manager_create_gate_test.go c1-net-transport
+package transport
+
+import (
+	"testing"
+
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// TestTransportCreateGate exercises the transport-creation policy predicate that
+// saveTransportInternal enforces: NoDirectTransports blocks direct p2p types but
+// exempts dmsg, and TransportCreateDeny blocks exactly the listed types
+// (including dmsg), alias-aware.
+func TestTransportCreateGate(t *testing.T) {
+	directTypes := []types.Type{types.STCPR, types.SUDPH, types.STCP, types.QUIC, types.WS, types.WT, types.WEBRTC}
+
+	t.Run("default allows everything", func(t *testing.T) {
+		tm := &Manager{Conf: &ManagerConfig{}}
+		for _, ty := range types.Known() {
+			if !tm.CanCreateTransport(ty) {
+				t.Errorf("default policy must allow %q", ty)
+			}
+		}
+	})
+
+	t.Run("NoDirectTransports blocks direct, exempts dmsg", func(t *testing.T) {
+		tm := &Manager{Conf: &ManagerConfig{NoDirectTransports: true}}
+		for _, ty := range directTypes {
+			if tm.CanCreateTransport(ty) {
+				t.Errorf("NoDirectTransports must block direct type %q", ty)
+			}
+		}
+		if !tm.CanCreateTransport(types.DMSG) {
+			t.Error("NoDirectTransports must still allow dmsg (relay, not direct p2p)")
+		}
+		// Alias-aware: legacy "quic"/"ws"/"wt" are direct and blocked too.
+		if tm.CanCreateTransport(types.QUICLegacy) || tm.CanCreateTransport(types.WSLegacy) {
+			t.Error("NoDirectTransports must block legacy direct aliases")
+		}
+	})
+
+	t.Run("TransportCreateDeny blocks listed types including dmsg", func(t *testing.T) {
+		tm := &Manager{Conf: &ManagerConfig{TransportCreateDeny: []types.Type{types.DMSG, types.SUDPH}}}
+		if tm.CanCreateTransport(types.DMSG) {
+			t.Error("explicit deny must block dmsg (the advanced/testing case)")
+		}
+		if tm.CanCreateTransport(types.SUDPH) {
+			t.Error("explicit deny must block sudph")
+		}
+		// Not listed → still allowed.
+		if !tm.CanCreateTransport(types.STCPR) {
+			t.Error("stcpr not in deny list must remain allowed")
+		}
+	})
+
+	t.Run("deny list is alias-aware", func(t *testing.T) {
+		// A deny entry given as the legacy alias must block the canonical type.
+		tm := &Manager{Conf: &ManagerConfig{TransportCreateDeny: []types.Type{types.QUICLegacy}}}
+		if tm.CanCreateTransport(types.QUIC) {
+			t.Error("deny of legacy \"quic\" must block canonical squicr")
+		}
+	})
+}

--- a/pkg/transport/types/types.go
+++ b/pkg/transport/types/types.go
@@ -105,3 +105,21 @@ func Valid(t Type) bool {
 		return false
 	}
 }
+
+// IsRelay reports whether t is a RELAY transport — one whose payload passes
+// through an intermediary service rather than over a direct visor↔visor pipe.
+// DMSG is the only relay type (it hops through a dmsg server that neither
+// endpoint can observe for path planning); every other known transport
+// (stcpr/sudph/stcp/squicr/swsr/swtr, and the genuinely-p2p webrtc) is direct.
+// This is the single predicate for the "dmsg is a relay, exempt it" rule that
+// was previously re-derived ad hoc at each call site. Alias-aware.
+func IsRelay(t Type) bool {
+	return NormalizeType(t) == DMSG
+}
+
+// IsDirect reports whether t is a DIRECT (non-relay) peer-to-peer transport
+// between two visors. It is the complement of IsRelay over the known types; an
+// unrecognized type is neither direct nor relay (returns false). Alias-aware.
+func IsDirect(t Type) bool {
+	return Valid(t) && !IsRelay(t)
+}

--- a/pkg/transport/types/types_valid_test.go
+++ b/pkg/transport/types/types_valid_test.go
@@ -23,3 +23,36 @@ func TestValidAndKnown(t *testing.T) {
 		t.Errorf("expected 8 known types, got %d", len(Known()))
 	}
 }
+
+func TestIsRelayIsDirect(t *testing.T) {
+	// DMSG is the only relay; every other known type is direct.
+	if !IsRelay(DMSG) {
+		t.Error("DMSG must be a relay")
+	}
+	if IsDirect(DMSG) {
+		t.Error("DMSG must not be direct")
+	}
+	for _, ty := range Known() {
+		if ty == DMSG {
+			continue
+		}
+		if !IsDirect(ty) {
+			t.Errorf("known type %q must be direct", ty)
+		}
+		if IsRelay(ty) {
+			t.Errorf("known type %q must not be a relay", ty)
+		}
+	}
+	// webrtc is the genuinely-p2p transport — direct, not relay.
+	if !IsDirect(WEBRTC) || IsRelay(WEBRTC) {
+		t.Error("WEBRTC must be direct, not relay")
+	}
+	// Alias-aware: legacy names classify by their canonical type.
+	if !IsDirect(QUICLegacy) || !IsDirect(WSLegacy) || !IsDirect(WTLegacy) {
+		t.Error("legacy direct aliases (quic/ws/wt) must be direct")
+	}
+	// Unknown types are neither direct nor relay.
+	if IsDirect("bogus") || IsRelay("bogus") || IsDirect("") {
+		t.Error("unknown/empty types must be neither direct nor relay")
+	}
+}

--- a/pkg/visor/autoconnect.go
+++ b/pkg/visor/autoconnect.go
@@ -147,10 +147,16 @@ func (a *autoconnector) Run(ctx context.Context, v *Visor) (err error) {
 			absent1 := a.filterDuplicates(addrs, a.tm.GetTransportsByLabel(transport.LabelAutomatic))
 
 			// Check which transport types are supported locally
-			localSupportsSUDPH := a.tm.IsKnownNetwork(tptypes.SUDPH)
-			localSupportsSTCPR := a.tm.IsKnownNetwork(tptypes.STCPR)
-			localSupportsSQUICR := a.tm.IsKnownNetwork(tptypes.QUIC)   // QUIC(squicr): 3rd distinct carrier family for route diversity
-			localSupportsWEBRTC := a.tm.IsKnownNetwork(tptypes.WEBRTC) // NAT-traversing (ICE/STUN); reaches more NAT types than sudph hole-punch
+			// Autoconnect only ever creates DIRECT transports (sudph/stcpr/squicr/
+			// webrtc), so honor the transport-creation policy here: with
+			// no_direct_transports (or a per-type deny) set, CanCreateTransport is
+			// false and the corresponding phase is skipped entirely — no wasted dials,
+			// no per-cycle "creation disabled" warnings from the funnel. dmsg is not an
+			// autoconnect phase, so the visor still keeps its dmsg baseline.
+			localSupportsSUDPH := a.tm.IsKnownNetwork(tptypes.SUDPH) && a.tm.CanCreateTransport(tptypes.SUDPH)
+			localSupportsSTCPR := a.tm.IsKnownNetwork(tptypes.STCPR) && a.tm.CanCreateTransport(tptypes.STCPR)
+			localSupportsSQUICR := a.tm.IsKnownNetwork(tptypes.QUIC) && a.tm.CanCreateTransport(tptypes.QUIC)     // QUIC(squicr): 3rd distinct carrier family for route diversity
+			localSupportsWEBRTC := a.tm.IsKnownNetwork(tptypes.WEBRTC) && a.tm.CanCreateTransport(tptypes.WEBRTC) // NAT-traversing (ICE/STUN); reaches more NAT types than sudph hole-punch
 			if !localSupportsSUDPH && !localSupportsSTCPR {
 				a.log.Warn("No supported network types available locally (SUDPH and STCPR both unavailable)")
 				continue

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -487,8 +487,14 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 	}
 
 	var arLimit int
+	var noDirectTransports bool
+	var transportCreateDeny []types.Type
 	if v.conf.Transport != nil {
 		arLimit = v.conf.Transport.ARTransportLimit
+		noDirectTransports = v.conf.Transport.NoDirectTransports
+		for _, s := range v.conf.Transport.TransportCreateDeny {
+			transportCreateDeny = append(transportCreateDeny, types.NormalizeType(types.Type(s)))
+		}
 	}
 	tpMConf := transport.ManagerConfig{
 		PubKey: v.conf.PK,
@@ -503,6 +509,8 @@ func initTransport(ctx context.Context, v *Visor, log *logging.Logger) error {
 		PersistentTransportsCache: pTps,
 		Version:                   buildinfo.Version(),
 		ARTransportLimit:          arLimit,
+		NoDirectTransports:        noDirectTransports,
+		TransportCreateDeny:       transportCreateDeny,
 	}
 
 	// todo: pass down configuration?

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -510,6 +510,18 @@ type Transport struct {
 	// When deregistered, the visor cannot receive new inbound transports
 	// but can still initiate outbound connections.
 	ARTransportLimit int `json:"ar_transport_limit,omitempty"`
+	// NoDirectTransports, when true, stops the visor from CREATING direct
+	// peer-to-peer transports (stcpr/sudph/stcp/squicr/swsr/swtr/webrtc) — whether
+	// via autoconnect, the on-demand route-setup hook, `tp add`, or `--direct`.
+	// DMSG (a relay through a dmsg server, not a direct link) is still created, so
+	// the visor keeps a baseline path and can still reach peers over existing
+	// transports/routes. Inbound transports peers dial to us are unaffected.
+	NoDirectTransports bool `json:"no_direct_transports,omitempty"`
+	// TransportCreateDeny is an advanced/testing per-type deny list of transport
+	// types the visor must not create, INCLUDING dmsg (to force a pure-direct or
+	// fully-offline visor). Applied on top of no_direct_transports. Legacy type
+	// aliases (quic/ws/wt) are accepted. Empty/omitted denies nothing.
+	TransportCreateDeny []string `json:"transport_create_deny,omitempty"`
 }
 
 // WTPeer is a statically-configured WebTransport peer (transport.wt_table): the


### PR DESCRIPTION
First change out of the routing examination. Adds a config-driven gate on **outbound transport creation** so an operator (or a test) can stop a visor from creating direct peer-to-peer transports while still keeping **dmsg** — the always-available relay baseline — and still reach peers over existing transports/routes.

## Why

The audit found the "dmsg is a relay, exempt it" rule was re-derived ad hoc in ~4 places with **no shared predicate**, and there was **no way** to express "create/allow dmsg, forbid direct p2p": `min_hops` treats a 1-hop dmsg route identically to a direct one, `policy_per_dial` gates *dials* not *creation*, and `existing-tp`/`public_autoconnect` are all-or-nothing.

## What

Two `transport` config knobs (both `omitempty`, default off):

- **`no_direct_transports`** — refuse creating any **direct** p2p transport (stcpr/sudph/stcp/squicr/swsr/swtr/webrtc). dmsg is exempt (relay, not direct p2p).
- **`transport_create_deny`** — advanced/testing per-type deny list, **including dmsg**, to force a pure-direct or fully-offline visor. Alias-aware (`quic`/`ws`/`wt`).

## How

- **`pkg/transport/types`**: new `IsRelay(Type)` / `IsDirect(Type)` predicates — the single source for the relay/direct split (DMSG is the only relay; webrtc is direct). Replaces the ad-hoc re-derivations.
- **`pkg/transport/manager`**: `transportCreateDenied` / exported `CanCreateTransport`, enforced at the **one** creation chokepoint `saveTransportInternal` (right after `IsKnownNetwork`) — so it covers **every** creation path at once: autoconnect, the on-demand route-setup hook, `tp add`, and `--direct`. New `ErrTransportCreateDisabled`. Gates **only outbound creation**; inbound (accepted) transports and reach-over-existing-route are unaffected.
- **`pkg/visor` autoconnect**: ANDs `CanCreateTransport` into each direct phase's support flag, so a denied type's phase is skipped entirely — no wasted dials, no per-cycle warnings.

## Testing

- Predicate classification (all known types + legacy aliases + unknowns).
- Gate: default-allow; `no_direct_transports` blocks direct + exempts dmsg; deny-list blocks dmsg + is alias-aware.
- `go test -race` on `pkg/transport` + `pkg/transport/types`, `go test` on `pkg/visor` + `pkg/visor/visorconfig` — pass. Lint clean on all changed packages.

## Notes / follow-ups

- Config-driven, read at construction (mirrors `ar_transport_limit`) — a restart applies it. A runtime RPC/CLI toggle for the testing knob is a natural follow-up.
- Inbound transport acceptance is intentionally out of scope (this gates creation only).