### PR TITLE
perf(router): race transport creation against routing over existing transports

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -95,6 +95,14 @@ type Config struct {
 	RulesGCInterval  time.Duration
 	MinHops          uint16
 	MaxHops          uint16
+	// DisableRaceRouteSetup turns OFF the app-dial race (default: race ON).
+	// Normally, when a dial would create a direct transport to the peer
+	// (min-hops==1, not existing-tp-only), DialRoutes runs that transport
+	// creation in the BACKGROUND and concurrently tries to route over EXISTING
+	// transports — returning as soon as either lands, instead of blocking on the
+	// (~20s worst-case) transport dial first. Set true to restore the legacy
+	// synchronous behavior (create-transport-then-route) as a safety valve.
+	DisableRaceRouteSetup bool
 	// AwaitSetupListener, if non-nil, is used instead of opening a fresh
 	// listener on DmsgAwaitSetupPort. This lets callers reserve the port
 	// earlier in init (before the transport manager is ready) so peers

--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -150,17 +150,43 @@ func (r *router) DialRoutes(
 	// Only run route setup hooks (which may create new transports) if UseExistingTpOnly is false
 	// on both the router level and the dial options level
 	useExistingOnly := routerExistingTpOnly || (opts != nil && opts.UseExistingTpOnly)
+	// hookDone, when non-nil, signals completion of a BACKGROUND transport-
+	// creation hook (the race path). The fetch loop waits on it only if it can't
+	// find a route over existing transports (see the fetch-error branch below).
+	var hookDone chan struct{}
 	if baseMinHops == 1 && !useExistingOnly {
 		r.routeSetupHookMu.Lock()
-		if len(r.routeSetupHooks) != 0 {
-			for _, rsf := range r.routeSetupHooks {
-				if err := rsf(rPK, r.tm); err != nil {
-					r.routeSetupHookMu.Unlock()
-					return nil, err
+		hooks := r.routeSetupHooks
+		r.routeSetupHookMu.Unlock()
+		if len(hooks) != 0 {
+			if r.conf.DisableRaceRouteSetup {
+				// Legacy synchronous path: create the transport, THEN route.
+				for _, rsf := range hooks {
+					if err := rsf(rPK, r.tm); err != nil {
+						return nil, err
+					}
 				}
+			} else {
+				// RACE (thread 1): the transport-creation hook can block ~20s
+				// (STCPR→SUDPH→DMSG dial attempts) before we ever query the
+				// route-finder. Run it in the BACKGROUND and route over EXISTING
+				// transports meanwhile — whichever lands first wins. The hook still
+				// creates the direct transport regardless (it self-manages its own
+				// context, so it's NOT canceled when this dial returns): it's ready
+				// for the next dial / a later upgrade. The fetch loop waits on
+				// hookDone only when no existing route is found, so a cold peer
+				// still gets connectivity via the freshly-created transport.
+				hookDone = make(chan struct{})
+				go func() {
+					defer close(hookDone)
+					for _, rsf := range hooks {
+						if err := rsf(rPK, r.tm); err != nil {
+							log.WithError(err).Debug("background route-setup hook (transport creation) failed; relying on existing routes")
+						}
+					}
+				}()
 			}
 		}
-		r.routeSetupHookMu.Unlock()
 	} else if useExistingOnly {
 		log.Debug("UseExistingTpOnly is set, skipping transport creation hooks")
 	}
@@ -195,6 +221,23 @@ func (r *router) DialRoutes(
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		forwardPath, reversePath, err := r.fetchBestRoutes(ctx, log, lPK, rPK, opts, baseMinHops)
 		if err != nil {
+			// RACE fallback: no route over existing transports (yet). If the
+			// background transport-creation hook is still running, wait for it
+			// ONCE — the direct transport it creates yields a 1-hop route on the
+			// next fetch. This is the cold-peer half of the race: when the shaped
+			// network has no usable route, we still get connectivity via the new
+			// transport, bounded by the dial ctx. A warm peer never reaches here
+			// (its fetch succeeded), so it never blocks on the hook.
+			if hookDone != nil {
+				log.Debug("No route over existing transports; waiting for background transport creation")
+				select {
+				case <-hookDone:
+					hookDone = nil // wait at most once
+					continue
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
 			if attempt < maxFetchAttempts {
 				log.WithError(err).Warnf("Route finder failed (attempt %d/%d), retrying with fresh query...", attempt, maxRetries)
 				continue


### PR DESCRIPTION
Part of the routing examination (thread 1 — race the route-finder against transport setup on app dial).

## Problem

An app dial that would create a direct transport to the peer (min-hops==1, not existing-tp-only) ran the transport-creation route-setup hook **synchronously** — STCPR→SUDPH→DMSG, each a 3-try retrier, up to ~20s worst case — **before** the route-finder was ever queried. So a peer already reachable over the visor's existing (autoconnect-shaped) transports still paid the full direct-dial latency first. Measured earlier: this is the dominant cost of "time to first transport / first app connect."

## Change

`DialRoutes` now runs that hook in the **background** and immediately tries to route over **existing** transports; whichever lands first wins:

- **Warm peer** (a route over existing transports exists): the fetch loop returns it immediately — no blocking on transport creation. The hook still finishes in the background and registers the direct transport for the next dial / a later upgrade. It self-manages its own context, so it is **not** cancelled when this dial returns — the "never cancel the transport" invariant.
- **Cold peer** (no existing route): the fetch loop finds nothing, waits on the hook **once** (bounded by the dial ctx), then the freshly-created transport yields a 1-hop route — same outcome as before, no slower.

This is the "consume the shaped network first, shape on-demand only if nothing exists" behavior: better autoconnect shaping ⇒ the warm path wins more often ⇒ faster app connects.

## Scope & safety

- Only the **min-hops==1, !UseExistingTpOnly** branch changes. `min-hops>=2`, existing-tp-only, and `--direct` paths are untouched.
- Gated by a new **`Config.DisableRaceRouteSetup`** (default `false` = race **ON**) as a safety valve to restore the legacy synchronous behavior if ever needed.

## Testing

- `go build` / `go vet` / `golangci-lint` clean on `pkg/router`.
- **Live on a native visor** (rebuilt with the change): app dials over skynet (skychat native→wasm, skysocks-client) route over existing transports and connect in ~0.5s (skychat ACK 555ms), with **0 panic/watchdog events** across the run — no regression.