### PR TITLE
feat(config): autoconfig + config-gen flags for privacy/routing knobs

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -203,6 +203,9 @@ func init() {
 	// protocol). Per-type ports above override it. Visible because this is the
 	// recommended way to expose a public visor behind a single firewall rule.
 	genConfigCmd.Flags().IntVar(&transportPort, "transport-port", scriptExecInt("${TRANSPORTPORT:-0}"), "shared master transport port for all transport types (0 = per-type ports)")
+	genConfigCmd.Flags().IntVar(&genMinHops, "min-hops", scriptExecInt("${MINHOPS:-1}"), "minimum route hops (1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy)")
+	genConfigCmd.Flags().IntVar(&arTransportLimit, "ar-transport-limit", scriptExecInt("${ARTRANSPORTLIMIT:-0}"), "address-resolver registration: 0 = stay registered, N>0 = deregister after N transports, N<0 = never register (inbound-invisible)")
+	genConfigCmd.Flags().BoolVar(&noDirectTransports, "no-direct-transports", scriptExecBool("${NODIRECTTRANSPORTS:-false}"), "never create direct p2p transports; dmsg (relay) is still allowed")
 
 	// Routing flags
 	msg = "add route setup node PKs"
@@ -1182,10 +1185,21 @@ func configureTransports() {
 			Location:         tpLogPath,
 			RotationInterval: visorconfig.DefaultLogRotationInterval,
 		},
-		SudphPort:     sudphPort,
-		StcprPort:     stcprPort,
-		TransportPort: transportPort,
+		SudphPort:          sudphPort,
+		StcprPort:          stcprPort,
+		TransportPort:      transportPort,
+		ARTransportLimit:   arTransportLimit,
+		NoDirectTransports: noDirectTransports,
 	}
+}
+
+// minHopsValue returns the --min-hops flag value clamped to a valid uint16.
+// Negative input (nonsensical for a hop count) is treated as 0 (no minimum).
+func minHopsValue() uint16 {
+	if genMinHops < 0 {
+		return 0
+	}
+	return uint16(genMinHops)
 }
 
 // configureRouting sets up routing configuration on conf, preserving MinHops
@@ -1195,7 +1209,7 @@ func configureRouting() {
 		RouteFinder:        services.RouteFinder,     //utilenv.RouteFinderAddr,
 		RouteSetupNodes:    services.RouteSetupNodes, //[]cipher.PubKey{utilenv.MustPK(utilenv.SetupPK)},
 		RouteFinderTimeout: visorconfig.DefaultTimeout,
-		MinHops:            1,
+		MinHops:            minHopsValue(),
 		CalculateRoutes:    enableCalculateRoutes,
 		// Cascade route setup is opt-in (--cascade); the legacy setup-node
 		// path stays the default until the cascade multihop data-plane bug
@@ -1208,7 +1222,10 @@ func configureRouting() {
 	}
 
 	if oldConfCache != nil && oldConfCache.Routing != nil {
-		if oldConfCache.Routing.MinHops != 0 {
+		// Preserve the previous min_hops across regen UNLESS --min-hops (or
+		// MINHOPS in skywire.conf) was set to a non-default value this run, in
+		// which case the new value already in the literal above wins.
+		if oldConfCache.Routing.MinHops != 0 && minHopsValue() == 1 {
 			conf.Routing.MinHops = oldConfCache.Routing.MinHops
 		}
 		// Preserve an opted-in cascade across regen (matches MinHops). To turn
@@ -2268,14 +2285,15 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 	// Map of flag names to the SKYENV variable they control.
 	// When a flag is explicitly set, uncomment the corresponding line.
 	flagToEnv := map[string]string{
-		"pkg":      "PKGENV=true",
-		"ishv":     "ISHYPERVISOR=true",
-		"testenv":  "TESTENV=true",
-		"dmsghttp": "DMSGHTTP=true",
-		"public":   "VISORISPUBLIC=true",
-		"servevpn": "VPNSERVER=true",
-		"autoconn": "DISABLEPUBLICAUTOCONN=true",
-		"publicip": "DISPLAYNODEIP=true",
+		"pkg":                  "PKGENV=true",
+		"ishv":                 "ISHYPERVISOR=true",
+		"testenv":              "TESTENV=true",
+		"dmsghttp":             "DMSGHTTP=true",
+		"public":               "VISORISPUBLIC=true",
+		"servevpn":             "VPNSERVER=true",
+		"autoconn":             "DISABLEPUBLICAUTOCONN=true",
+		"publicip":             "DISPLAYNODEIP=true",
+		"no-direct-transports": "NODIRECTTRANSPORTS=true",
 	}
 
 	// Also handle string/value flags
@@ -2290,9 +2308,11 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 	// When the flag is explicitly set, uncomment + replace with the value so
 	// `config gen --transport-port 7777 -q` reflects it in the template.
 	intFlagToEnv := map[string]string{
-		"transport-port": "TRANSPORTPORT",
-		"stcpr":          "STCPRPORT",
-		"sudph":          "SUDPHPORT",
+		"transport-port":     "TRANSPORTPORT",
+		"stcpr":              "STCPRPORT",
+		"sudph":              "SUDPHPORT",
+		"min-hops":           "MINHOPS",
+		"ar-transport-limit": "ARTRANSPORTLIMIT",
 	}
 
 	// Array-shaped flags map to bash-array env vars of the form

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -28,6 +28,9 @@ var (
 	stcprPort                  int
 	sudphPort                  int
 	transportPort              int
+	genMinHops                 int
+	arTransportLimit           int
+	noDirectTransports         bool
 	sk                         cipher.SecKey
 	output                     string
 	confPath                   string

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -158,6 +158,9 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addString("SVCCONF", "svcconf", autoconfigVals.SvcConf)
 	addInt("MINDMSGSESS", "minsess", autoconfigVals.MinSess)
 	addInt("MAXTRANSPORTS", "maxtransports", autoconfigVals.MaxTransports)
+	addInt("MINHOPS", "min-hops", autoconfigVals.MinHops)
+	addInt("ARTRANSPORTLIMIT", "ar-transport-limit", autoconfigVals.ARTransportLimit)
+	addSoloBool("NODIRECTTRANSPORTS", "no-direct-transports", autoconfigVals.NoDirectTransports)
 	addArray("STUNSERVERS", "stun", autoconfigVals.StunServers)
 
 	// Transport ports

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -132,6 +132,11 @@ type Values struct {
 	LanDmsgPort   int
 	LanDmsgPublic string
 
+	// --- Privacy / routing knobs ---
+	MinHops            int  // MINHOPS (>=2 forces multihop for sender privacy)
+	ARTransportLimit   int  // ARTRANSPORTLIMIT (address-resolver registration policy)
+	NoDirectTransports bool // NODIRECTTRANSPORTS (never create direct p2p transports)
+
 	// --- Whitelists ---
 	DmsgptyPks     string
 	SurveyPks      string // SURVEYPKS
@@ -281,6 +286,9 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().IntVar(&v.StcprPort, "stcpr", 0, "stcp transport listening port (0 = leave unchanged, random at runtime) — writes STCPRPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.SudphPort, "sudph", 0, "sudp transport listening port (0 = leave unchanged, random at runtime) — writes SUDPHPORT in skywire.conf")
 	cmd.Flags().IntVar(&v.TransportPort, "transport-port", 0, "ONE shared master port for ALL transport types — stcpr+WS on <port>/tcp, sudph+quic+wt+webrtc on <port>/udp (0 = per-type ports) — writes TRANSPORTPORT in skywire.conf")
+	cmd.Flags().IntVar(&v.MinHops, "min-hops", 1, "minimum route hops — 1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy — writes MINHOPS in skywire.conf")
+	cmd.Flags().IntVar(&v.ARTransportLimit, "ar-transport-limit", 0, "address-resolver registration: 0 = stay registered, N>0 = deregister after N transports, N<0 = never register (inbound-invisible) — writes ARTRANSPORTLIMIT in skywire.conf")
+	cmd.Flags().BoolVar(&v.NoDirectTransports, "no-direct-transports", false, "never create direct p2p transports; dmsg relay still allowed — writes NODIRECTTRANSPORTS=true in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
 
@@ -423,11 +431,16 @@ var envMap = map[string]EnvMapping{
 	// Transport ports. 0 = OS-assigned random port at runtime;
 	// stays unchanged across visor restarts only when pinned to a
 	// non-zero value.
-	"stcpr":           {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
-	"sudph":           {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
-	"transport-port":  {Key: "TRANSPORTPORT", Format: EnvFormatInt, Default: "0 (per-type ports)"},
-	"lan-dmsg-port":   {Key: "LANDMSGPORT", Format: EnvFormatInt, Default: "0 (random)"},
-	"lan-dmsg-public": {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
+	"stcpr":          {Key: "STCPRPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"sudph":          {Key: "SUDPHPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"transport-port": {Key: "TRANSPORTPORT", Format: EnvFormatInt, Default: "0 (per-type ports)"},
+
+	// Privacy / routing knobs.
+	"min-hops":             {Key: "MINHOPS", Format: EnvFormatInt, Default: "1"},
+	"ar-transport-limit":   {Key: "ARTRANSPORTLIMIT", Format: EnvFormatInt, Default: "0 (stay registered)"},
+	"no-direct-transports": {Key: "NODIRECTTRANSPORTS", Format: EnvFormatBool},
+	"lan-dmsg-port":        {Key: "LANDMSGPORT", Format: EnvFormatInt, Default: "0 (random)"},
+	"lan-dmsg-public":      {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
 
 	// Whitelists
 	"dmsgpty-pks": {Key: "DMSGPTYPKS", Format: EnvFormatBashArray},


### PR DESCRIPTION
Adds CLI flags for three per-visor privacy/routing controls on both the `config gen` and `autoconfig` surfaces. Previously these could only be set by hand-editing the generated `skywire.json` (which `config gen -r` can clobber).

| flag | SKYENV var | config field |
|------|-----------|--------------|
| `--min-hops N` | `MINHOPS` | `routing.min_hops` |
| `--ar-transport-limit N` | `ARTRANSPORTLIMIT` | `transport.ar_transport_limit` |
| `--no-direct-transports` | `NODIRECTTRANSPORTS` | `transport.no_direct_transports` |

- **`--min-hops`** — `>=2` forces multihop routing (sender-anonymity lever). Preserved across `config gen -r` unless explicitly overridden this run; negative input clamps to `0`.
- **`--ar-transport-limit`** — address-resolver registration policy: `0` = stay registered, `N>0` = deregister after N transports, `N<0` = never register (inbound-invisible). Enforced in `pkg/transport/manager.go`.
- **`--no-direct-transports`** — stops creation of direct p2p transports (stcpr/sudph/stcp/squicr/swsr/swtr/webrtc) while leaving the dmsg relay path intact. Enforced in `pkg/transport/manager.go` via `types.IsDirect`.

Preserves the SKYENV round-trip: `autoconfig` writes the vars to `skywire.conf`, `config gen` sources them. Maintains the documented autoconfig↔config-gen parity contract — every SKYENV variable `config gen` reads via `scriptExec*` now has a matching `autoconfig` flag.

Verified end-to-end: `autoconfig --min-hops 4 --ar-transport-limit -1 --no-direct-transports` → `MINHOPS=4`/`ARTRANSPORTLIMIT=-1`/`NODIRECTTRANSPORTS=true` in skywire.conf → `config gen` emits `min_hops:4`, `ar_transport_limit:-1`, `no_direct_transports:true`. Defaults (nothing set) emit `min_hops:1` with the other two omitted (omitempty). Follow-up: the list-typed knob `transport_create_deny` still needs a flag-format design.