### PR TITLE
feat(skynet): pool + yamux-reuse explicit source-route dials

### DIFF
--- a/pkg/skyroute/pool.go
+++ b/pkg/skyroute/pool.go
@@ -9,7 +9,7 @@
 // route-finding + per-hop rule setup (seconds). Direct routes re-set-up instantly,
 // which is why "it only worked for direct routes".
 //
-// Pool fixes that by holding ONE route group per destination open and multiplexing
+// Pool fixes that by holding ONE route group per route KEY open and multiplexing
 // many logical connections over it with yamux — exactly the shape skysocks-lite
 // already used privately. The held route group's keepalive keeps the multihop hops
 // warm, so subsequent connections reuse it with zero setup. The route lives on the
@@ -17,6 +17,12 @@
 // external-browser SOCKS5 case and the in-tab iframe case identically. An idle
 // route group is reclaimed after IdleTTL; a holder that knows it's done (an iframe
 // window closing) can Release it eagerly.
+//
+// The key is opaque to the pool: the resolving proxy keys the route-finder path on
+// the destination PK and the explicit source-route path on destination+hop-set, so
+// a `<pk>.skynet` fetch and a `<hop>.<pk>.skynet` fetch hold independent warm route
+// groups instead of one clobbering the other. The caller passes the dial closure
+// per OpenStream, so the pool needs no knowledge of how a given route is built.
 //
 // The far end must run the yamux-aware skyfwd server (skyenv.SkyForwardingMuxPort).
 // Against older visors that don't, the first dial fails, OpenStream returns
@@ -33,13 +39,12 @@ import (
 	"github.com/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
 
-	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
 // ErrNoMux means the destination's visor does not serve the yamux forwarding port
 // (an older build). The caller should fall back to a 1:1 SkyForwardingServerPort
-// dial. The pool negative-caches this per destination so it isn't re-probed on
+// dial. The pool negative-caches this per route key so it isn't re-probed on
 // every request.
 var ErrNoMux = errors.New("skyroute: destination does not serve the mux forwarding port")
 
@@ -48,7 +53,7 @@ const (
 	// closes before the reaper reclaims it. The route's keepalive keeps the hops
 	// warm during this window so reconnects reuse it with no setup.
 	DefaultIdleTTL = 10 * time.Minute
-	// negativeCacheTTL is how long a destination found to lack mux support is
+	// negativeCacheTTL is how long a route key found to lack mux support is
 	// skipped (returns ErrNoMux without re-dialing) before being re-probed.
 	negativeCacheTTL = 5 * time.Minute
 	// firstStreamTimeout bounds the first yamux stream open, so a route dialed to a
@@ -58,31 +63,31 @@ const (
 )
 
 // DialRoute dials the destination's forwarding server on muxPort over a (possibly
-// multihop) route and returns the route-group net.Conn. The pool yamux-muxes over
-// whatever conn this returns; it can take several seconds (route setup) and is
-// always called without the pool lock held.
-type DialRoute func(ctx context.Context, dest cipher.PubKey, muxPort uint16) (net.Conn, error)
+// multihop) route and returns the route-group net.Conn. It captures whatever
+// destination / hop-set specifics it needs, so the pool stays route-agnostic. The
+// pool yamux-muxes over whatever conn this returns; it can take several seconds
+// (route setup) and is always called without the pool lock held.
+type DialRoute func(ctx context.Context, muxPort uint16) (net.Conn, error)
 
 type heldSession struct {
 	sess       *yamux.Session
 	lastActive time.Time // last time this route group had ≥1 stream (or was opened)
 }
 
-// Pool holds and reuses route groups keyed by destination PK.
+// Pool holds and reuses route groups keyed by an opaque route key.
 type Pool struct {
-	dial    DialRoute
 	idleTTL time.Duration
 	log     logrus.FieldLogger
 
 	mu       sync.Mutex
-	sessions map[cipher.PubKey]*heldSession
-	negative map[cipher.PubKey]time.Time // dest -> earliest re-probe time
+	sessions map[string]*heldSession
+	negative map[string]time.Time // key -> earliest re-probe time
 	closed   bool
 	stop     chan struct{}
 }
 
 // New builds a Pool. idleTTL ≤ 0 uses DefaultIdleTTL. A nil log discards output.
-func New(dial DialRoute, idleTTL time.Duration, log logrus.FieldLogger) *Pool {
+func New(idleTTL time.Duration, log logrus.FieldLogger) *Pool {
 	if idleTTL <= 0 {
 		idleTTL = DefaultIdleTTL
 	}
@@ -92,30 +97,30 @@ func New(dial DialRoute, idleTTL time.Duration, log logrus.FieldLogger) *Pool {
 		log = l
 	}
 	p := &Pool{
-		dial:     dial,
 		idleTTL:  idleTTL,
 		log:      log,
-		sessions: map[cipher.PubKey]*heldSession{},
-		negative: map[cipher.PubKey]time.Time{},
+		sessions: map[string]*heldSession{},
+		negative: map[string]time.Time{},
 		stop:     make(chan struct{}),
 	}
 	go p.reapLoop()
 	return p
 }
 
-// OpenStream returns a stream to dest's skyfwd server over a HELD, reused route
-// group, dialing + caching the route group on first use (or after the previous one
-// died). The caller then runs the skynet handshake (skynetweb.PerformHandshake) on
-// the returned conn exactly as it would on a fresh route. Returns ErrNoMux when
-// dest doesn't serve the mux port (caller should fall back to a 1:1 dial).
-func (p *Pool) OpenStream(ctx context.Context, dest cipher.PubKey) (net.Conn, error) {
+// OpenStream returns a stream to the route key's skyfwd server over a HELD, reused
+// route group, dialing (via the supplied closure) + caching the route group on
+// first use (or after the previous one died). The caller then runs the skynet
+// handshake (skynetweb.PerformHandshake) on the returned conn exactly as it would
+// on a fresh route. Returns ErrNoMux when the destination doesn't serve the mux
+// port (caller should fall back to a 1:1 dial).
+func (p *Pool) OpenStream(ctx context.Context, key string, dial DialRoute) (net.Conn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
 		return nil, errors.New("skyroute: pool closed")
 	}
 	// Reuse an open session.
-	if s, ok := p.sessions[dest]; ok {
+	if s, ok := p.sessions[key]; ok {
 		if !s.sess.IsClosed() {
 			s.lastActive = time.Now()
 			sess := s.sess
@@ -125,27 +130,27 @@ func (p *Pool) OpenStream(ctx context.Context, dest cipher.PubKey) (net.Conn, er
 			}
 			// Session is up but won't yield a stream — drop it and redial below.
 			p.mu.Lock()
-			if cur, ok := p.sessions[dest]; ok && cur.sess == sess {
+			if cur, ok := p.sessions[key]; ok && cur.sess == sess {
 				_ = sess.Close() //nolint:errcheck
-				delete(p.sessions, dest)
+				delete(p.sessions, key)
 			}
 		} else {
 			_ = s.sess.Close() //nolint:errcheck
-			delete(p.sessions, dest)
+			delete(p.sessions, key)
 		}
 	}
-	// Skip destinations recently found to lack mux support.
-	if t, ok := p.negative[dest]; ok {
+	// Skip keys recently found to lack mux support.
+	if t, ok := p.negative[key]; ok {
 		if time.Now().Before(t) {
 			p.mu.Unlock()
 			return nil, ErrNoMux
 		}
-		delete(p.negative, dest)
+		delete(p.negative, key)
 	}
 	p.mu.Unlock()
 
 	// Dial the mux forwarding port over a route (may take seconds; no lock held).
-	conn, err := p.dial(ctx, dest, skyenv.SkyForwardingMuxPort)
+	conn, err := dial(ctx, skyenv.SkyForwardingMuxPort)
 	if err != nil {
 		return nil, err
 	}
@@ -161,11 +166,11 @@ func (p *Pool) OpenStream(ctx context.Context, dest cipher.PubKey) (net.Conn, er
 		_ = sess.Close() //nolint:errcheck
 		_ = conn.Close() //nolint:errcheck
 		p.mu.Lock()
-		p.negative[dest] = time.Now().Add(negativeCacheTTL)
+		p.negative[key] = time.Now().Add(negativeCacheTTL)
 		p.mu.Unlock()
 		return nil, ErrNoMux
 	}
-	// Publish, unless a concurrent dial for the same dest already won.
+	// Publish, unless a concurrent dial for the same key already won.
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -173,7 +178,7 @@ func (p *Pool) OpenStream(ctx context.Context, dest cipher.PubKey) (net.Conn, er
 		_ = sess.Close()   //nolint:errcheck
 		return nil, errors.New("skyroute: pool closed")
 	}
-	if cur, ok := p.sessions[dest]; ok && !cur.sess.IsClosed() {
+	if cur, ok := p.sessions[key]; ok && !cur.sess.IsClosed() {
 		other := cur.sess
 		p.mu.Unlock()
 		_ = stream.Close() //nolint:errcheck
@@ -183,19 +188,19 @@ func (p *Pool) OpenStream(ctx context.Context, dest cipher.PubKey) (net.Conn, er
 		}
 		return nil, errors.New("skyroute: raced session unusable")
 	}
-	p.sessions[dest] = &heldSession{sess: sess, lastActive: time.Now()}
+	p.sessions[key] = &heldSession{sess: sess, lastActive: time.Now()}
 	p.mu.Unlock()
 	return stream, nil
 }
 
-// Release eagerly closes and drops dest's held route group (e.g. an iframe window
-// that owned it has closed). Idempotent.
-func (p *Pool) Release(dest cipher.PubKey) {
+// Release eagerly closes and drops a route key's held route group (e.g. an iframe
+// window that owned it has closed). Idempotent.
+func (p *Pool) Release(key string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if s, ok := p.sessions[dest]; ok {
+	if s, ok := p.sessions[key]; ok {
 		_ = s.sess.Close() //nolint:errcheck
-		delete(p.sessions, dest)
+		delete(p.sessions, key)
 	}
 }
 
@@ -208,9 +213,9 @@ func (p *Pool) Close() error {
 	}
 	p.closed = true
 	close(p.stop)
-	for dest, s := range p.sessions {
+	for key, s := range p.sessions {
 		_ = s.sess.Close() //nolint:errcheck
-		delete(p.sessions, dest)
+		delete(p.sessions, key)
 	}
 	return nil
 }
@@ -235,9 +240,9 @@ func (p *Pool) reap() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	now := time.Now()
-	for dest, s := range p.sessions {
+	for key, s := range p.sessions {
 		if s.sess.IsClosed() {
-			delete(p.sessions, dest)
+			delete(p.sessions, key)
 			continue
 		}
 		if s.sess.NumStreams() > 0 {
@@ -246,13 +251,13 @@ func (p *Pool) reap() {
 		}
 		if now.Sub(s.lastActive) > p.idleTTL {
 			_ = s.sess.Close() //nolint:errcheck
-			delete(p.sessions, dest)
-			p.log.WithField("dest", dest.String()).Debug("skyroute: released idle route group")
+			delete(p.sessions, key)
+			p.log.WithField("key", key).Debug("skyroute: released idle route group")
 		}
 	}
-	for dest, t := range p.negative {
+	for key, t := range p.negative {
 		if now.After(t) {
-			delete(p.negative, dest)
+			delete(p.negative, key)
 		}
 	}
 }

--- a/pkg/skyroute/pool_test.go
+++ b/pkg/skyroute/pool_test.go
@@ -29,11 +29,11 @@ func echoServer(conn net.Conn) {
 	}
 }
 
-func testPK(b byte) cipher.PubKey {
+func testKey(b byte) string {
 	var pk cipher.PubKey
 	pk[0] = 0x02
 	pk[1] = b
-	return pk
+	return pk.Hex()
 }
 
 func roundtrip(t *testing.T, c net.Conn, msg string) {
@@ -49,18 +49,18 @@ func roundtrip(t *testing.T, c net.Conn, msg string) {
 // A working mux far-end reuses ONE route group across many OpenStream calls.
 func TestPool_ReusesRouteGroup(t *testing.T) {
 	var dials int32
-	dial := func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
 		atomic.AddInt32(&dials, 1)
 		a, b := net.Pipe()
 		go echoServer(b)
 		return a, nil
 	}
-	p := New(dial, time.Minute, nil)
+	p := New(time.Minute, nil)
 	defer p.Close() //nolint:errcheck
 
-	dest := testPK(1)
+	key := testKey(1)
 	for i := 0; i < 4; i++ {
-		s, err := p.OpenStream(context.Background(), dest)
+		s, err := p.OpenStream(context.Background(), key, dial)
 		require.NoError(t, err)
 		roundtrip(t, s, "ping")
 		require.NoError(t, s.Close())
@@ -72,20 +72,20 @@ func TestPool_ReusesRouteGroup(t *testing.T) {
 // re-dial) so the caller falls back cheaply.
 func TestPool_NoMuxFallbackAndNegativeCache(t *testing.T) {
 	var dials int32
-	dial := func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
 		atomic.AddInt32(&dials, 1)
 		a, b := net.Pipe()
 		_ = b.Close() //nolint:errcheck // no yamux server → session dies immediately
 		return a, nil
 	}
-	p := New(dial, time.Minute, nil)
+	p := New(time.Minute, nil)
 	defer p.Close() //nolint:errcheck
 
-	dest := testPK(2)
-	_, err := p.OpenStream(context.Background(), dest)
+	key := testKey(2)
+	_, err := p.OpenStream(context.Background(), key, dial)
 	require.ErrorIs(t, err, ErrNoMux)
 	// Second call is served from the negative cache — no second dial.
-	_, err = p.OpenStream(context.Background(), dest)
+	_, err = p.OpenStream(context.Background(), key, dial)
 	require.ErrorIs(t, err, ErrNoMux)
 	require.EqualValues(t, 1, atomic.LoadInt32(&dials), "no-mux destination must be negative-cached")
 }
@@ -94,29 +94,29 @@ func TestPool_NoMuxFallbackAndNegativeCache(t *testing.T) {
 // the next OpenStream re-dials.
 func TestPool_IdleReap(t *testing.T) {
 	var dials int32
-	dial := func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
 		atomic.AddInt32(&dials, 1)
 		a, b := net.Pipe()
 		go echoServer(b)
 		return a, nil
 	}
-	p := New(dial, 60*time.Millisecond, nil)
+	p := New(60*time.Millisecond, nil)
 	defer p.Close() //nolint:errcheck
 
-	dest := testPK(3)
-	s, err := p.OpenStream(context.Background(), dest)
+	key := testKey(3)
+	s, err := p.OpenStream(context.Background(), key, dial)
 	require.NoError(t, err)
 	roundtrip(t, s, "a")
 	require.NoError(t, s.Close())
 
 	require.Eventually(t, func() bool {
 		p.mu.Lock()
-		_, held := p.sessions[dest]
+		_, held := p.sessions[key]
 		p.mu.Unlock()
 		return !held
 	}, 2*time.Second, 20*time.Millisecond, "idle route group should be reaped")
 
-	_, err = p.OpenStream(context.Background(), dest)
+	_, err = p.OpenStream(context.Background(), key, dial)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, atomic.LoadInt32(&dials), "should re-dial after idle reap")
 }
@@ -124,22 +124,48 @@ func TestPool_IdleReap(t *testing.T) {
 // Release eagerly drops the held route group so the next call re-dials.
 func TestPool_Release(t *testing.T) {
 	var dials int32
-	dial := func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
 		atomic.AddInt32(&dials, 1)
 		a, b := net.Pipe()
 		go echoServer(b)
 		return a, nil
 	}
-	p := New(dial, time.Minute, nil)
+	p := New(time.Minute, nil)
 	defer p.Close() //nolint:errcheck
 
-	dest := testPK(4)
-	s, err := p.OpenStream(context.Background(), dest)
+	key := testKey(4)
+	s, err := p.OpenStream(context.Background(), key, dial)
 	require.NoError(t, err)
 	require.NoError(t, s.Close())
 
-	p.Release(dest)
-	_, err = p.OpenStream(context.Background(), dest)
+	p.Release(key)
+	_, err = p.OpenStream(context.Background(), key, dial)
 	require.NoError(t, err)
 	require.EqualValues(t, 2, atomic.LoadInt32(&dials), "Release should force a re-dial")
+}
+
+// Distinct route keys to the same destination (e.g. a plain <pk>.skynet fetch vs an
+// explicit <hop>.<pk>.skynet source route) hold independent warm route groups.
+func TestPool_DistinctKeysIndependent(t *testing.T) {
+	var dials int32
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
+		atomic.AddInt32(&dials, 1)
+		a, b := net.Pipe()
+		go echoServer(b)
+		return a, nil
+	}
+	p := New(time.Minute, nil)
+	defer p.Close() //nolint:errcheck
+
+	dest := testKey(5)
+	plain := dest
+	sourceRoute := dest + "|" + testKey(6)
+
+	for _, key := range []string{plain, sourceRoute, plain, sourceRoute} {
+		s, err := p.OpenStream(context.Background(), key, dial)
+		require.NoError(t, err)
+		roundtrip(t, s, "x")
+		require.NoError(t, s.Close())
+	}
+	require.EqualValues(t, 2, atomic.LoadInt32(&dials), "each distinct key dials once and reuses")
 }

--- a/pkg/visor/embedded_skynetweb.go
+++ b/pkg/visor/embedded_skynetweb.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -236,7 +237,7 @@ func (e *EmbeddedSkynetWeb) serve(ctx context.Context) {
 	// so multihop routes die and re-set-up each time (the "only works for direct
 	// routes" limitation). The pool keeps one route group per destination warm and
 	// yamux-muxes over it; idle groups reclaim after ~10 min. See pkg/skyroute.
-	dialer.pool = skyroute.New(dialer.dialRouteForPool, skyroute.DefaultIdleTTL, e.log)
+	dialer.pool = skyroute.New(skyroute.DefaultIdleTTL, e.log)
 	go func() {
 		<-ctx.Done()
 		_ = dialer.pool.Close() //nolint:errcheck
@@ -316,7 +317,12 @@ func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKe
 	// multihop skynet routes dying under the resolving proxy. Falls back to a fresh
 	// 1:1 route dial only against older visors that don't serve the mux port.
 	if d.pool != nil {
-		stream, err := d.pool.OpenStream(ctx, remote)
+		// Key the pool on the destination PK: the route-finder picks the path, so all
+		// plain <pk>.skynet fetches to this dest share one warm route group.
+		dest := remote
+		stream, err := d.pool.OpenStream(ctx, dest.Hex(), func(ctx context.Context, muxPort uint16) (net.Conn, error) {
+			return d.dialRouteForPool(ctx, dest, muxPort)
+		})
 		if err == nil {
 			if hErr := skynetweb.PerformHandshake(stream, port); hErr != nil {
 				_ = stream.Close() //nolint:errcheck,gosec
@@ -349,11 +355,52 @@ func (d *routerSkynetDialer) DialSkynet(ctx context.Context, remote cipher.PubKe
 	return conn, nil
 }
 
-// dialSourceRoute builds explicit forward+reverse hops from a parsed route and
-// dials them with DialRoutes (route-finder bypassed). Single-path; the reverse
-// path mirrors the forward path (transport IDs are symmetric, so the same TpIDs
-// are reused with edges swapped).
+// dialSourceRoute dials an explicit forward+reverse hop-set parsed from the
+// hostname (route-finder bypassed). It first tries a HELD, yamux-muxed route via
+// the pool — keyed on destination+hops so it doesn't collide with the route-finder
+// path's per-dest group — so an explicit multihop source route stays warm across
+// short SOCKS5 connections instead of being re-set-up each time (the same decay the
+// plain path already fixed). It falls back to a fresh 1:1 dial against older far
+// ends that don't serve the mux forwarding port.
 func (d *routerSkynetDialer) dialSourceRoute(ctx context.Context, dest cipher.PubKey, port uint16, route []skynetweb.RouteLabel) (net.Conn, error) {
+	if d.pool != nil {
+		key := sourceRouteKey(dest, route)
+		stream, err := d.pool.OpenStream(ctx, key, func(ctx context.Context, muxPort uint16) (net.Conn, error) {
+			return d.dialSourceRouteConn(ctx, dest, route, muxPort)
+		})
+		if err == nil {
+			if hErr := skynetweb.PerformHandshake(stream, port); hErr != nil {
+				_ = stream.Close() //nolint:errcheck,gosec
+				return nil, hErr
+			}
+			return stream, nil
+		}
+		if !errors.Is(err, skyroute.ErrNoMux) {
+			// A real route-setup failure — the 1:1 path would fail identically.
+			return nil, err
+		}
+		d.log.WithField("dest", dest.String()).Debug("Skynet: source-route mux forwarding unavailable; using 1:1 route")
+	}
+
+	// 1:1 fallback (far ends without the mux forwarding port): dial the explicit
+	// hops to the single-connection forwarding port.
+	conn, err := d.dialSourceRouteConn(ctx, dest, route, skyenv.SkyForwardingServerPort)
+	if err != nil {
+		return nil, err
+	}
+	if err := skynetweb.PerformHandshake(conn, port); err != nil {
+		_ = conn.Close() //nolint:errcheck,gosec
+		return nil, err
+	}
+	return conn, nil
+}
+
+// dialSourceRouteConn builds explicit forward+reverse hops from the parsed route and
+// dials them to fwdPort with DialRoutes, returning the raw route-group conn with no
+// skynet handshake (the pool yamux-wraps it first; the 1:1 fallback handshakes
+// itself). Single-path; the reverse path mirrors the forward path (transport IDs
+// are symmetric, so the same TpIDs are reused with edges swapped).
+func (d *routerSkynetDialer) dialSourceRouteConn(ctx context.Context, dest cipher.PubKey, route []skynetweb.RouteLabel, fwdPort uint16) (net.Conn, error) {
 	fwd, rev, err := d.buildSourceRoute(ctx, dest, route)
 	if err != nil {
 		return nil, fmt.Errorf("skynet source-route to %s: %w", dest, err)
@@ -365,15 +412,27 @@ func (d *routerSkynetDialer) dialSourceRoute(ctx context.Context, dest cipher.Pu
 	opts.ForwardHops = fwd
 	opts.ReverseHops = rev
 	lPort := routing.Port(atomic.AddUint32(&d.nextPort, 1)) //nolint:gosec
-	conn, err := d.router.DialRoutes(ctx, dest, lPort, routing.Port(skyenv.SkyForwardingServerPort), opts)
-	if err != nil {
-		return nil, err
+	return d.router.DialRoutes(ctx, dest, lPort, routing.Port(fwdPort), opts)
+}
+
+// sourceRouteKey derives a stable pool key for an explicit source route: the
+// destination plus each hop label (PK or transport ID) in order. Distinct hop-sets
+// to the same destination get independent warm route groups, and neither collides
+// with the route-finder path (which keys on the bare destination hex).
+func sourceRouteKey(dest cipher.PubKey, route []skynetweb.RouteLabel) string {
+	var b strings.Builder
+	b.WriteString(dest.Hex())
+	for _, rl := range route {
+		b.WriteByte('|')
+		if rl.IsTpID {
+			b.WriteString("t:")
+			b.WriteString(rl.TpID.String())
+		} else {
+			b.WriteString("p:")
+			b.WriteString(rl.PK.Hex())
+		}
 	}
-	if err := skynetweb.PerformHandshake(conn, port); err != nil {
-		_ = conn.Close() //nolint:errcheck,gosec
-		return nil, err
-	}
-	return conn, nil
+	return b.String()
 }
 
 // buildSourceRoute turns the parsed route into forward+reverse routing hops. A

--- a/pkg/visor/skyfwd_mux_test.go
+++ b/pkg/visor/skyfwd_mux_test.go
@@ -45,17 +45,18 @@ func TestSkyForwardingMux_PoolReuseOverRealServer(t *testing.T) {
 	go serveSkyForwardingMuxSession(log, serverConn, v)
 
 	var dials int32
-	pool := skyroute.New(func(_ context.Context, _ cipher.PubKey, _ uint16) (net.Conn, error) {
+	dial := func(_ context.Context, _ uint16) (net.Conn, error) {
 		atomic.AddInt32(&dials, 1)
 		return clientConn, nil // the single held route group
-	}, time.Minute, nil)
+	}
+	pool := skyroute.New(time.Minute, nil)
 	defer pool.Close() //nolint:errcheck
 
 	dest, _ := cipher.GenerateKeyPair()
 
 	for i := 0; i < 5; i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		stream, err := pool.OpenStream(ctx, dest)
+		stream, err := pool.OpenStream(ctx, dest.Hex(), dial)
 		require.NoError(t, err, "open stream %d", i)
 		require.NoError(t, skynetweb.PerformHandshake(stream, echoPort), "handshake %d", i)
 


### PR DESCRIPTION
## What

Extends the resolving proxy's route-reuse pool (`pkg/skyroute`) to cover **explicit source-route** dials (`<hop>.<dest>.skynet`).

## Why

The resolving proxy already holds one yamux-muxed, keepalive-warmed route group open per destination for plain `<pk>.skynet` fetches (`skyroute.Pool` + `SkyForwardingMuxPort`), so short-lived SOCKS5 connections reuse a warm multihop route instead of re-running route setup on every request.

Explicit source routes skipped that path entirely: `dialSourceRoute` dialed a fresh single-path route to the 1:1 forwarding port per connection, so an explicit multihop route **died and re-set-up on every page load** — the exact route-decay the pool was built to fix, just for the manually-pinned-route case.

## How

- Generalize `skyroute.Pool` to key on an opaque `string` with a **per-call dial closure**, instead of a destination `PubKey` with one stored dialer. The pool becomes route-agnostic; the caller supplies how each route is built.
- The resolving proxy keys the route-finder path on the destination hex and the source-route path on **destination + hop-set**, so the two hold independent warm route groups — a `<hop>.<pk>.skynet` fetch no longer clobbers the plain `<pk>.skynet` group, and distinct hop-sets to the same dest each stay warm.
- `dialSourceRoute` now tries the pooled mux route first and falls back to a fresh 1:1 dial against older far ends that don't serve the mux port (`ErrNoMux`), mirroring the plain path.

The pool has a single consumer (the resolving proxy), so the key-generalization is fully contained.

## Test

- `pkg/skyroute` unit tests updated to the new API + a new `TestPool_DistinctKeysIndependent` (plain vs source-route keys to the same dest hold independent warm groups). Passes under `-race`.
- `pkg/visor` skyfwd-mux reuse test updated; `go build .`, `go vet`, `gofmt`, and `golangci-lint` clean on the changed packages.