### PR TITLE
feat(autoconfig): add --transport-port (shared master transport port)

### DIFF
--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -163,6 +163,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	// Transport ports
 	addInt("STCPRPORT", "stcpr", autoconfigVals.StcprPort)
 	addInt("SUDPHPORT", "sudph", autoconfigVals.SudphPort)
+	addInt("TRANSPORTPORT", "transport-port", autoconfigVals.TransportPort)
 	addInt("LANDMSGPORT", "lan-dmsg-port", autoconfigVals.LanDmsgPort)
 	addString("LANDMSGPUBLIC", "lan-dmsg-public", autoconfigVals.LanDmsgPublic)
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -128,6 +128,7 @@ type Values struct {
 	// --- Transport ports ---
 	StcprPort     int
 	SudphPort     int
+	TransportPort int
 	LanDmsgPort   int
 	LanDmsgPublic string
 
@@ -279,6 +280,7 @@ func New(v *Values) *cobra.Command {
 	// --- Transport ports ---
 	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "stcp transport listening port (0 = leave unchanged, random at runtime) — writes STCPRPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
+	cmd.Flags().IntVar(&v.TransportPort, "transport-port", 0, "ONE shared master port for ALL transport types — stcpr+WS on <port>/tcp, sudph+quic+wt+webrtc on <port>/udp (0 = per-type ports) — writes TRANSPORTPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
 
@@ -423,6 +425,7 @@ var envMap = map[string]EnvMapping{
 	// non-zero value.
 	"stcpr":           {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
 	"sudph":           {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"transport-port":  {Key: "TRANSPORTPORT", Format: EnvFormatInt, Default: "0 (per-type ports)"},
 	"lan-dmsg-port":   {Key: "LANDMSGPORT", Format: EnvFormatInt, Default: "0 (random)"},
 	"lan-dmsg-public": {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
 

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd_test.go
@@ -18,7 +18,7 @@ var allFlags = []string{
 	// Service discovery / deployment
 	"testenv", "url", "svcconf", "minsess", "maxtransports", "stun",
 	// Transport ports
-	"stcpr", "sudph", "lan-dmsg-port", "lan-dmsg-public",
+	"stcpr", "sudph", "transport-port", "lan-dmsg-port", "lan-dmsg-public",
 	// Whitelists
 	"dmsgpty-pks", "survey", "routesetup", "tpsetup",
 	// Route calculation
@@ -116,6 +116,7 @@ func TestNew_BindingsTrackValues(t *testing.T) {
 		{"pk-endpoint", "true", func() bool { return v.PkEndpoint }},
 		{"no-pk-endpoint", "true", func() bool { return v.NoPkEndpoint }},
 		{"stcpr", "7777", func() bool { return v.StcprPort == 7777 }},
+		{"transport-port", "7777", func() bool { return v.TransportPort == 7777 }},
 		// New flags from the parity expansion: cover one per group.
 		{"testenv", "true", func() bool { return v.TestEnv }},
 		{"minsess", "5", func() bool { return v.MinSess == 5 }},


### PR DESCRIPTION
`skywire autoconfig` could set per-type transport ports (`--stcpr` / `--sudph`) but **not** the unified master port — even though `config gen` has had `--transport-port` for a while. So the autoconfig-driven install path, **and the web install-command generator** (which enumerates the `autoconfig` flag set via wasm), had no way to configure the one-port-for-all-transports setup.

Adds `--transport-port` to `autoconfig`, mirroring `--stcpr`/`--sudph`:
- `Values.TransportPort` + the `IntVar` flag,
- `EnvMap`: `transport-port → TRANSPORTPORT`,
- the skywire.conf writer (`addInt("TRANSPORTPORT", …)`).

`config gen` already consumes `TRANSPORTPORT` to set `transport.transport_port` (stcpr + WS on `<port>`/tcp; sudph + quic + WebTransport + WebRTC on `<port>`/udp, demuxed by protocol), so the chain autoconfig → skywire.conf → config gen is complete. Test covers the flag parse; `autoconfig --help` shows it.

Unblocks the apt-repo install-command generator update (surfacing `--transport-port` + the one-port-forward guidance).