### PR TITLE
fix(reward-uptime): score visor uptime against the 5-min heartbeat cadence (fixes the ~30% regression)

### DIFF
--- a/pkg/transport-discovery/store/redis_store.go
+++ b/pkg/transport-discovery/store/redis_store.go
@@ -113,7 +113,22 @@ func (s *redisStore) Close() {
 
 const timelineSlots = 24 * 60 / 5
 const uptimeHistoryDays = 7
+
+// expectedHeartbeatsPerDay is the denominator for TRANSPORT uptime: transports
+// re-register on a ~90-second cadence (transport.Manager.runReRegisterTransports),
+// so a continuously-registered transport lands ~960 RecordHeartbeat calls/day.
 const expectedHeartbeatsPerDay = float64(24*60*60) / float64(90) // 960
+
+// expectedVisorHeartbeatsPerDay is the denominator for VISOR uptime. A visor's
+// dedicated presence heartbeat fires every 5 minutes (tickDuration in
+// pkg/visor/init_services.go), so a continuously-up visor lands 288 heartbeats/
+// day. Dividing visor uptime by the 90-second TRANSPORT figure (960) scored a
+// continuously-up NON-hub visor at 288/960 = 30% — below the 75% reward bar —
+// which is the v1.3.88+ fleet-wide reward-uptime regression (transport HUBS read
+// 100% only because their frequent re-registration also calls RecordHeartbeat).
+// Because the daily percentage is computed from the stored count at READ time,
+// correcting the divisor also fixes every day still in Redis retroactively.
+const expectedVisorHeartbeatsPerDay = float64(24*60*60) / float64(5*60) // 288
 
 // RecordHeartbeat records a visor heartbeat for uptime tracking.
 // Each heartbeat increments the daily counter and updates the version/last_seen.

--- a/pkg/transport-discovery/store/redis_uptime.go
+++ b/pkg/transport-discovery/store/redis_uptime.go
@@ -125,7 +125,7 @@ func (s *redisStore) getDailyUptime(ctx context.Context, pkHex string, now time.
 			continue
 		}
 
-		pct := (count / expectedHeartbeatsPerDay) * 100
+		pct := (count / expectedVisorHeartbeatsPerDay) * 100
 		if pct > 100 {
 			pct = 100
 		}


### PR DESCRIPTION
## The bug

Daily visor uptime — which gates rewards at ≥75% — is computed from the per-day heartbeat `count` as `count / expectedHeartbeatsPerDay`. That divisor was **960** (`86400/90`), the **~90-second transport re-registration** cadence. But a visor's dedicated presence heartbeat fires **every 5 minutes** (`tickDuration`, `pkg/visor/init_services.go`), so a continuously-up visor only lands **288 heartbeats/day**.

So a fully-up, non-hub visor scored `288/960 = **30.00%**` — below the 75% bar — while transport **hubs** read 100% only because their frequent re-registration *also* calls `RecordHeartbeat`. This is the stable, fleet-wide **v1.3.88+ reward-uptime regression** (roughly half the fleet clustered at ~30%).

`#3619`'s timeline backfill did not help because the reward percentage reads `count`, not the timeline bitmap.

## The fix

Score **visor** uptime with `expectedVisorHeartbeatsPerDay = 86400/300 = 288` (the real 5-min heartbeat cadence). **Transport** uptime keeps the 90s figure (transports genuinely re-register ~every 90s).

Because the daily percentage is computed from the stored `count` **at read time**, correcting the divisor also fixes **every day still in Redis retroactively** — no fleet update, no backfill. The ~30% cluster maps straight to ~100%.

## Verification
- A pure non-hub visor at exactly 30.00% has `count ≈ 288` → `288/288 = 100%` after the fix.
- Live: a continuously-up local visor recorded 27–34%/day for a week while its local process/dmsg/skynet uptime was 100%.
- `go test ./pkg/transport-discovery/...` green; gofmt/vet/golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)