### PR TITLE
fix(security): gate RPC-initiated dmsgpty exec behind opt-in config

### DIFF
--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -206,6 +206,7 @@ func init() {
 	genConfigCmd.Flags().IntVar(&genMinHops, "min-hops", scriptExecInt("${MINHOPS:-1}"), "minimum route hops (1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy)")
 	genConfigCmd.Flags().IntVar(&arTransportLimit, "ar-transport-limit", scriptExecInt("${ARTRANSPORTLIMIT:-0}"), "address-resolver registration: 0 = stay registered, N>0 = deregister after N transports, N<0 = never register (inbound-invisible)")
 	genConfigCmd.Flags().BoolVar(&noDirectTransports, "no-direct-transports", scriptExecBool("${NODIRECTTRANSPORTS:-false}"), "never create direct p2p transports; dmsg (relay) is still allowed")
+	genConfigCmd.Flags().BoolVar(&ptyRPCExec, "pty-rpc-exec", scriptExecBool("${PTYRPCEXEC:-false}"), "allow visor-RPC-initiated dmsgpty exec (control/jump node opt-in; off = closes a local privilege-escalation vector)")
 
 	// Routing flags
 	msg = "add route setup node PKs"
@@ -1312,9 +1313,10 @@ func configureLauncher(log *logging.Logger) {
 		dmsgptyAddr = filepath.Join(os.TempDir(), "dmsgpty-test.sock")
 	}
 	conf.Pty = &visorconfig.Pty{
-		DmsgPort: skyenv.DmsgPtyPort,
-		CLINet:   skyenv.DmsgPtyCLINet,
-		CLIAddr:  dmsgptyAddr,
+		DmsgPort:     skyenv.DmsgPtyPort,
+		CLINet:       skyenv.DmsgPtyCLINet,
+		CLIAddr:      dmsgptyAddr,
+		AllowRPCExec: ptyRPCExec,
 	}
 
 	conf.STCP = &network.STCPConfig{
@@ -2294,6 +2296,7 @@ func applyFlagsToConf(conf string, cmd *cobra.Command) string {
 		"autoconn":             "DISABLEPUBLICAUTOCONN=true",
 		"publicip":             "DISPLAYNODEIP=true",
 		"no-direct-transports": "NODIRECTTRANSPORTS=true",
+		"pty-rpc-exec":         "PTYRPCEXEC=true",
 	}
 
 	// Also handle string/value flags

--- a/cmd/skywire-cli/commands/config/root.go
+++ b/cmd/skywire-cli/commands/config/root.go
@@ -31,6 +31,7 @@ var (
 	genMinHops                 int
 	arTransportLimit           int
 	noDirectTransports         bool
+	ptyRPCExec                 bool
 	sk                         cipher.SecKey
 	output                     string
 	confPath                   string

--- a/cmd/skywire/commands/autoconfig.go
+++ b/cmd/skywire/commands/autoconfig.go
@@ -161,6 +161,7 @@ func collectSkyenvEdits(cmd *cobra.Command) []skyenvEdit {
 	addInt("MINHOPS", "min-hops", autoconfigVals.MinHops)
 	addInt("ARTRANSPORTLIMIT", "ar-transport-limit", autoconfigVals.ARTransportLimit)
 	addSoloBool("NODIRECTTRANSPORTS", "no-direct-transports", autoconfigVals.NoDirectTransports)
+	addSoloBool("PTYRPCEXEC", "pty-rpc-exec", autoconfigVals.PtyRPCExec)
 	addArray("STUNSERVERS", "stun", autoconfigVals.StunServers)
 
 	// Transport ports

--- a/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
+++ b/pkg/skywireconfig/autoconfigcmd/autoconfigcmd.go
@@ -136,6 +136,7 @@ type Values struct {
 	MinHops            int  // MINHOPS (>=2 forces multihop for sender privacy)
 	ARTransportLimit   int  // ARTRANSPORTLIMIT (address-resolver registration policy)
 	NoDirectTransports bool // NODIRECTTRANSPORTS (never create direct p2p transports)
+	PtyRPCExec         bool // PTYRPCEXEC (allow visor-RPC-initiated dmsgpty exec)
 
 	// --- Whitelists ---
 	DmsgptyPks     string
@@ -289,6 +290,7 @@ func New(v *Values) *cobra.Command {
 	cmd.Flags().IntVar(&v.MinHops, "min-hops", 1, "minimum route hops — 1 = allow direct 1-hop routes, >=2 = force multihop through intermediaries for sender privacy — writes MINHOPS in skywire.conf")
 	cmd.Flags().IntVar(&v.ARTransportLimit, "ar-transport-limit", 0, "address-resolver registration: 0 = stay registered, N>0 = deregister after N transports, N<0 = never register (inbound-invisible) — writes ARTRANSPORTLIMIT in skywire.conf")
 	cmd.Flags().BoolVar(&v.NoDirectTransports, "no-direct-transports", false, "never create direct p2p transports; dmsg relay still allowed — writes NODIRECTTRANSPORTS=true in skywire.conf")
+	cmd.Flags().BoolVar(&v.PtyRPCExec, "pty-rpc-exec", false, "allow visor-RPC-initiated dmsgpty exec (control/jump node opt-in; off closes a local privilege-escalation vector) — writes PTYRPCEXEC=true in skywire.conf")
 	cmd.Flags().IntVar(&v.LanDmsgPort, "lan-dmsg-port", 0, "LAN dmsg-server listening port (0 = leave unchanged) — writes LANDMSGPORT in skywire.conf")
 	cmd.Flags().StringVar(&v.LanDmsgPublic, "lan-dmsg-public", "", "public host:port for the LAN dmsg-server entry in dmsg discovery — writes LANDMSGPUBLIC in skywire.conf")
 
@@ -439,6 +441,7 @@ var envMap = map[string]EnvMapping{
 	"min-hops":             {Key: "MINHOPS", Format: EnvFormatInt, Default: "1"},
 	"ar-transport-limit":   {Key: "ARTRANSPORTLIMIT", Format: EnvFormatInt, Default: "0 (stay registered)"},
 	"no-direct-transports": {Key: "NODIRECTTRANSPORTS", Format: EnvFormatBool},
+	"pty-rpc-exec":         {Key: "PTYRPCEXEC", Format: EnvFormatBool},
 	"lan-dmsg-port":        {Key: "LANDMSGPORT", Format: EnvFormatInt, Default: "0 (random)"},
 	"lan-dmsg-public":      {Key: "LANDMSGPUBLIC", Format: EnvFormatString},
 

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -554,6 +554,14 @@ func (v *Visor) DmsgPtyExec(args DmsgPtyExecArgs) (*pty.CommandExecResult, error
 	if v.dmsgPty == nil {
 		return nil, fmt.Errorf("dmsgpty: not initialized on this visor")
 	}
+	// Gate the RPC-initiated exec path (see Pty.AllowRPCExec). OFF by
+	// default so a local process reaching the visor RPC socket cannot
+	// borrow this visor's identity to exec on itself or on peers that
+	// whitelist it. Opt in on a control/jump node that drives remote
+	// `cli pty exec` sessions.
+	if v.conf.Pty == nil || !v.conf.Pty.AllowRPCExec {
+		return nil, fmt.Errorf("dmsgpty: RPC-initiated exec is disabled; set pty.allow_rpc_exec=true (config gen --pty-rpc-exec) on this visor to enable it")
+	}
 	if args.RemotePK.Null() {
 		return nil, fmt.Errorf("dmsgpty: remote_pk required")
 	}

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -181,6 +181,21 @@ type Pty struct {
 	// web terminal degrades to fresh-shell-on-reconnect against hosts that
 	// have it off.
 	PersistentSessions bool `json:"persistent_sessions,omitempty"`
+
+	// AllowRPCExec gates the visor-RPC-initiated dmsgpty exec path
+	// (API.DmsgPtyExec, reached by `skywire cli dmsg pty` / `cli pty
+	// exec --via`). OFF by default: without it, any local process that
+	// can reach the visor's RPC socket (loopback :3435 on a root
+	// deployment — every local user) could borrow the visor's identity
+	// to open an authenticated dmsgpty stream to itself or to any peer
+	// that whitelists this visor, i.e. a local privilege-escalation /
+	// lateral-movement vector distinct from the whitelist-gated INBOUND
+	// dmsgpty host. Enabling it is an operator opt-in for a control /
+	// jump node that legitimately drives remote `cli pty exec` sessions.
+	// This gate does NOT affect the inbound dmsgpty host (the hypervisor
+	// web terminal and standalone dmsgpty-cli use separate, whitelist-
+	// gated paths), only the outbound RPC-initiated exec.
+	AllowRPCExec bool `json:"allow_rpc_exec,omitempty"`
 }
 
 // Dmsgscp configures the dmsgscp-host (scp-over-dmsg daemon).


### PR DESCRIPTION
Closes a local privilege-escalation / lateral-movement vector in `API.DmsgPtyExec`.

### The vector
`API.DmsgPtyExec` (reached by `skywire cli dmsg pty` and `cli pty exec --via`) opens an authenticated dmsgpty stream **using the visor's own identity** — to the visor itself, or to any peer that whitelists this visor. Its only gate was "can you reach the visor RPC". On a root deployment the RPC socket is loopback `:3435`, reachable by **every local user**, so any unprivileged local process could borrow the root visor's identity to exec commands. This is distinct from — and bypasses — the whitelist that gates the **inbound** dmsgpty host.

### The fix
New `Pty.AllowRPCExec` config field (`json: allow_rpc_exec`), **off by default**. When off, `DmsgPtyExec` returns an error naming the flag. Enabling it is an operator opt-in for a control/jump node that legitimately drives remote `cli pty exec` sessions.

**Blast radius is small:** fleet nodes are inbound *targets* (gated by their own whitelist — unaffected). Only a node that *initiates* `cli pty exec --via` needs `allow_rpc_exec=true`, and those are operator-run control nodes. The inbound dmsgpty host is untouched — the hypervisor web terminal and standalone `dmsgpty-cli` use separate, whitelist-gated paths and keep working.

### Surfaces
- `config gen --pty-rpc-exec`
- `autoconfig --pty-rpc-exec` → `PTYRPCEXEC=true` in skywire.conf

Maintains the autoconfig↔config-gen SKYENV parity contract.

Verified: `config gen` omits `allow_rpc_exec` by default (omitempty), emits `true` with the flag; gated handler returns the opt-in error when disabled.

> **Operators using `cli pty exec --via` for remote debugging:** set `PTYRPCEXEC=true` (or `config gen --pty-rpc-exec`) on the node you run the command *from* before upgrading, or that path will start returning the opt-in error.