### PR TITLE
refactor(cli): centralize routing-session application in one shared helper

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -158,52 +157,25 @@ var startCmd = &cobra.Command{
 		// that constraint. Always SetExistingTPOnly / SetForceLocalRoutes
 		// to exactly the current flag value so the visor mirrors what
 		// the operator just typed.
-		if err := rpcClient.SetExistingTPOnly(existingTpOnly); err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set existing transport only mode: %w", err))
+		// Apply the routing-session options via the shared helper (clirpc),
+		// the SAME sequence + quirks the generic `cli visor app start` and
+		// `cli vpn start` use, so the surfaces can't drift. existing-tp /
+		// local-route are always applied to the current flag value (so a later
+		// `proxy start <pk>` with no flags mirrors exactly what was typed and
+		// doesn't silently inherit stale state); mux/mux-mode carry their
+		// sentinel/skip semantics inside the helper; --min-hops only fires when
+		// explicitly set (0 is rejected there).
+		routeOpts := clirpc.RoutingSessionOpts{
+			ExistingTP: &existingTpOnly,
+			LocalRoute: &forceLocalRoutes,
+			MuxRoutes:  &muxRoutes,
+			MuxMode:    &muxMode,
 		}
-		if err := rpcClient.SetForceLocalRoutes(forceLocalRoutes); err != nil {
-			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set force local routes mode: %w", err))
-		}
-
-		// If --mux flag is set, enable route multiplexing.
-		// 0 means "unlimited" — translate to a large sentinel that
-		// establishMuxRoutes (router_dial.go) iterates against; that
-		// loop already breaks on the first fetchBestRoutes error, so
-		// passing a high number stops naturally at the discoverable
-		// path count.
-		// 1 (default) means "no mux"; SetMuxRoutes is skipped so the
-		// router uses its existing single-route path.
-		// 2+ means N parallel routes, same as before.
-		muxArg := muxRoutes
-		if muxArg == 0 {
-			muxArg = math.MaxInt32
-		}
-		if muxArg > 1 {
-			if err := rpcClient.SetMuxRoutes(muxArg); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set mux routes: %w", err))
-			}
-		}
-
-		// Set mux weight mode if specified
-		if muxMode != "" && muxMode != "auto" {
-			if err := rpcClient.SetMuxMode(muxMode); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set mux mode: %w", err))
-			}
-		}
-
-		// --min-hops only fires when the user explicitly set it; we
-		// don't want to clobber visor's default just because the flag
-		// has a default value of 1. Reusing the existing global
-		// SetMinHops RPC (matches the SetMux*/SetExistingTPOnly idiom);
-		// changes the visor-wide setting, so a follow-up `proxy start
-		// --min-hops=1` is needed to revert.
 		if cmd.Flags().Changed("min-hops") {
-			if minHops == 0 {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("--min-hops=0 disables routing; pick at least 1"))
-			}
-			if err := rpcClient.SetMinHops(minHops); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set min-hops: %w", err))
-			}
+			routeOpts.MinHops = &minHops
+		}
+		if err := clirpc.ApplyRoutingSession(rpcClient, routeOpts); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
 		}
 
 		// In --verbose mode the SignalContext-driven cleanup path needs

--- a/cmd/skywire-cli/commands/rpc/routingsession.go
+++ b/cmd/skywire-cli/commands/rpc/routingsession.go
@@ -1,0 +1,68 @@
+// Package clirpc cmd/skywire-cli/commands/rpc/routingsession.go c4-vis-cli
+package clirpc
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/skycoin/skywire/pkg/visor"
+)
+
+// RoutingSessionOpts carries the routing-session options shared by the app-start
+// surfaces (`cli proxy start`, `cli vpn start`, `cli visor app start`). Every
+// field is a pointer so the caller applies ONLY what it wants set — a nil field
+// leaves that visor setting untouched. This lets each command keep its own
+// flag/Changed semantics while the actual RPC sequence (and its quirks) lives in
+// exactly one place, so the three surfaces can't drift.
+type RoutingSessionOpts struct {
+	ExistingTP *bool   // SetExistingTPOnly
+	LocalRoute *bool   // SetForceLocalRoutes
+	MuxRoutes  *int    // SetMuxRoutes — raw flag value; 0=unlimited, 1=disabled (skipped), 2+=N
+	MuxMode    *string // SetMuxMode — "" / "auto" skipped (router default)
+	MinHops    *uint16 // SetMinHops — 0 is rejected (disables routing)
+}
+
+// ApplyRoutingSession applies the non-nil options in canonical order via the
+// visor RPC. It preserves the exact semantics the proxy-start path established:
+//   - mux 0 → MaxInt32 ("unlimited", establishMuxRoutes stops at the discoverable
+//     path count); mux 1 → skipped (single-route default); 2+ → N parallel routes.
+//   - mux-mode "" / "auto" → skipped (router's own default weighting).
+//   - min-hops 0 → error (0 disables routing).
+func ApplyRoutingSession(rc visor.API, o RoutingSessionOpts) error {
+	if o.ExistingTP != nil {
+		if err := rc.SetExistingTPOnly(*o.ExistingTP); err != nil {
+			return fmt.Errorf("failed to set existing-transport-only mode: %w", err)
+		}
+	}
+	if o.LocalRoute != nil {
+		if err := rc.SetForceLocalRoutes(*o.LocalRoute); err != nil {
+			return fmt.Errorf("failed to set force-local-routes mode: %w", err)
+		}
+	}
+	if o.MuxRoutes != nil {
+		n := *o.MuxRoutes
+		if n == 0 {
+			n = math.MaxInt32
+		}
+		if n > 1 {
+			if err := rc.SetMuxRoutes(n); err != nil {
+				return fmt.Errorf("failed to set mux routes: %w", err)
+			}
+		}
+	}
+	if o.MuxMode != nil && *o.MuxMode != "" && *o.MuxMode != "auto" {
+		if err := rc.SetMuxMode(*o.MuxMode); err != nil {
+			return fmt.Errorf("failed to set mux mode: %w", err)
+		}
+	}
+	if o.MinHops != nil {
+		if *o.MinHops == 0 {
+			return errors.New("--min-hops=0 disables routing; pick at least 1")
+		}
+		if err := rc.SetMinHops(*o.MinHops); err != nil {
+			return fmt.Errorf("failed to set min-hops: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/skywire-cli/commands/visor/app.go
+++ b/cmd/skywire-cli/commands/visor/app.go
@@ -216,22 +216,26 @@ var startAppCmd = &cobra.Command{
 
 		// Generic routing-session options — apply each only when the operator
 		// passed it, so a bare `visor app start <name>` doesn't silently flip
-		// visor-wide routing preferences. Same RPCs `cli proxy`/`cli vpn` call.
+		// visor-wide routing preferences. The shared helper applies the SAME
+		// sequence + quirks (mux sentinel, min-hops guard) as `cli proxy start`
+		// / `cli vpn start`, so the three surfaces can't drift.
+		o := clirpc.RoutingSessionOpts{}
 		if cmd.Flags().Changed("existing-tp") {
-			internal.Catch(cmd.Flags(), rpcClient.SetExistingTPOnly(appExistingTP))
+			o.ExistingTP = &appExistingTP
 		}
 		if cmd.Flags().Changed("local-route") {
-			internal.Catch(cmd.Flags(), rpcClient.SetForceLocalRoutes(appLocalRoute))
+			o.LocalRoute = &appLocalRoute
 		}
 		if cmd.Flags().Changed("mux") {
-			internal.Catch(cmd.Flags(), rpcClient.SetMuxRoutes(appMuxRoutes))
+			o.MuxRoutes = &appMuxRoutes
 		}
 		if cmd.Flags().Changed("mux-mode") {
-			internal.Catch(cmd.Flags(), rpcClient.SetMuxMode(appMuxMode))
+			o.MuxMode = &appMuxMode
 		}
 		if cmd.Flags().Changed("min-hops") {
-			internal.Catch(cmd.Flags(), rpcClient.SetMinHops(appMinHops))
+			o.MinHops = &appMinHops
 		}
+		internal.Catch(cmd.Flags(), clirpc.ApplyRoutingSession(rpcClient, o))
 
 		internal.Catch(cmd.Flags(), rpcClient.StartAppWithMode(args[0], launcherMode))
 		internal.PrintOutput(cmd.Flags(), "OK", "OK\n")

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -71,18 +71,18 @@ var startCmd = &cobra.Command{
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("unable to create RPC client: %w", err))
 		}
 
-		// If --existing-tp flag is set, configure router to only use existing transports
+		// Apply the routing-session options via the shared helper (clirpc), the
+		// SAME path `cli proxy start` / `cli visor app start` use so the surfaces
+		// can't drift. vpn only offers existing-tp / local-route, applied when set.
+		routeOpts := clirpc.RoutingSessionOpts{}
 		if existingTpOnly {
-			if err := rpcClient.SetExistingTPOnly(true); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set existing transport only mode: %w", err))
-			}
+			routeOpts.ExistingTP = &existingTpOnly
 		}
-
-		// If --local-route flag is set, skip route finder and use local route calculation
 		if forceLocalRoutes {
-			if err := rpcClient.SetForceLocalRoutes(true); err != nil {
-				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to set force local routes mode: %w", err))
-			}
+			routeOpts.LocalRoute = &forceLocalRoutes
+		}
+		if err := clirpc.ApplyRoutingSession(rpcClient, routeOpts); err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
 		}
 
 		launcherMode := ""


### PR DESCRIPTION
Extracts the routing-session RPC sequence — `SetExistingTPOnly` / `SetForceLocalRoutes` / `SetMuxRoutes` / `SetMuxMode` / `SetMinHops`, previously duplicated across `cli proxy start`, `cli vpn start`, and (as of #3664) `cli visor app start` — into a single shared helper `clirpc.ApplyRoutingSession` + `RoutingSessionOpts`.

Each command keeps its own flags and `Changed`/semantics by populating only the optional (pointer) fields it owns; the helper applies the **same order and quirks in one place** (mux `0`→unlimited / `1`→skip / `2+`=N, mux-mode `""`/`"auto"` skip, min-hops `0` rejected), so the three surfaces can't drift.

**Behavior preserved by construction** — same RPCs, same order, same guards:
- **proxy**: existing-tp/local-route always applied, mux/mux-mode carried through, min-hops only when `Changed`.
- **vpn**: existing-tp/local-route applied only when set (unchanged).
- **visor app**: all fields `Changed`-gated (now also gains the mux sentinel + min-hops guard for consistency).

The sensitive proxy/vpn flows (verbose gRPC streaming, in-process reconnect, state-polling, service-specific start RPCs) are **untouched** — this is the routing-options extraction only, the anti-drift step from the CLI-convergence audit. Builds + golangci-lint clean.

> Not auto-merged — touches `cli proxy`/`cli vpn start`; worth a quick live `proxy start`/`vpn start` sanity check before merge even though the RPC sequence is identical.
