### PR TITLE
fix(rewards): record "survey not found" as ineligible instead of a silent drop

### DIFF
--- a/cmd/skywire-cli/commands/rewards/calc.go
+++ b/cmd/skywire-cli/commands/rewards/calc.go
@@ -950,6 +950,11 @@ Architectures:
 			survey, parseErr := parseSurvey(surveyPath)
 			if parseErr != nil {
 				log.Debug(parseErr.Error())
+				// Met uptime but no usable survey — record it as ineligible with a
+				// reason instead of a silent drop, so a survey-collection gap surfaces
+				// in the ineligible report rather than an invisible dash. Mirrors the
+				// same fix in runday.go's calcDay.
+				grrInfos = append(grrInfos, nodeinfo{PK: pk, Reason: "survey not found"})
 				continue
 			}
 

--- a/cmd/skywire-cli/commands/rewards/runday.go
+++ b/cmd/skywire-cli/commands/rewards/runday.go
@@ -355,6 +355,15 @@ func calcDay(opts calcOpts) (*dayResult, error) {
 		survey, parseErr := parseSurvey(surveyPath)
 		if parseErr != nil {
 			log.Debug(parseErr.Error())
+			// This PK met the daily uptime bar (it's in _ut.txt) but its survey is
+			// missing or unreadable, so it can't be scored. Record it as ineligible
+			// with an explicit reason instead of silently dropping it: previously such
+			// a visor was an invisible dash in the reward tables — neither rewarded nor
+			// listed in the ineligible report — so operators had no way to see WHY a
+			// demonstrably-up visor wasn't paid. The usual cause is a survey-collection
+			// gap (the hourly collector gated on the UT online flag and skipped
+			// reachable-but-flag-offline visors); see the survey-push redesign.
+			grrInfos = append(grrInfos, nodeinfo{PK: pk, Reason: "survey not found"})
 			continue
 		}
 


### PR DESCRIPTION
## Problem

A visor can **meet the daily uptime bar yet be paid nothing, with no visible reason.**

The calc iterates `hist/{date}_ut.txt` — the PKs that already met daily uptime (`runday.go:347`). For each it parses `node-info.json`; if the survey is missing/unreadable it does `log.Debug(...); continue` (`runday.go:355`, `calc.go:951`) **before** the PK is added to the ineligible list. So a demonstrably-up visor whose survey wasn't collected shows up as **neither rewarded nor ineligible-with-reason** — an invisible dash in the reward tables, with nothing an operator can inspect.

This surfaced in a real operator complaint: multiple reachable visors (surveys downloadable right now over the resolving proxy) simply not paid, with no failed-download or ineligibility record anywhere.

## Fix

Emit an explicit ineligible row (`Reason: "survey not found"`) at that `continue` in both the current (`runday.go` `calcDay`) and legacy (`calc.go`) loops, so a survey-collection gap shows up in `hist/{date}_ineligible.csv`.

**Payout-neutral:** the ineligible list is not the payout list — no reward amounts change. This only makes the omission visible.

## Context

The gap itself — hourly survey collection gated on the uptime-tracker `Online` flag (≥2 heartbeat-credited transports), which silently skips reachable-but-flag-offline visors — is being addressed separately by a survey-**push** redesign (visor POSTs its survey over dmsg on-change/daily, decoupling survey freshness from the reachability snapshot). This PR is the observability half so these cases stop being invisible in the interim.

## Test

`go build .`, `go vet`, `gofmt` clean.