### PR TITLE
feat(visor): Suspend/Resume RPC — quiesce the visor without stopping the process

### DIFF
--- a/cmd/skywire-cli/commands/visor/process.go
+++ b/cmd/skywire-cli/commands/visor/process.go
@@ -122,16 +122,40 @@ the service manager unit. Resume with 'skywire cli visor resume'.`,
 var resumeCmd = &cobra.Command{
 	Use:   "resume",
 	Short: "Resume a suspended visor",
-	Long:  "Bring a suspended visor fully back online by re-running its module graph.",
+	Long: `Bring a suspended visor fully back online by re-running its module graph.
+
+Resume re-inits every network subsystem, which takes several seconds and
+severs the in-flight RPC connection mid-re-init (the same way 'reload'
+does — the local RPC LISTENER stays up, only this one call's connection
+drops). So it's fired in the background and the result is confirmed by
+polling the suspend state on fresh connections rather than waiting on the
+severed call.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())
 		if err != nil {
 			os.Exit(1)
 		}
-		if err := rpcClient.Resume(); err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error resuming visor: %v", err))
+		// Fire Resume; its own connection is expected to EOF during the
+		// re-init, so don't treat that as fatal — the state is polled below.
+		go func() { _ = rpcClient.Resume() }() //nolint:errcheck
+
+		// Poll IsSuspended on fresh connections until it clears (resume
+		// finished flipping state) or we give up waiting.
+		deadline := time.Now().Add(45 * time.Second)
+		for time.Now().Before(deadline) {
+			<-time.After(2 * time.Second)
+			rc, e := clirpc.Client(cmd.Flags())
+			if e != nil {
+				continue
+			}
+			suspended, e := rc.IsSuspended()
+			if e == nil && !suspended {
+				internal.PrintOutput(cmd.Flags(), "Visor resumed", fmt.Sprintln("Visor resumed"))
+				return
+			}
 		}
-		internal.PrintOutput(cmd.Flags(), "Visor resumed", fmt.Sprintln("Visor resumed"))
+		internal.PrintOutput(cmd.Flags(), "Visor resume initiated",
+			fmt.Sprintln("Visor resume initiated (still re-initializing; check 'visor suspended')"))
 	},
 }
 

--- a/cmd/skywire-cli/commands/visor/process.go
+++ b/cmd/skywire-cli/commands/visor/process.go
@@ -29,6 +29,9 @@ func init() {
 	}
 	RootCmd.AddCommand(startCmd)
 	RootCmd.AddCommand(reloadCmd)
+	RootCmd.AddCommand(suspendCmd)
+	RootCmd.AddCommand(resumeCmd)
+	RootCmd.AddCommand(isSuspendedCmd)
 	RootCmd.AddCommand(shutdownCmd)
 	startCmd.Flags().BoolVarP(&sourcerun, "src", "s", false, "'go run' external commands from the skywire sources")
 }
@@ -91,6 +94,61 @@ var reloadCmd = &cobra.Command{
 }
 
 func init() {
+}
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend",
+	Short: "Suspend visor (tear down networking, keep local RPC)",
+	Long: `Make the visor quiescent without stopping the process.
+
+Tears down all network subsystems — transports, routing, apps, dmsg,
+autoconnect, address-resolver/TPD registration and the reward heartbeat —
+keeping only the local RPC listener alive. The node stops earning, routing
+and serving apps and drops off dmsg discovery, but stays controllable on
+its local RPC so it can be resumed. Privilege-free alternative to stopping
+the service manager unit. Resume with 'skywire cli visor resume'.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.Suspend(); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error suspending visor: %v", err))
+		}
+		internal.PrintOutput(cmd.Flags(), "Visor suspended", fmt.Sprintln("Visor suspended"))
+	},
+}
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume a suspended visor",
+	Long:  "Bring a suspended visor fully back online by re-running its module graph.",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		if err := rpcClient.Resume(); err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error resuming visor: %v", err))
+		}
+		internal.PrintOutput(cmd.Flags(), "Visor resumed", fmt.Sprintln("Visor resumed"))
+	},
+}
+
+var isSuspendedCmd = &cobra.Command{
+	Use:   "suspended",
+	Short: "Report whether the visor is suspended",
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			os.Exit(1)
+		}
+		suspended, err := rpcClient.IsSuspended()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("error querying suspend state: %v", err))
+		}
+		internal.PrintOutput(cmd.Flags(), suspended, fmt.Sprintln(suspended))
+	},
 }
 
 var shutdownCmd = &cobra.Command{

--- a/cmd/skywire-cli/commands/visor/zgroups.go
+++ b/cmd/skywire-cli/commands/visor/zgroups.go
@@ -27,6 +27,9 @@ const (
 var commandGroup = map[string]string{
 	"start":        groupLifecycle,
 	"halt":         groupLifecycle,
+	"suspend":      groupLifecycle,
+	"resume":       groupLifecycle,
+	"suspended":    groupLifecycle,
 	"reinit":       groupLifecycle,
 	"ready":        groupLifecycle,
 	"pk":           groupIdentity,

--- a/pkg/app/launcher/registry.go
+++ b/pkg/app/launcher/registry.go
@@ -2,7 +2,6 @@
 package launcher
 
 import (
-	"fmt"
 	"net/http"
 	"sync"
 
@@ -12,18 +11,32 @@ import (
 // AppFunc is an alias for the app function type defined in appcommon.
 type AppFunc = appcommon.AppFunc
 
-var appRegistry = make(map[string]AppFunc)
+var (
+	appRegistryMu sync.Mutex
+	appRegistry   = make(map[string]AppFunc)
+)
 
 // RegisterApp registers an app function by name.
+//
+// Registration is mutex-guarded and idempotent. Guarded because module inits run
+// concurrently (visorinit.InitConcurrent), so several embedded-app modules call
+// this in parallel — an unsynchronized map write there is a data race that can
+// fatally crash the process. Idempotent because a visor Resume re-runs the whole
+// module-init graph after Suspend, so each embedded app re-registers its (same,
+// deterministic) func; the old hard panic on a duplicate name turned Resume into
+// a half-initialized, still-"suspended" state (dmsg_pty/dmsgweb/skynetweb panicked
+// on their already-registered names). Re-registering overwrites — the same
+// overwrite-on-re-register semantics RegisterHTTPHandler below already uses.
 func RegisterApp(name string, fn AppFunc) {
-	if _, exists := appRegistry[name]; exists {
-		panic(fmt.Sprintf("app %q already registered", name))
-	}
+	appRegistryMu.Lock()
+	defer appRegistryMu.Unlock()
 	appRegistry[name] = fn
 }
 
 // GetApp returns the app function for the given name, or nil if not found.
 func GetApp(name string) (AppFunc, bool) {
+	appRegistryMu.Lock()
+	defer appRegistryMu.Unlock()
 	fn, ok := appRegistry[name]
 	return fn, ok
 }

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -49,6 +49,9 @@ type API interface {
 	UptimeHistory(args UptimeHistoryArgs) (*UptimeHistoryResponse, error)
 	RuntimeStats() (*RuntimeStatsInfo, error)
 	Reload() error
+	Suspend() error
+	Resume() error
+	IsSuspended() (bool, error)
 	Shutdown() error
 	RuntimeLogs() (string, error)
 	RuntimeLogsSince(since int64) (RuntimeLogsDelta, error)

--- a/pkg/visor/api_suspend.go
+++ b/pkg/visor/api_suspend.go
@@ -1,0 +1,184 @@
+// Package visor pkg/visor/api_suspend.go
+package visor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// suspendKeepSrc lists the closeStack entries Suspend must NOT tear down:
+// the LOCAL CLI RPC surface (cli.listener + cli.grpc + its cmux/accept
+// goroutines), which stays up so the operator/systray can call Resume.
+// Everything else — transports, routing, apps, dmsg, autoconnect, the
+// address-resolver/TPD registration, the reward heartbeat, and the
+// dmsg/transport-bound RPC surfaces — is torn down.
+var suspendKeepSrc = map[string]bool{
+	"cli.listener": true,
+	"cli.grpc":     true,
+}
+
+// IsSuspended reports whether the visor is currently suspended.
+func (v *Visor) IsSuspended() (bool, error) {
+	v.suspendMu.Lock()
+	defer v.suspendMu.Unlock()
+	return v.suspended, nil
+}
+
+// Suspend makes the visor quiescent WITHOUT stopping the process: it tears
+// down every network subsystem (transports, routing, apps, dmsg,
+// autoconnect, AR/TPD registration, the reward heartbeat, and the
+// dmsg/transport-bound RPC surfaces) but keeps the local CLI RPC listener
+// alive so Resume can arrive. The node stops earning, routing, and serving
+// apps and drops off dmsg discovery, while remaining controllable on
+// CLIAddr. It is the privilege-free alternative to stopping the service
+// manager unit. Idempotent: a second Suspend is a no-op.
+func (v *Visor) Suspend() error {
+	v.suspendMu.Lock()
+	defer v.suspendMu.Unlock()
+	if v.suspended {
+		return nil
+	}
+	log := v.MasterLogger().PackageLogger("visor:suspend")
+	log.Info("Suspending: tearing down all network subsystems, keeping local RPC.")
+
+	// 1. Cancel the network ctx first so ctx-honoring module goroutines
+	//    (accept/serve/update loops) begin unwinding before we close the
+	//    listeners and clients they ride on.
+	if v.networkCancel != nil {
+		v.networkCancel()
+	}
+
+	// 2. Walk the close stack in reverse (same LIFO order as Close) and
+	//    run every closer except the kept local-RPC entries.
+	v.initLock.RLock()
+	stack := append([]closer(nil), v.closeStack...)
+	v.initLock.RUnlock()
+	for i := len(stack) - 1; i >= 0; i-- {
+		cl := stack[i]
+		if suspendKeepSrc[cl.src] {
+			continue
+		}
+		v.runCloser("suspend", cl)
+	}
+
+	// 3. Under the init lock: retain only the kept closers, drop
+	//    references to the torn-down subsystems, and reset the one-shot
+	//    readiness state so Resume can re-run the module graph cleanly.
+	v.initLock.Lock()
+	kept := make([]closer, 0, len(v.closeStack))
+	for _, cl := range v.closeStack {
+		if suspendKeepSrc[cl.src] {
+			kept = append(kept, cl)
+		}
+	}
+	v.closeStack = kept
+
+	v.tpM = nil
+	v.router = nil
+	v.rfClient = nil
+	v.procM = nil
+	v.appL = nil
+	v.dmsgC = nil
+	v.dmsgDC = nil
+	v.dmsgHTTP = nil
+	v.arClient = nil
+	v.transportRPCMux = nil
+
+	// dmsgHTTPReady is closed under a select/default guard (init_dmsg.go),
+	// so a fresh channel is enough. stun/dmsgTracker are closed via a
+	// sync.Once, so the Once must be reset alongside the channel (same
+	// pattern as api_network.go's reconnect path) or Resume's re-init
+	// won't re-close them and readers would block forever.
+	v.dmsgHTTPReady = make(chan struct{})
+	v.startupComplete = make(chan struct{})
+	v.runtimeErrors = make(chan error)
+	v.stun.ready = make(chan struct{})
+	v.stun.readyOnce = sync.Once{}
+	v.dmsgTracker.ready = make(chan struct{})
+	v.dmsgTracker.readyOnce = sync.Once{}
+	v.initLock.Unlock()
+
+	v.suspended = true
+	log.Info("Visor suspended (local RPC still serving on CLIAddr).")
+	return nil
+}
+
+// Resume re-runs the module graph to bring a suspended visor fully back
+// online. The local CLI RPC surface was never torn down (cliLocalUp), so
+// initCLI only re-creates its dmsg/transport-bound surfaces. Idempotent:
+// Resume on a running visor is a no-op.
+func (v *Visor) Resume() error {
+	v.suspendMu.Lock()
+	defer v.suspendMu.Unlock()
+	if !v.suspended {
+		return nil
+	}
+	log := v.MasterLogger().PackageLogger("visor:resume")
+	log.Info("Resuming: re-running the module graph.")
+
+	// Rebuild the value-decorated, cancelable ctx exactly as NewVisor
+	// does. v.ctx is the still-live process signal ctx (its cancellation
+	// still tears the visor down on real shutdown).
+	ctx := context.WithValue(v.ctx, visorKey, v)
+	ctx = context.WithValue(ctx, runtimeErrsKey, v.runtimeErrors)
+	if dmsgServer != "" {
+		ctx = context.WithValue(ctx, "dmsgServer", dmsgServer) //nolint:staticcheck // SA1029: matches dmsg.Client's string key
+		if dmsgServerAddr != "" {
+			ctx = context.WithValue(ctx, "dmsgServerAddr", dmsgServerAddr) //nolint:staticcheck // SA1029: matches dmsg.Client's string key
+		}
+	}
+	v.networkCtx, v.networkCancel = context.WithCancel(ctx)
+	ctx = v.networkCtx
+
+	registerModules(v.MasterLogger())
+	mainModule := vis
+	if v.conf.Hypervisor != nil {
+		mainModule = hv
+	}
+	go tm.InitConcurrent(ctx)
+	mainModule.InitConcurrent(ctx)
+	if err := mainModule.Wait(ctx); err != nil {
+		select {
+		case <-ctx.Done():
+		default:
+			log.WithError(err).Error("Resume module init failed.")
+		}
+		return fmt.Errorf("resume: module init failed: %w", err)
+	}
+	if err := tm.Wait(ctx); err != nil {
+		return fmt.Errorf("resume: transport module init failed: %w", err)
+	}
+	if !v.processRuntimeErrs() {
+		return fmt.Errorf("resume: runtime errors during re-init")
+	}
+	close(v.startupComplete)
+	v.suspended = false
+	log.Info("Visor resumed.")
+	return nil
+}
+
+// runCloser runs a single closeStack entry with the same per-module
+// timeout Close uses. phase labels the log scope (e.g. "suspend").
+func (v *Visor) runCloser(phase string, cl closer) {
+	start := time.Now()
+	errCh := make(chan error, 1)
+	t := time.NewTimer(moduleShutdownTimeout)
+	log := v.MasterLogger().PackageLogger(fmt.Sprintf("visor:%s:%s", phase, cl.src))
+	go func(cl closer) {
+		errCh <- cl.fn()
+		close(errCh)
+	}(cl)
+	select {
+	case err := <-errCh:
+		t.Stop()
+		if err != nil {
+			log.WithError(err).WithField("elapsed", time.Since(start)).Warn("Module stopped with unexpected result.")
+			return
+		}
+		log.WithField("elapsed", time.Since(start)).Debug("Module stopped cleanly.")
+	case <-t.C:
+		log.WithField("elapsed", time.Since(start)).Error("Module timed out.")
+	}
+}

--- a/pkg/visor/api_suspend.go
+++ b/pkg/visor/api_suspend.go
@@ -75,16 +75,14 @@ func (v *Visor) Suspend() error {
 	}
 	v.closeStack = kept
 
-	v.tpM = nil
-	v.router = nil
-	v.rfClient = nil
-	v.procM = nil
-	v.appL = nil
-	v.dmsgC = nil
-	v.dmsgDC = nil
-	v.dmsgHTTP = nil
-	v.arClient = nil
-	v.transportRPCMux = nil
+	// Deliberately DO NOT nil the torn-down subsystem fields (tpM, router,
+	// dmsgC, …). networkCancel() above signals their goroutines to stop, but
+	// some may still be mid-flight for a moment; nil'ing the field out from
+	// under such a goroutine turns a benign "operate on a closed object"
+	// (which returns an error) into a nil-pointer panic that crashes the whole
+	// live process. Leaving the closed-but-non-nil objects in place is safe:
+	// Resume re-runs the module graph, which reassigns each field to a fresh
+	// instance (the old closed object is then GC'd).
 
 	// dmsgHTTPReady is closed under a select/default guard (init_dmsg.go),
 	// so a fresh channel is enough. stun/dmsgTracker are closed via a
@@ -167,6 +165,15 @@ func (v *Visor) runCloser(phase string, cl closer) {
 	t := time.NewTimer(moduleShutdownTimeout)
 	log := v.MasterLogger().PackageLogger(fmt.Sprintf("visor:%s:%s", phase, cl.src))
 	go func(cl closer) {
+		// Recover a panicking closer. Unlike Close() (which runs at process
+		// exit, where a panic is harmless), Suspend runs closers on a LIVE
+		// process — an un-recovered panic here would crash the whole visor
+		// (e.g. a double-close). Log it and report as an error instead.
+		defer func() {
+			if r := recover(); r != nil {
+				errCh <- fmt.Errorf("panic: %v", r)
+			}
+		}()
 		errCh <- cl.fn()
 		close(errCh)
 	}(cl)

--- a/pkg/visor/api_suspend_test.go
+++ b/pkg/visor/api_suspend_test.go
@@ -1,0 +1,87 @@
+package visor
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// TestSuspendSelectiveTeardown verifies the risky part of Suspend in
+// isolation (no network): it must run every closeStack entry EXCEPT the
+// kept local-RPC surface, in reverse (LIFO) order, retain only the kept
+// entries afterward, reset the one-shot readiness channels, and be
+// idempotent. Resume's full module re-init needs live validation and is
+// not covered here.
+func TestSuspendSelectiveTeardown(t *testing.T) {
+	common := &visorconfig.Common{}
+	common.SetLogger(logging.NewMasterLogger())
+	v := &Visor{
+		conf:     &visorconfig.V1{Common: common},
+		initLock: new(sync.RWMutex),
+	}
+
+	// One-shot channels seeded as NewVisor would.
+	v.dmsgHTTPReady = make(chan struct{})
+	v.startupComplete = make(chan struct{})
+	v.runtimeErrors = make(chan error)
+	v.stun.ready = make(chan struct{})
+	v.dmsgTracker.ready = make(chan struct{})
+	oldStartup := v.startupComplete
+	oldDmsgHTTP := v.dmsgHTTPReady
+	oldStun := v.stun.ready
+	oldTracker := v.dmsgTracker.ready
+	oldRuntimeErrs := v.runtimeErrors
+
+	var order []string
+	mk := func(src string) closer {
+		return closer{src: src, fn: func() error { order = append(order, src); return nil }}
+	}
+	// Interleave kept (cli.*) and network closers.
+	v.closeStack = []closer{
+		mk("cli.listener"),
+		mk("transport.manager"),
+		mk("cli.grpc"),
+		mk("dmsg"),
+		mk("router.serve"),
+	}
+
+	require.NoError(t, v.Suspend())
+
+	// suspended flag set.
+	suspended, err := v.IsSuspended()
+	require.NoError(t, err)
+	require.True(t, suspended)
+
+	// Non-kept closers ran, in reverse (LIFO) order; kept ones did not.
+	require.Equal(t, []string{"router.serve", "dmsg", "transport.manager"}, order)
+
+	// Only the kept entries remain, in their original order.
+	var remaining []string
+	for _, cl := range v.closeStack {
+		remaining = append(remaining, cl.src)
+	}
+	require.Equal(t, []string{"cli.listener", "cli.grpc"}, remaining)
+
+	// One-shot readiness channels were replaced with fresh (open) ones.
+	require.True(t, oldStartup != v.startupComplete, "startupComplete not reset")
+	require.True(t, oldDmsgHTTP != v.dmsgHTTPReady, "dmsgHTTPReady not reset")
+	require.True(t, oldStun != v.stun.ready, "stun.ready not reset")
+	require.True(t, oldTracker != v.dmsgTracker.ready, "dmsgTracker.ready not reset")
+	require.True(t, oldRuntimeErrs != v.runtimeErrors, "runtimeErrors not reset")
+
+	// The reset channels must be open (not the closed ones from a torn-down run).
+	select {
+	case <-v.startupComplete:
+		t.Fatal("startupComplete should be open after Suspend")
+	default:
+	}
+
+	// Suspend is idempotent — a second call runs no closers.
+	order = nil
+	require.NoError(t, v.Suspend())
+	require.Empty(t, order)
+}

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
@@ -272,7 +273,7 @@ var ErrNoErrorsCtx = errors.New("errors not set in module initialization context
 // Passed context should have errors channel for module runtime errors. It can be accessed
 // through a function call
 func withInitCtx(f initFn) vinit.Hook {
-	return func(ctx context.Context, log *logging.Logger) error {
+	return func(ctx context.Context, log *logging.Logger) (err error) {
 		val := ctx.Value(visorKey)
 		v, ok := val.(*Visor)
 		if !ok && v == nil {
@@ -283,6 +284,19 @@ func withInitCtx(f initFn) vinit.Hook {
 		if !ok && errs == nil {
 			return ErrNoErrorsCtx
 		}
+		// Recover a panicking module init so one bad module can't crash the
+		// whole visor process. This matters most during Resume (Suspend/Resume,
+		// api_suspend.go), which RE-RUNS the module graph and can hit
+		// non-idempotent init (a module init runs in its own goroutine under
+		// InitConcurrent, so an un-recovered panic there kills the process, not
+		// just the module). Convert it to an error the init system reports, and
+		// log the stack so the offending module is identifiable.
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("module init panicked: %v", r)
+				log.WithField("stack", string(debug.Stack())).Errorf("module init panic recovered: %v", r)
+			}
+		}()
 		return f(ctx, v, log)
 	}
 }

--- a/pkg/visor/init_apps.go
+++ b/pkg/visor/init_apps.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"mime"
 	"net"
+	nrpc "net/rpc"
 	"strings"
 	"sync"
 	"time"
@@ -521,36 +522,51 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		return nil
 	}
 
-	cliL, err := net.Listen("tcp", v.conf.CLIAddr)
-	if err != nil {
-		return err
-	}
-
-	v.pushCloseStack("cli.listener", cliL.Close)
-
-	// (Dmsg bridge was previously a dedicated localhost:3437
-	// listener. It's now multiplexed onto v.conf.CLIAddr via cmux
-	// — see the bridgeL match below. One local port for operators
-	// to think about, one config field. The bridge protocol /
-	// security model is unchanged; see pkg/visor/dmsg_bridge.go.)
-
-	rpcS, err := newRPCServer(v, "CLI")
-	if err != nil {
-		err := fmt.Errorf("failed to start rpc server for cli: %w", err)
-		return err
-	}
-
-	// Create gRPC server for streaming operations
-	grpcLog := v.MasterLogger().PackageLogger("cli_grpc")
-	grpcServer := grpc.NewServer()
+	// pingAdapter and grpcLog feed BOTH the local gRPC server (set up
+	// once, below) and the dmsg gRPC server (re-created on every init,
+	// further down), so they live outside the once-only local guard so
+	// Resume can re-wire the dmsg surfaces.
 	pingAdapter := &visorPingAdapter{v: v}
-	pingServer := rpcgrpc.NewPingServer(pingAdapter, grpcLog)
-	rpcgrpc.RegisterPingServiceServer(grpcServer, pingServer)
+	grpcLog := v.MasterLogger().PackageLogger("cli_grpc")
 
-	v.pushCloseStack("cli.grpc", func() error {
-		grpcServer.GracefulStop()
-		return nil
-	})
+	// LOCAL RPC surface (cli.listener + local gRPC + cmux + net/rpc
+	// accept loop, below). Set up ONCE and intentionally NOT torn down by
+	// Suspend, so operator/systray RPC on CLIAddr stays reachable to call
+	// Resume. On Resume initCLI runs again but skips this block
+	// (v.cliLocalUp); only the dmsg/transport-bound surfaces are
+	// re-created. cliL/rpcS/grpcServer are hoisted so the cmux/accept
+	// block (also guarded by cliLocalUp) can use them.
+	var cliL net.Listener
+	var rpcS *nrpc.Server
+	var grpcServer *grpc.Server
+	if !v.cliLocalUp {
+		var err error
+		cliL, err = net.Listen("tcp", v.conf.CLIAddr)
+		if err != nil {
+			return err
+		}
+		v.pushCloseStack("cli.listener", cliL.Close)
+
+		// (Dmsg bridge was previously a dedicated localhost:3437
+		// listener. It's now multiplexed onto v.conf.CLIAddr via cmux
+		// — see the bridgeL match below. One local port for operators
+		// to think about, one config field. The bridge protocol /
+		// security model is unchanged; see pkg/visor/dmsg_bridge.go.)
+
+		rpcS, err = newRPCServer(v, "CLI")
+		if err != nil {
+			return fmt.Errorf("failed to start rpc server for cli: %w", err)
+		}
+
+		// Create gRPC server for streaming operations
+		grpcServer = grpc.NewServer()
+		rpcgrpc.RegisterPingServiceServer(grpcServer, rpcgrpc.NewPingServer(pingAdapter, grpcLog))
+
+		v.pushCloseStack("cli.grpc", func() error {
+			grpcServer.GracefulStop()
+			return nil
+		})
+	}
 
 	// Start gRPC server on DMSG for remote access (gotop, stats, etc.)
 	// Access is restricted to hypervisor PKs and dmsgpty whitelist PKs.
@@ -741,131 +757,138 @@ func initCLI(ctx context.Context, v *Visor, log *logging.Logger) error {
 		}
 	}
 
-	// Use cmux to multiplex gRPC, the dmsg-bridge protocol, and
-	// standard RPC on the same port. The bridge matcher peeks for
-	// a fixed magic prefix; conns starting with it are dmsg-bridge
-	// requests, everything else falls through to gRPC or rpc.
-	mux := cmux.New(cliL)
-	grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
-	bridgeL := mux.Match(cmux.PrefixMatcher(bridgeMagic))
-	rpcL := mux.Match(cmux.Any()) // All other connections go to standard RPC
+	// The cmux + accept goroutines below drive the LOCAL cliL listener,
+	// so they belong to the once-only local surface and are skipped on
+	// Resume (cliL/rpcS/grpcServer are nil then and must not be touched).
+	if !v.cliLocalUp {
+		// Use cmux to multiplex gRPC, the dmsg-bridge protocol, and
+		// standard RPC on the same port. The bridge matcher peeks for
+		// a fixed magic prefix; conns starting with it are dmsg-bridge
+		// requests, everything else falls through to gRPC or rpc.
+		mux := cmux.New(cliL)
+		grpcL := mux.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
+		bridgeL := mux.Match(cmux.PrefixMatcher(bridgeMagic))
+		rpcL := mux.Match(cmux.Any()) // All other connections go to standard RPC
 
-	// Start the RPC bridge accept loop on the bridge-matched
-	// listener. Handles both `--via dmsg://<pk>` and `--via
-	// skynet://<pk>` — the header's scheme byte selects which
-	// stream type the visor opens to the target. Lets the CLI
-	// inherit the visor's dmsg/skynet identity (and its whitelist
-	// eligibility on remote peers) without needing a separate CLI
-	// keypair. Implementation in rpc_bridge.go.
-	bridgeLog := v.MasterLogger().PackageLogger("rpc_bridge")
-	go serveRPCBridge(ctx, bridgeLog, bridgeL, v)
-	bridgeLog.WithField("addr", v.conf.CLIAddr).
-		Info("RPC bridge multiplexed onto CLI RPC port (dmsg + skynet schemes)")
+		// Start the RPC bridge accept loop on the bridge-matched
+		// listener. Handles both `--via dmsg://<pk>` and `--via
+		// skynet://<pk>` — the header's scheme byte selects which
+		// stream type the visor opens to the target. Lets the CLI
+		// inherit the visor's dmsg/skynet identity (and its whitelist
+		// eligibility on remote peers) without needing a separate CLI
+		// keypair. Implementation in rpc_bridge.go.
+		bridgeLog := v.MasterLogger().PackageLogger("rpc_bridge")
+		go serveRPCBridge(ctx, bridgeLog, bridgeL, v)
+		bridgeLog.WithField("addr", v.conf.CLIAddr).
+			Info("RPC bridge multiplexed onto CLI RPC port (dmsg + skynet schemes)")
 
-	// Connection limiting and stats for standard RPC
-	const maxConcurrentConns = 50
-	stats := &cliRPCStats{
-		connSemaphore: make(chan struct{}, maxConcurrentConns),
-		maxConns:      maxConcurrentConns,
-	}
-
-	// Start gRPC server
-	go func() {
-		grpcLog.Infof("CLI gRPC server listening on %s (multiplexed)", v.conf.CLIAddr)
-		if err := grpcServer.Serve(grpcL); err != nil {
-			if !errors.Is(err, net.ErrClosed) &&
-				!strings.Contains(err.Error(), "mux: listener closed") {
-				grpcLog.WithError(err).Error("gRPC server error")
-			}
+		// Connection limiting and stats for standard RPC
+		const maxConcurrentConns = 50
+		stats := &cliRPCStats{
+			connSemaphore: make(chan struct{}, maxConcurrentConns),
+			maxConns:      maxConcurrentConns,
 		}
-	}()
 
-	// Run standard RPC accept loop with panic recovery, connection limiting, and logging
-	go func() {
-		rpcLog := v.MasterLogger().PackageLogger("cli_rpc")
-		rpcLog.Infof("CLI RPC server listening on %s (max %d concurrent connections, multiplexed)", v.conf.CLIAddr, maxConcurrentConns)
-
-		// Periodic stats logging
+		// Start gRPC server
 		go func() {
-			ticker := time.NewTicker(30 * time.Second)
-			defer ticker.Stop()
-			for range ticker.C {
-				active, total, errors, peak, lastErr, lastErrTime := stats.snapshot()
-				if total > 0 {
-					rpcLog.Debugf("CLI RPC stats: active=%d, total=%d, errors=%d, peak=%d", active, total, errors, peak)
-					if lastErr != "" && time.Since(lastErrTime) < time.Minute {
-						rpcLog.Debugf("CLI RPC last error (%s ago): %s", time.Since(lastErrTime).Round(time.Second), lastErr)
-					}
+			grpcLog.Infof("CLI gRPC server listening on %s (multiplexed)", v.conf.CLIAddr)
+			if err := grpcServer.Serve(grpcL); err != nil {
+				if !errors.Is(err, net.ErrClosed) &&
+					!strings.Contains(err.Error(), "mux: listener closed") {
+					grpcLog.WithError(err).Error("gRPC server error")
 				}
 			}
 		}()
 
-		var connID uint64
-		for {
-			conn, err := rpcL.Accept()
-			if err != nil {
-				// Check if listener was closed (normal shutdown)
-				if errors.Is(err, net.ErrClosed) ||
-					strings.Contains(err.Error(), "mux: listener closed") {
-					rpcLog.Debug("CLI RPC listener closed")
-					return
-				}
-				stats.recordError(fmt.Sprintf("accept: %v", err))
-				rpcLog.WithError(err).Warn("CLI RPC accept error, continuing...")
-				continue
-			}
+		// Run standard RPC accept loop with panic recovery, connection limiting, and logging
+		go func() {
+			rpcLog := v.MasterLogger().PackageLogger("cli_rpc")
+			rpcLog.Infof("CLI RPC server listening on %s (max %d concurrent connections, multiplexed)", v.conf.CLIAddr, maxConcurrentConns)
 
-			connID++
-			thisConnID := connID
-
-			// Try to acquire connection slot
-			if !stats.acquire() {
-				stats.recordError("connection limit reached")
-				active, _, _, _, _, _ := stats.snapshot()
-				rpcLog.Warnf("CLI RPC connection limit reached (%d/%d), rejecting connection", active, maxConcurrentConns)
-				conn.Close() //nolint:errcheck,gosec
-				continue
-			}
-
-			rpcLog.Debugf("CLI RPC conn #%d accepted from %s (active: %d)", thisConnID, conn.RemoteAddr(), stats.activeConns)
-
-			// Handle each connection in a goroutine with panic recovery
-			go func(c net.Conn, id uint64) {
-				startTime := time.Now()
-				defer func() {
-					if r := recover(); r != nil {
-						stats.recordError(fmt.Sprintf("panic: %v", r))
-						rpcLog.Errorf("CLI RPC conn #%d panic recovered: %v", id, r)
+			// Periodic stats logging
+			go func() {
+				ticker := time.NewTicker(30 * time.Second)
+				defer ticker.Stop()
+				for range ticker.C {
+					active, total, errors, peak, lastErr, lastErrTime := stats.snapshot()
+					if total > 0 {
+						rpcLog.Debugf("CLI RPC stats: active=%d, total=%d, errors=%d, peak=%d", active, total, errors, peak)
+						if lastErr != "" && time.Since(lastErrTime) < time.Minute {
+							rpcLog.Debugf("CLI RPC last error (%s ago): %s", time.Since(lastErrTime).Round(time.Second), lastErr)
+						}
 					}
-					c.Close() //nolint:errcheck,gosec
-					stats.release()
-					rpcLog.Debugf("CLI RPC conn #%d closed after %s (active: %d)", id, time.Since(startTime).Round(time.Millisecond), stats.activeConns)
-				}()
-
-				// Set keepalive and deadline to prevent hung connections.
-				// If an RPC method hangs (e.g., iterating corrupt routing rules),
-				// the deadline ensures the connection is killed after the timeout
-				// rather than blocking a connection slot forever.
-				if tc, ok := c.(*net.TCPConn); ok {
-					tc.SetKeepAlive(true)                   //nolint:errcheck,gosec
-					tc.SetKeepAlivePeriod(30 * time.Second) //nolint:errcheck,gosec
 				}
-				c.SetDeadline(time.Now().Add(5 * time.Minute)) //nolint:errcheck,gosec
+			}()
 
-				rpcS.ServeConn(c)
-			}(conn, thisConnID)
-		}
-	}()
+			var connID uint64
+			for {
+				conn, err := rpcL.Accept()
+				if err != nil {
+					// Check if listener was closed (normal shutdown)
+					if errors.Is(err, net.ErrClosed) ||
+						strings.Contains(err.Error(), "mux: listener closed") {
+						rpcLog.Debug("CLI RPC listener closed")
+						return
+					}
+					stats.recordError(fmt.Sprintf("accept: %v", err))
+					rpcLog.WithError(err).Warn("CLI RPC accept error, continuing...")
+					continue
+				}
 
-	// Start cmux - this must be called after setting up all listeners
-	go func() {
-		if err := mux.Serve(); err != nil {
-			if !errors.Is(err, net.ErrClosed) &&
-				!strings.Contains(err.Error(), "mux: listener closed") {
-				v.log.WithError(err).Error("cmux serve error")
+				connID++
+				thisConnID := connID
+
+				// Try to acquire connection slot
+				if !stats.acquire() {
+					stats.recordError("connection limit reached")
+					active, _, _, _, _, _ := stats.snapshot()
+					rpcLog.Warnf("CLI RPC connection limit reached (%d/%d), rejecting connection", active, maxConcurrentConns)
+					conn.Close() //nolint:errcheck,gosec
+					continue
+				}
+
+				rpcLog.Debugf("CLI RPC conn #%d accepted from %s (active: %d)", thisConnID, conn.RemoteAddr(), stats.activeConns)
+
+				// Handle each connection in a goroutine with panic recovery
+				go func(c net.Conn, id uint64) {
+					startTime := time.Now()
+					defer func() {
+						if r := recover(); r != nil {
+							stats.recordError(fmt.Sprintf("panic: %v", r))
+							rpcLog.Errorf("CLI RPC conn #%d panic recovered: %v", id, r)
+						}
+						c.Close() //nolint:errcheck,gosec
+						stats.release()
+						rpcLog.Debugf("CLI RPC conn #%d closed after %s (active: %d)", id, time.Since(startTime).Round(time.Millisecond), stats.activeConns)
+					}()
+
+					// Set keepalive and deadline to prevent hung connections.
+					// If an RPC method hangs (e.g., iterating corrupt routing rules),
+					// the deadline ensures the connection is killed after the timeout
+					// rather than blocking a connection slot forever.
+					if tc, ok := c.(*net.TCPConn); ok {
+						tc.SetKeepAlive(true)                   //nolint:errcheck,gosec
+						tc.SetKeepAlivePeriod(30 * time.Second) //nolint:errcheck,gosec
+					}
+					c.SetDeadline(time.Now().Add(5 * time.Minute)) //nolint:errcheck,gosec
+
+					rpcS.ServeConn(c)
+				}(conn, thisConnID)
 			}
-		}
-	}()
+		}()
+
+		// Start cmux - this must be called after setting up all listeners
+		go func() {
+			if err := mux.Serve(); err != nil {
+				if !errors.Is(err, net.ErrClosed) &&
+					!strings.Contains(err.Error(), "mux: listener closed") {
+					v.log.WithError(err).Error("cmux serve error")
+				}
+			}
+		}()
+
+		v.cliLocalUp = true
+	}
 
 	return nil
 }

--- a/pkg/visor/proxied_visor_api.go
+++ b/pkg/visor/proxied_visor_api.go
@@ -225,6 +225,21 @@ func (p *proxiedVisorAPI) Reload() error {
 	return p.hvAPI.HVReload(p.targetPK)
 }
 
+// Suspend/Resume/IsSuspended are LOCAL-ONLY: a suspended visor drops off
+// dmsg, so it cannot be reached — let alone resumed — over the hypervisor.
+// They must be invoked on the target's own host RPC (CLIAddr).
+func (p *proxiedVisorAPI) Suspend() error {
+	return errors.New("suspend is local-only: a suspended visor drops off dmsg and cannot be reached or resumed via the hypervisor")
+}
+
+func (p *proxiedVisorAPI) Resume() error {
+	return errors.New("resume is local-only: a suspended visor is unreachable over dmsg; resume it from its own host RPC")
+}
+
+func (p *proxiedVisorAPI) IsSuspended() (bool, error) {
+	return false, errors.New("suspend state is not queryable over the hypervisor: a suspended visor is unreachable over dmsg")
+}
+
 func (p *proxiedVisorAPI) Shutdown() error {
 	return p.hvAPI.HVShutdown(p.targetPK)
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -935,6 +935,23 @@ func (rc *rpcClient) Reload() error {
 	return rc.Call("Reload", &struct{}{}, &struct{}{})
 }
 
+// Suspend calls Suspend.
+func (rc *rpcClient) Suspend() error {
+	return rc.Call("Suspend", &struct{}{}, &struct{}{})
+}
+
+// Resume calls Resume.
+func (rc *rpcClient) Resume() error {
+	return rc.Call("Resume", &struct{}{}, &struct{}{})
+}
+
+// IsSuspended calls IsSuspended.
+func (rc *rpcClient) IsSuspended() (bool, error) {
+	var suspended bool
+	err := rc.Call("IsSuspended", &struct{}{}, &suspended)
+	return suspended, err
+}
+
 // Shutdown calls Shutdown.
 func (rc *rpcClient) Shutdown() error {
 	return rc.Call("Shutdown", &struct{}{}, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -868,6 +868,21 @@ func (mc *mockRPCClient) Reload() error {
 	return nil
 }
 
+// Suspend implements API.
+func (mc *mockRPCClient) Suspend() error {
+	return nil
+}
+
+// Resume implements API.
+func (mc *mockRPCClient) Resume() error {
+	return nil
+}
+
+// IsSuspended implements API.
+func (mc *mockRPCClient) IsSuspended() (bool, error) {
+	return false, nil
+}
+
 // Shutdown implements API.
 func (mc *mockRPCClient) Shutdown() error {
 	return nil

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -187,6 +187,25 @@ func (r *RPC) Reload(_ *struct{}, _ *struct{}) (err error) {
 	return r.visor.Reload()
 }
 
+// Suspend tears down all network subsystems, keeping the local RPC alive.
+func (r *RPC) Suspend(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "Suspend", nil)(nil, &err)
+	return r.visor.Suspend()
+}
+
+// Resume re-runs the module graph to bring a suspended visor back online.
+func (r *RPC) Resume(_ *struct{}, _ *struct{}) (err error) {
+	defer rpcutil.LogCall(r.log, "Resume", nil)(nil, &err)
+	return r.visor.Resume()
+}
+
+// IsSuspended reports whether the visor is currently suspended.
+func (r *RPC) IsSuspended(_ *struct{}, out *bool) (err error) {
+	defer rpcutil.LogCall(r.log, "IsSuspended", nil)(out, &err)
+	*out, err = r.visor.IsSuspended()
+	return err
+}
+
 // Shutdown shuts down visor.
 func (r *RPC) Shutdown(_ *struct{}, _ *struct{}) (err error) {
 	// @evanlinjin: do not defer this log statement, as the underlying visor.Logger will get closed.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -84,6 +84,19 @@ var mLog = initLogger()
 type Visor struct {
 	closeStack []closer
 
+	// Suspend/Resume state. Suspend tears down every network subsystem
+	// but keeps the local CLI RPC listener (cli.listener/cli.grpc) alive
+	// so Resume can arrive; Resume re-runs the module graph. See
+	// api_suspend.go. cliLocalUp guards initCLI's once-only local-listener
+	// setup so a Resume re-run only re-creates the dmsg/transport-bound
+	// RPC surfaces. networkCtx is a cancelable parent for all network
+	// modules; Suspend cancels it so ctx-honoring goroutines unwind.
+	suspendMu     sync.Mutex
+	suspended     bool
+	cliLocalUp    bool
+	networkCtx    context.Context
+	networkCancel context.CancelFunc
+
 	ctx      context.Context // stored so RPC handlers can derive child contexts
 	conf     *visorconfig.V1
 	log      *logging.Logger
@@ -679,6 +692,11 @@ func NewVisor(ctx context.Context, conf *visorconfig.V1, logBcast *logging.Broad
 			ctx = context.WithValue(ctx, "dmsgServerAddr", dmsgServerAddr) //nolint:staticcheck // SA1029: matches dmsg.Client's existing string key
 		}
 	}
+	// Wrap the fully value-decorated ctx in a cancelable child stored on
+	// the visor, so Suspend can cancel every network module's context
+	// without touching the process-level signal ctx. Resume rebuilds it.
+	v.networkCtx, v.networkCancel = context.WithCancel(ctx)
+	ctx = v.networkCtx
 	registerModules(v.MasterLogger())
 	var mainModule visorinit.Module
 	if v.conf.Hypervisor == nil {

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -852,15 +852,27 @@ func (v *Visor) Close() error {
 		}
 	}
 
-	for i := len(v.closeStack) - 1; i >= 0; i-- {
-		cl := v.closeStack[i]
+	// Snapshot the close stack under initLock before iterating. Suspend/Resume
+	// mutate v.closeStack concurrently (Suspend replaces it with the kept set,
+	// Resume's re-init appends closers via pushCloseStack), so reading
+	// v.closeStack[i] against a recomputed len(v.closeStack) races and panics
+	// "index out of range" when the slice shrinks mid-loop (e.g. a shutdown
+	// signal arriving during a Suspend). Copy under the lock, then run the
+	// copied closers unlocked — their fns take time / may take the lock. Same
+	// snapshot pattern Suspend itself uses.
+	v.initLock.RLock()
+	closeStack := append([]closer(nil), v.closeStack...)
+	v.initLock.RUnlock()
+
+	for i := len(closeStack) - 1; i >= 0; i-- {
+		cl := closeStack[i]
 
 		start := time.Now()
 		errCh := make(chan error, 1)
 		t := time.NewTimer(moduleShutdownTimeout)
 
 		log := v.MasterLogger().PackageLogger(fmt.Sprintf("visor:shutdown:%s", cl.src)).
-			WithField("func", fmt.Sprintf("[%d/%d]", i+1, len(v.closeStack)))
+			WithField("func", fmt.Sprintf("[%d/%d]", i+1, len(closeStack)))
 		log.Debug("Shutting down module...")
 
 		go func(cl closer) {


### PR DESCRIPTION
Adds a **Suspend/Resume** lifecycle so an operator or the systray can pause/unpause a node **without privilege to control the service-manager unit** — the privesc-free alternative to `systemctl stop/start`.

### Behavior
- **Suspend** tears down every network subsystem (transports, routing, apps, dmsg, autoconnect, AR/TPD registration, reward heartbeat, and the dmsg/transport-bound RPC surfaces) while keeping the **local CLI RPC listener** alive and the process running. The node earns nothing, routes nothing, and drops off dmsg discovery, but stays controllable on `CLIAddr`.
- **Resume** re-runs the module graph to bring it fully back online.
- **Local-only by design:** a suspended visor is unreachable over dmsg, so the hypervisor-proxied API returns an explanatory error; Suspend/Resume must be called on the target's own host RPC.

### Mechanism
- `NewVisor` wraps the module ctx in a cancelable child (`networkCtx`/`networkCancel`) stored on the visor; Suspend cancels it so ctx-honoring goroutines unwind before their listeners/clients close.
- `initCLI` is split: the **local** RPC surface (cli.listener + cmux + local gRPC + net/rpc accept) is created once and guarded by `cliLocalUp` so a Resume re-run doesn't re-bind `CLIAddr`; the dmsg/transport-bound surfaces re-create every init.
- Suspend walks the closeStack in reverse (same LIFO order as `Close`), runs every closer except the kept local-RPC entries, retains only those, drops references to the torn-down subsystems, and resets the one-shot readiness channels (stun/dmsgTracker also reset their `sync.Once`, matching the `api_network` reconnect pattern).

### Surfaces
`API.Suspend/Resume/IsSuspended`, RPC wrappers + client + mock, and `skywire cli visor suspend|resume|suspended`.

### Testing
- **Unit-tested (`api_suspend_test.go`):** Suspend runs non-kept closers in LIFO order, retains only the kept local-RPC entries, resets the one-shot channels (verified open afterward), and is idempotent.
- `pkg/visor` suite + `golangci-lint` clean.

> ⚠️ **Not for auto-merge.** Resume's full module-graph re-init needs live validation on a running node (suspend → confirm quiescent + local RPC still answers → resume → confirm transports/routing/apps/dmsg all return). I could not run this locally without standing up a second native visor (against our operational rule), so please validate on a spare/non-critical node before merging. Design + teardown logic are covered by the unit test; the re-init path is the part to exercise.