### PR TITLE
fix(wasm): dial skysocks over a single route, not a 2-route mux

### DIFF
--- a/cmd/wasm-visor/skysocks_js.go
+++ b/cmd/wasm-visor/skysocks_js.go
@@ -116,14 +116,16 @@ func skysocksSession(winID string, serverPK cipher.PubKey) (*yamux.Session, erro
 	// try another, not hang ~45s. Runs off skysocksMu so exits establish in parallel.
 	dctx, cancel := context.WithTimeout(ctx, 18*time.Second)
 	defer cancel()
-	// Optimized routing for the browsing proxy: request a small mux (2 parallel
-	// routes) for throughput + mid-browse resilience — if one route degrades the
-	// other carries and the router's mux-auto GROW adapts. Latency weighting is
-	// the route-finder default. The policy DialHook clamps this, and it degrades
-	// gracefully to a single route when mux isn't available, so it's safe.
-	dopts := router.DefaultDialOptions()
-	dopts.MuxRoutes = 2
-	conn, err := rtr.DialRoutes(dctx, serverPK, 0, skysocksPort, dopts)
+	// Single route to the skysocks server — matching the native visor's working
+	// BrowseClearnet path (which dials with nil opts). Requesting a 2-route mux
+	// here looked cheap but broke browsing: the mux route group reports "2/2
+	// established", yet the yamux session over it immediately reads EOF ("socks
+	// connect tcp: session shutdown") — the mux data plane never carries the
+	// skysocks bytes to the exit, so every fetch failed. The native's single
+	// route to the SAME exit returns 200, so we mirror it. mux-auto GROW can
+	// still adapt an established single route later; it just isn't requested up
+	// front where it was silently killing the session.
+	conn, err := rtr.DialRoutes(dctx, serverPK, 0, skysocksPort, router.DefaultDialOptions())
 	if err != nil {
 		emitProxyLog(winID, fmt.Sprintf("[skysocks-lite %s] route dial to exit %s FAILED (%dms): %v", winID, serverPK.Hex()[:8], time.Since(t0).Milliseconds(), err))
 		return nil, fmt.Errorf("dial skysocks route: %w", err)


### PR DESCRIPTION
The browser proxy (`fetchClearnet` → `skysocksSession`) dialed the exit with `DialOptions.MuxRoutes = 2`. The mux route group reports "2/2 established", but the yamux session over it immediately reads **EOF** (`socks connect tcp: session shutdown`), so every clearnet fetch failed.

Root cause (confirmed against the mux code): a mux aux leg that black-holes *beyond the first hop* keeps being selected — the ready-gate only guards the local send side, not a silently-forwarding-but-dropping intermediate — and the reorder buffer force-flushes out of order only after 64 backlogged packets. So a freshly-established multihop mux leg silently loses the SOCKS-handshake bytes and the stream breaks.

The native visor's `BrowseClearnet` dials the **same exit** with a single route (`nil` opts) and returns 200. Mirror that: dial skysocks with `router.DefaultDialOptions()` (single route). mux-auto GROW can still adapt an established route afterward; it just isn't requested up front where it was killing the session.

**Verified live:** with the single-route dial, the wasm visor browses clearnet through a mesh skysocks exit — HTTP 200, egress IP = the exit's IP.

Wasm-only (`cmd/wasm-visor/skysocks_js.go`); blob re-embeds at release. `GOOS=js GOARCH=wasm` build passes.