### PR TITLE
feat(apps): shared skynet→dmsg dial-fallback primitive; opt-in for proxy + vpn clients

### DIFF
--- a/cmd/apps/skychat/commands/filexfer.go
+++ b/cmd/apps/skychat/commands/filexfer.go
@@ -73,23 +73,14 @@ func isEstablishedPeer(pk cipher.PubKey) bool {
 // fileDialFunc opens a fresh transfer stream to peer on the file port, trying
 // skynet first (on-mesh, IP-anonymous) then dmsg — the same preference order as
 // the chat conn. It always uses SkychatFilePort on both networks.
-func fileDialFunc(_ context.Context, peer cipher.PubKey, port uint16) (net.Conn, error) {
+func fileDialFunc(ctx context.Context, peer cipher.PubKey, port uint16) (net.Conn, error) {
 	if appCl == nil {
 		return nil, fmt.Errorf("skychat: app client not initialized")
 	}
-	var lastErr error
-	for _, netType := range []appnet.Type{appnet.TypeSkynet, appnet.TypeDmsg} {
-		addr := appnet.Addr{Net: netType, PubKey: peer, Port: routing.Port(port)}
-		conn, err := appCl.Dial(addr)
-		if err == nil {
-			return conn, nil
-		}
-		lastErr = err
-	}
-	if lastErr == nil {
-		lastErr = fmt.Errorf("skychat: no network available for file dial")
-	}
-	return nil, lastErr
+	conn, _, err := appnet.DialWithFallback(ctx,
+		func(_ context.Context, addr appnet.Addr) (net.Conn, error) { return appCl.Dial(addr) },
+		peer, routing.Port(port), appnet.TypeSkynet, appnet.TypeDmsg)
+	return conn, err
 }
 
 // acceptInbound implements the auto-accept policy and picks the save path. It

--- a/cmd/apps/skysocks-client/commands/skysocks-client.go
+++ b/cmd/apps/skysocks-client/commands/skysocks-client.go
@@ -49,6 +49,7 @@ var (
 	reconnect      bool
 	reconnectDelay int64
 	direct         bool
+	dmsgFallback   bool
 )
 
 func init() {
@@ -69,6 +70,7 @@ func init() {
 	RootCmd.Flags().BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure (vs exiting)")
 	RootCmd.Flags().Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between in-process reconnect attempts")
 	RootCmd.Flags().BoolVar(&direct, "direct", false, "force a direct-transport-only route to the server (create the transport on demand, dial 1-hop, bypass the route-finder + setup node); self-heals when the server restarts")
+	RootCmd.Flags().BoolVar(&dmsgFallback, "dmsg-fallback", false, "if the skynet (route) dial to the server fails, fall back to a direct dmsg stream (opt-in: dmsg relays via a dmsg server — higher latency + the server sees both endpoint PKs)")
 }
 
 // RootCmd is the root command for skysocks
@@ -103,6 +105,7 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 		fs.BoolVar(&reconnect, "reconnect", false, "in-process reconnect on stream failure")
 		fs.Int64Var(&reconnectDelay, "reconnect-delay", 2, "seconds between reconnect attempts")
 		fs.BoolVar(&direct, "direct", false, "force a direct-transport-only route to the server (1-hop, bypass the route-finder + setup node); self-heals on server restart")
+		fs.BoolVar(&dmsgFallback, "dmsg-fallback", false, "fall back to a direct dmsg stream if the skynet dial fails")
 		if err := fs.Parse(args); err != nil {
 			return fmt.Errorf("failed to parse flags: %w", err)
 		}
@@ -267,23 +270,23 @@ func RunSkysocksClient(ctx context.Context, args []string) error {
 func dialServer(ctx context.Context, appCl *app.Client, pk cipher.PubKey, port routing.Port) (net.Conn, error) {
 	//nolint:errcheck
 	appCl.SetDetailedStatus(appserver.AppDetailedStatusStarting) //nolint:errcheck,gosec
+	// dial one network to the server. On skynet, --direct forces a 1-hop
+	// direct-transport-only dial (create-on-demand, bypass the route-finder +
+	// setup node, self-heals on server restart); dmsg is a plain relay stream.
+	dial := func(_ context.Context, a appnet.Addr) (net.Conn, error) {
+		if a.Net == netType && direct {
+			return appCl.DialWithOptions(a, 0, 0, 0, 0, 0, 0, true)
+		}
+		return appCl.Dial(a)
+	}
+	nets := []appnet.Type{netType}
+	if dmsgFallback {
+		nets = append(nets, appnet.TypeDmsg)
+	}
 	var conn net.Conn
 	err := r.Do(ctx, func() error {
 		var err error
-		dstAddr := appnet.Addr{
-			Net:    netType,
-			PubKey: pk,
-			Port:   port,
-		}
-		if direct {
-			// Direct-transport-only: the router creates a direct transport to
-			// the server if none exists and dials 1-hop over it, bypassing the
-			// route-finder and setup node (and therefore the destination
-			// circuit breaker). Self-heals when the server restarts.
-			conn, err = appCl.DialWithOptions(dstAddr, 0, 0, 0, 0, 0, 0, true)
-		} else {
-			conn, err = appCl.Dial(dstAddr)
-		}
+		conn, _, err = appnet.DialWithFallback(ctx, dial, pk, port, nets...)
 		return err
 	})
 	if err != nil {

--- a/cmd/apps/vpn-client/commands/vpn-client.go
+++ b/cmd/apps/vpn-client/commands/vpn-client.go
@@ -32,20 +32,21 @@ import (
 )
 
 var (
-	serverPKStr string
-	localPKStr  string
-	localSKStr  string
-	killswitch  bool
-	dnsAddr     string
-	appPort     uint16
-	muxRoutes   int
-	minHops     int
-	meshGateway bool
-	meshGWCIDR  string
-	meshTLS     bool
-	meshCACert  string
-	meshCAKey   string
-	meshAliases []string
+	serverPKStr  string
+	localPKStr   string
+	localSKStr   string
+	killswitch   bool
+	dnsAddr      string
+	appPort      uint16
+	muxRoutes    int
+	minHops      int
+	dmsgFallback bool
+	meshGateway  bool
+	meshGWCIDR   string
+	meshTLS      bool
+	meshCACert   string
+	meshCAKey    string
+	meshAliases  []string
 )
 
 // defaultMeshCADir is where the client mesh gateway persists its self-generated
@@ -62,6 +63,7 @@ func init() {
 	RootCmd.Flags().Uint16Var(&appPort, "port", 0, "routing port for communication between app and visor")
 	RootCmd.Flags().IntVar(&muxRoutes, "mux", 0, "dial the server over this many parallel (multiplexed) routes")
 	RootCmd.Flags().IntVar(&minHops, "min-hops", 0, "force the route through at least this many intermediate visors")
+	RootCmd.Flags().BoolVar(&dmsgFallback, "dmsg-fallback", false, "if the skynet (route) dial to the server fails, fall back to a direct dmsg stream (opt-in: dmsg relays via a dmsg server — higher latency + the server sees both endpoint PKs)")
 	RootCmd.Flags().BoolVar(&meshGateway, "mesh-gateway", false, "mesh gateway: resolve *.dmsg / *.skynet on this host and proxy them over the mesh (opt-in; Linux only)")
 	RootCmd.Flags().StringVar(&meshGWCIDR, "mesh-gateway-cidr", "", "mesh-gateway synthetic-IP pool (empty = 100.64.0.0/16)")
 	RootCmd.Flags().BoolVar(&meshTLS, "mesh-gateway-tls", false, "mesh gateway: TLS-MITM HTTPS to *.dmsg/*.skynet with a self-generated CA (host must trust it)")
@@ -115,6 +117,7 @@ func RunVPNClient(ctx context.Context, args []string) error {
 		fs.Uint16Var(&appPort, "port", 0, "routing port")
 		fs.IntVar(&muxRoutes, "mux", 0, "multiplexed route count")
 		fs.IntVar(&minHops, "min-hops", 0, "minimum hops")
+		fs.BoolVar(&dmsgFallback, "dmsg-fallback", false, "fall back to a direct dmsg stream if the skynet dial fails")
 		fs.BoolVar(&meshGateway, "mesh-gateway", false, "mesh gateway")
 		fs.StringVar(&meshGWCIDR, "mesh-gateway-cidr", "", "mesh-gateway synthetic-IP pool")
 		fs.BoolVar(&meshTLS, "mesh-gateway-tls", false, "mesh-gateway TLS-MITM")
@@ -241,11 +244,12 @@ func RunVPNClient(ctx context.Context, args []string) error {
 	}
 
 	vpnClientCfg := vpn.ClientConfig{
-		Killswitch: killswitch,
-		ServerPK:   serverPK,
-		DNSAddr:    dnsAddress,
-		MuxRoutes:  muxRoutes,
-		MinHops:    minHops,
+		Killswitch:   killswitch,
+		ServerPK:     serverPK,
+		DNSAddr:      dnsAddress,
+		MuxRoutes:    muxRoutes,
+		MinHops:      minHops,
+		DmsgFallback: dmsgFallback,
 	}
 
 	if meshGateway {

--- a/pkg/app/appnet/dial_fallback.go
+++ b/pkg/app/appnet/dial_fallback.go
@@ -1,0 +1,65 @@
+// Package appnet pkg/app/appnet/dial_fallback.go c1-app-net
+package appnet
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// ConnDialer dials a single appnet Addr and returns the resulting conn or an
+// error. It abstracts over the concrete dial primitive a caller uses (the RPC
+// app.Client, the in-visor appnet.DialContext, a raw dmsg client, …) so the
+// ordered-try logic below can be shared regardless of how each network dials.
+type ConnDialer func(ctx context.Context, addr Addr) (net.Conn, error)
+
+// DialWithFallback dials pk:port over each network in nets IN ORDER, returning
+// the first successful conn and the network that carried it. This is the single
+// shared "try skynet, then dmsg" primitive — replacing the per-app copies of the
+// same ordered-try loop (skychat filexfer, skysocks-client, …). dmsg is the
+// natural last entry: it relays through a dmsg server, so it's the
+// always-available baseline when a direct/route network can't reach the peer.
+//
+// Networks are tried sequentially (not raced): the first is the preferred path,
+// later ones are fallbacks tried only after the preferred one fails. Empty net
+// entries are skipped. If every dial fails, the last error is returned (wrapped);
+// if nets is empty, a descriptive error is returned.
+func DialWithFallback(ctx context.Context, dial ConnDialer, pk cipher.PubKey, port routing.Port, nets ...Type) (net.Conn, Type, error) {
+	var lastErr error
+	for _, n := range nets {
+		if n == "" {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil, "", ctx.Err()
+		default:
+		}
+		conn, err := dial(ctx, Addr{Net: n, PubKey: pk, Port: port})
+		if err == nil {
+			return conn, n, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		return nil, "", fmt.Errorf("appnet: no network to dial %s:%d", pk, port)
+	}
+	return nil, "", fmt.Errorf("appnet: all networks failed to dial %s:%d: %w", pk, port, lastErr)
+}
+
+// OtherNet returns the alternate of the two first-class app networks
+// (skynet↔dmsg), or "" for any other/unknown value. Small shared helper for the
+// "dial the OTHER network" fallback pattern.
+func OtherNet(n Type) Type {
+	switch n {
+	case TypeSkynet:
+		return TypeDmsg
+	case TypeDmsg:
+		return TypeSkynet
+	default:
+		return ""
+	}
+}

--- a/pkg/app/appnet/dial_fallback_test.go
+++ b/pkg/app/appnet/dial_fallback_test.go
@@ -1,0 +1,97 @@
+// Package appnet pkg/app/appnet/dial_fallback_test.go
+package appnet
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestDialWithFallback(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+
+	t.Run("first network wins, no fallback attempted", func(t *testing.T) {
+		var tried []Type
+		dial := func(_ context.Context, a Addr) (net.Conn, error) {
+			tried = append(tried, a.Net)
+			return &net.TCPConn{}, nil
+		}
+		conn, used, err := DialWithFallback(context.Background(), dial, pk, 1, TypeSkynet, TypeDmsg)
+		if err != nil || conn == nil {
+			t.Fatalf("expected success, got conn=%v err=%v", conn, err)
+		}
+		if used != TypeSkynet {
+			t.Errorf("expected skynet to carry, got %q", used)
+		}
+		if len(tried) != 1 || tried[0] != TypeSkynet {
+			t.Errorf("fallback must not be attempted when the first net succeeds; tried=%v", tried)
+		}
+	})
+
+	t.Run("falls through to dmsg when skynet fails", func(t *testing.T) {
+		var tried []Type
+		dial := func(_ context.Context, a Addr) (net.Conn, error) {
+			tried = append(tried, a.Net)
+			if a.Net == TypeSkynet {
+				return nil, errors.New("skynet down")
+			}
+			return &net.TCPConn{}, nil
+		}
+		conn, used, err := DialWithFallback(context.Background(), dial, pk, 1, TypeSkynet, TypeDmsg)
+		if err != nil || conn == nil {
+			t.Fatalf("expected dmsg fallback success, got err=%v", err)
+		}
+		if used != TypeDmsg {
+			t.Errorf("expected dmsg to carry, got %q", used)
+		}
+		if len(tried) != 2 {
+			t.Errorf("expected both nets tried in order, got %v", tried)
+		}
+	})
+
+	t.Run("no fallback net → only skynet tried", func(t *testing.T) {
+		var tried []Type
+		dial := func(_ context.Context, a Addr) (net.Conn, error) {
+			tried = append(tried, a.Net)
+			return nil, errors.New("down")
+		}
+		_, _, err := DialWithFallback(context.Background(), dial, pk, 1, TypeSkynet)
+		if err == nil {
+			t.Fatal("expected error when the only net fails")
+		}
+		if len(tried) != 1 {
+			t.Errorf("expected only skynet tried, got %v", tried)
+		}
+	})
+
+	t.Run("canceled context stops before dialing", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		called := false
+		dial := func(_ context.Context, _ Addr) (net.Conn, error) {
+			called = true
+			return &net.TCPConn{}, nil
+		}
+		if _, _, err := DialWithFallback(ctx, dial, pk, 1, TypeSkynet, TypeDmsg); err == nil {
+			t.Error("expected context error")
+		}
+		if called {
+			t.Error("dial must not be attempted once ctx is canceled")
+		}
+	})
+}
+
+func TestOtherNet(t *testing.T) {
+	if OtherNet(TypeSkynet) != TypeDmsg {
+		t.Error("skynet's other net is dmsg")
+	}
+	if OtherNet(TypeDmsg) != TypeSkynet {
+		t.Error("dmsg's other net is skynet")
+	}
+	if OtherNet("bogus") != "" {
+		t.Error("unknown net has no alternate")
+	}
+}

--- a/pkg/vpn/client.go
+++ b/pkg/vpn/client.go
@@ -725,22 +725,19 @@ func (c *Client) dialServer(appCl *app.Client, pk cipher.PubKey) (net.Conn, erro
 		serverPort = routing.Port(skyenv.VPNServerPort) // VPN server port (44)
 	)
 
-	addr := appnet.Addr{
-		Net:    netType,
-		PubKey: pk,
-		Port:   serverPort,
+	// dial one network to the server. On skynet, honor the per-call route options
+	// (mux/min-hops) when set; dmsg is a plain relay stream with no such options.
+	dial := func(_ context.Context, a appnet.Addr) (net.Conn, error) {
+		if a.Net == netType && (c.cfg.MuxRoutes > 1 || c.cfg.MinHops >= 2) {
+			return appCl.DialWithOptions(a, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0, false)
+		}
+		return appCl.Dial(a)
 	}
-
-	var conn net.Conn
-	var err error
-	// Use the per-call dial options only when the user asked for multiplexed
-	// or multihop routing; otherwise keep the plain single-route dial.
-	if c.cfg.MuxRoutes > 1 || c.cfg.MinHops >= 2 {
-		conn, err = appCl.DialWithOptions(addr, c.cfg.MuxRoutes, c.cfg.MinHops, 0, 0, 0, 0, false)
-	} else {
-		conn, err = appCl.Dial(addr)
+	nets := []appnet.Type{netType}
+	if c.cfg.DmsgFallback {
+		nets = append(nets, appnet.TypeDmsg)
 	}
-
+	conn, _, err := appnet.DialWithFallback(context.Background(), dial, pk, serverPort, nets...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vpn/client_config.go
+++ b/pkg/vpn/client_config.go
@@ -18,6 +18,13 @@ type ClientConfig struct {
 	// direct path. Both default to 0 (the plain single-route dial).
 	MuxRoutes int
 	MinHops   int
+	// DmsgFallback, when true, dials the VPN server over a direct dmsg stream if
+	// the skynet (route) dial fails. Opt-in: dmsg relays through a dmsg server, so
+	// the fallback trades higher latency and a metadata downgrade (the dmsg server
+	// sees both endpoint PKs, unlike a source-routed multihop skynet path) for the
+	// resilience of an always-available baseline. Default off keeps the plain
+	// skynet-only dial.
+	DmsgFallback bool
 
 	// MeshGateway, when true (Linux only), additionally runs a local MESH
 	// GATEWAY: the host resolves *.dmsg / *.skynet by name and those connections


### PR DESCRIPTION
Second change out of the routing examination (threads 1 & 3 — the cross-network fallback unevenness).

## Why

The audit found cross-network (skynet↔dmsg) fallback implemented **ad hoc and unevenly**: skychat did it three different ways, while **skysocks-client and vpn-client were skynet-only with no fallback at all**, and skydex is dmsg-only. Examining the three skychat copies showed only one (filexfer) is a clean ordered-try; the DM controller (write-time last-resort intertwined with conn eviction + message framing) and voice (two different dial primitives) legitimately differ — so this consolidates what *should* be shared without forcing the two that shouldn't.

## What

- **`appnet.DialWithFallback(ctx, dial, pk, port, nets…)`** — one shared primitive: dial each network in order, return the first success + the network that carried it. dmsg is the natural last entry (a relay through a dmsg server = the always-available baseline). Plus **`appnet.OtherNet`** for the "dial the other network" pattern.
- **skychat filexfer** → uses the primitive (behavior-preserving).
- **skysocks-client + vpn-client** → new **`--dmsg-fallback`** flag (**default off, opt-in**) appending dmsg as a fallback network.

## The default is off, and identical for both clients

dmsg relays through a dmsg server, so a dmsg fallback trades **higher latency** and a **metadata downgrade** — the server sees both endpoint PKs, unlike a source-routed multihop skynet path where no single intermediate knows both ends — for resilience. That trade-off is the **same** for a proxy stream and a vpn tunnel, so both clients get identical opt-in semantics (no special-casing). `--direct` (skysocks) and `--mux`/`--min-hops` (vpn) still apply only to the skynet leg; dmsg is a plain relay stream.

## Testing

- Primitive: preferred-net-wins (no fallback attempted), fall-through to dmsg, single-net failure, ctx-cancel; `OtherNet`.
- `go build ./...`, `go test` on `pkg/app/appnet` + `pkg/vpn` + the app command packages, lint clean on all changed packages.

## Notes

- Left intentionally as-is (examined, legitimately different): skychat DM controller + voice fallbacks.
- Follow-up candidate: promote `--dmsg-fallback` to a config/default decision per deployment once validated.