### PR TITLE
fix(rewards): harden the Go survey collector to match the live fetch_surveys.sh

### DIFF
--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -167,93 +167,103 @@ var logCmd = &cobra.Command{
 		// Get visors data
 		var wg sync.WaitGroup
 		for _, v := range uptimes {
-			//only attempt to fetch from online visors
-			if v.Online {
-				if fetchFile == "" {
-					if v.Version == "" {
-						log.Warnf("The version for visor %s is blank", v.PubKey)
-						continue
-					}
-					includeV := contains(incVerList, v.Version)
-					visorVersion, err := version.NewVersion(v.Version)
-					if err != nil {
-						if !includeV {
-							log.Warnf("The version %s for visor %s is not valid", v.Version, v.PubKey)
-							continue
-						}
-						// Version in include list but can't be parsed - skip version comparison
-						log.Debugf("Including visor %s with unparseable version %s", v.PubKey, v.Version)
-					} else if !allVisors && visorVersion.LessThan(minimumVersion) && !includeV {
-						log.Warnf("The version %s for visor %s does not satisfy our minimum version condition", v.Version, v.PubKey)
-						continue
-					}
-					wg.Add(1)
-					go func(key string, wg *sync.WaitGroup, vver *version.Version) {
-						httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
-						defer httpC.CloseIdleConnections()
-						defer wg.Done()
+			// Attempt collection from EVERY visor the uptime tracker saw today, not
+			// only those currently flagged Online. A visor can meet the daily uptime
+			// bar yet read Online=false at the instant we poll (transient transport/
+			// heartbeat churn); gating on that instantaneous flag SILENTLY dropped such
+			// a visor from collection, so a demonstrably-up, reward-eligible visor could
+			// earn uptime but have no survey — and thus no reward — with nothing logged.
+			// The /health fetch below doubles as the reachability check (a genuinely
+			// offline visor just fails it) AND supplies the authoritative version, so the
+			// online flag is no longer load-bearing here. (The survey-push redesign will
+			// invert this entirely; this keeps the pull correct in the interim.)
 
-						deleteOnError := false
-						if _, err := os.ReadDir(key); err != nil {
-							if err := os.Mkdir(key, 0750); err != nil {
-								log.Errorf("Unable to create directory for visor %s", key)
-								return
-							}
-							deleteOnError = true
+			// Omit the filters if a specific file was requested.
+			if fetchFile != "" {
+				wg.Add(1)
+				go func(key string, wg *sync.WaitGroup) {
+					httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
+					defer httpC.CloseIdleConnections()
+					defer wg.Done()
+					if _, err := os.ReadDir(key); err != nil {
+						if err := os.Mkdir(key, 0750); err != nil {
+							log.Errorf("Unable to create directory for visor %s", key)
+							return
 						}
-						// health check before downloading anything else
-						// delete that folder if the health check fails
-						err = download(ctx, log, httpC, "health", "health.json", key, maxFileSize)
-						if err != nil {
-							if deleteOnErrors {
-								if deleteOnError {
-									bulkFolders = append(bulkFolders, key)
-								}
-								return
-							}
-						}
-						if !logOnly {
-							// vver may be nil for unparseable versions included via --include-versions flag
-							// In that case, skip version-based API selection and use the current API
-							if vver != nil && vver.LessThan(fver) {
-								download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
-							} else {
-								// Check survey checksum before downloading — skip if unchanged
-								// Falls back to full download if visor doesn't support checksum endpoint
-								if !surveyUnchanged(ctx, log, &httpC, key) {
-									download(ctx, log, httpC, "node-info", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
-								}
-							}
-						}
-						if !surveyOnly {
-							for i := 0; i <= duration; i++ {
-								date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
-								download(ctx, log, httpC, date+".csv", date+".csv", key, maxFileSize) //nolint:errcheck,gosec
-							}
-						}
-					}(v.PubKey, &wg, visorVersion)
-					batchSize--
-					if batchSize == 0 {
-						time.Sleep(15 * time.Second)
-						batchSize = 50
+					}
+					_ = download(ctx, log, httpC, fetchFile, fetchFile, key, maxFileSize) //nolint:errcheck
+				}(v.PubKey, &wg)
+				continue
+			}
+
+			wg.Add(1)
+			go func(key string, wg *sync.WaitGroup) {
+				httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
+				defer httpC.CloseIdleConnections()
+				defer wg.Done()
+
+				deleteOnError := false
+				if _, err := os.ReadDir(key); err != nil {
+					if err := os.Mkdir(key, 0750); err != nil {
+						log.Errorf("Unable to create directory for visor %s", key)
+						return
+					}
+					deleteOnError = true
+				}
+				// Health check first — also the reachability gate. An unreachable or
+				// offline visor fails here and is skipped (nothing to collect, and we
+				// can't read its version). This replaces the old uptime-tracker online
+				// flag as the "is it up right now" signal.
+				if err := download(ctx, log, httpC, "health", "health.json", key, maxFileSize); err != nil {
+					log.Debugf("visor %s unreachable (health fetch failed) — skipping", key)
+					if deleteOnErrors && deleteOnError {
+						bulkFolders = append(bulkFolders, key)
+					}
+					return
+				}
+				// Authoritative version gate from the visor's OWN /health
+				// (build_info.version). Survey collection IS the version-eligibility gate
+				// downstream — version is not re-checked at calc time — so an ineligible-
+				// version visor must NOT have its survey stored. Reading the version here
+				// rather than from the uptime tracker keeps collection self-contained now
+				// that it no longer depends on the UT online snapshot.
+				healthVer := parseHealthVersion(key + "/health.json")
+				includeV := contains(incVerList, healthVer)
+				vver, verr := version.NewVersion(healthVer)
+				eligible := true
+				switch {
+				case healthVer == "" && !includeV:
+					log.Warnf("The version for visor %s is blank in /health — skipping survey", key)
+					eligible = false
+				case verr != nil && !includeV:
+					log.Warnf("The version %q for visor %s (from /health) is not valid — skipping survey", healthVer, key)
+					eligible = false
+				case verr == nil && !allVisors && vver.LessThan(minimumVersion) && !includeV:
+					log.Warnf("The version %s for visor %s does not satisfy our minimum version condition — skipping survey", healthVer, key)
+					eligible = false
+				}
+				if !logOnly && eligible {
+					// vver may be nil for unparseable versions included via
+					// --include-versions; then use the current node-info API.
+					if vver != nil && vver.LessThan(fver) {
+						download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
+					} else if !surveyUnchanged(ctx, log, &httpC, key) {
+						// checksum unchanged → skip; falls back to a full download if the
+						// visor doesn't support the checksum endpoint.
+						download(ctx, log, httpC, "node-info", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
 					}
 				}
-				//omit the filters if a file was specified
-				if fetchFile != "" {
-					wg.Add(1)
-					go func(key string, wg *sync.WaitGroup) {
-						httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
-						defer httpC.CloseIdleConnections()
-						defer wg.Done()
-						if _, err := os.ReadDir(key); err != nil {
-							if err := os.Mkdir(key, 0750); err != nil {
-								log.Errorf("Unable to create directory for visor %s", key)
-								return
-							}
-						}
-						_ = download(ctx, log, httpC, fetchFile, fetchFile, key, maxFileSize) //nolint:errcheck
-					}(v.PubKey, &wg)
+				if !surveyOnly {
+					for i := 0; i <= duration; i++ {
+						date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
+						download(ctx, log, httpC, date+".csv", date+".csv", key, maxFileSize) //nolint:errcheck,gosec
+					}
 				}
+			}(v.PubKey, &wg)
+			batchSize--
+			if batchSize == 0 {
+				time.Sleep(15 * time.Second)
+				batchSize = 50
 			}
 		}
 
@@ -286,6 +296,26 @@ var logCmd = &cobra.Command{
 
 		log.Infof("Total Process Duration: %s", time.Since(start))
 	},
+}
+
+// parseHealthVersion reads a downloaded health.json and returns the visor's
+// build_info.version. Empty string on any read/parse failure. This is the
+// authoritative version for reward eligibility: it comes from the visor's own
+// running binary (/health), not the uptime tracker's possibly-stale report.
+func parseHealthVersion(path string) string {
+	data, err := os.ReadFile(path) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+	var doc struct {
+		BuildInfo struct {
+			Version string `json:"version"`
+		} `json:"build_info"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return doc.BuildInfo.Version
 }
 
 // surveyUnchanged checks if the remote survey checksum matches the local file.

--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -164,27 +164,123 @@ var logCmd = &cobra.Command{
 
 		start := time.Now()
 		var bulkFolders []string
-		// Get visors data
-		var wg sync.WaitGroup
-		for _, v := range uptimes {
-			// Attempt collection from EVERY visor the uptime tracker saw today, not
-			// only those currently flagged Online. A visor can meet the daily uptime
-			// bar yet read Online=false at the instant we poll (transient transport/
-			// heartbeat churn); gating on that instantaneous flag SILENTLY dropped such
-			// a visor from collection, so a demonstrably-up, reward-eligible visor could
-			// earn uptime but have no survey — and thus no reward — with nothing logged.
-			// The /health fetch below doubles as the reachability check (a genuinely
-			// offline visor just fails it) AND supplies the authoritative version, so the
-			// online flag is no longer load-bearing here. (The survey-push redesign will
-			// invert this entirely; this keeps the pull correct in the interim.)
+		var bulkMu sync.Mutex // bulkFolders is appended from concurrent fetch goroutines
 
-			// Omit the filters if a specific file was requested.
-			if fetchFile != "" {
-				wg.Add(1)
-				go func(key string, wg *sync.WaitGroup) {
+		// fetchVisorSurvey collects health + survey (+ optional tp logs) for one visor.
+		// Returns true when the visor was UNREACHABLE (its /health fetch failed) — a
+		// candidate for the retry pass: a cold dmsg session to a peer we've never dialed
+		// can exceed the per-request timeout on first contact yet succeed once the
+		// session is warm. quiet suppresses the per-visor "unreachable" line so the first
+		// pass stays silent and the operator only sees the final state.
+		//
+		// Attempts collection from EVERY visor the uptime tracker saw today, not only
+		// those currently flagged Online: a visor can meet the daily uptime bar yet read
+		// Online=false at the instant we poll (transient transport/heartbeat churn), and
+		// gating on that flag SILENTLY dropped it from collection — earned uptime, no
+		// survey, no reward, nothing logged. The /health fetch is the reachability gate
+		// (an offline visor fails it) AND supplies the authoritative version.
+		fetchVisorSurvey := func(key string, quiet bool) bool {
+			httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
+			defer httpC.CloseIdleConnections()
+
+			deleteOnError := false
+			if _, err := os.ReadDir(key); err != nil {
+				if err := os.Mkdir(key, 0750); err != nil {
+					log.Errorf("Unable to create directory for visor %s", key)
+					return false
+				}
+				deleteOnError = true
+			}
+			if err := download(ctx, log, httpC, "health", "health.json", key, maxFileSize); err != nil {
+				if !quiet {
+					log.Debugf("visor %s unreachable (health fetch failed) — skipping", key)
+				}
+				if deleteOnErrors && deleteOnError {
+					bulkMu.Lock()
+					bulkFolders = append(bulkFolders, key)
+					bulkMu.Unlock()
+				}
+				return true // retry candidate
+			}
+			// Authoritative version gate from the visor's OWN /health (build_info.version).
+			// Survey collection IS the version-eligibility gate downstream — version is
+			// not re-checked at calc time — so an ineligible-version visor must NOT have
+			// its survey stored.
+			healthVer := parseHealthVersion(key + "/health.json")
+			includeV := contains(incVerList, healthVer)
+			vver, verr := version.NewVersion(healthVer)
+			eligible := true
+			switch {
+			case healthVer == "" && !includeV:
+				log.Warnf("The version for visor %s is blank in /health — skipping survey", key)
+				eligible = false
+			case verr != nil && !includeV:
+				log.Warnf("The version %q for visor %s (from /health) is not valid — skipping survey", healthVer, key)
+				eligible = false
+			case verr == nil && !allVisors && vver.LessThan(minimumVersion) && !includeV:
+				log.Warnf("The version %s for visor %s does not satisfy our minimum version condition — skipping survey", healthVer, key)
+				eligible = false
+			}
+			if !logOnly && eligible {
+				// vver may be nil for unparseable versions included via
+				// --include-versions; then use the current node-info API.
+				if vver != nil && vver.LessThan(fver) {
+					download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
+				} else if !surveyUnchanged(ctx, log, &httpC, key) {
+					// checksum unchanged → skip; falls back to a full download if the
+					// visor doesn't support the checksum endpoint.
+					download(ctx, log, httpC, "node-info", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
+				}
+			}
+			if !surveyOnly {
+				for i := 0; i <= duration; i++ {
+					date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
+					download(ctx, log, httpC, date+".csv", date+".csv", key, maxFileSize) //nolint:errcheck,gosec
+				}
+			}
+			return false
+		}
+
+		// runPass fetches every pk concurrently in throttled batches (--batchSize per
+		// batch, 15s between batches) and returns the pks that were unreachable.
+		runPass := func(pks []string, quiet bool) []string {
+			var passWG sync.WaitGroup
+			var failedMu sync.Mutex
+			var failed []string
+			batch := batchSize
+			for _, pk := range pks {
+				passWG.Add(1)
+				go func(key string) {
+					defer passWG.Done()
+					if fetchVisorSurvey(key, quiet) {
+						failedMu.Lock()
+						failed = append(failed, key)
+						failedMu.Unlock()
+					}
+				}(pk)
+				if batch > 0 {
+					batch--
+					if batch == 0 {
+						time.Sleep(15 * time.Second)
+						batch = batchSize
+					}
+				}
+			}
+			passWG.Wait()
+			return failed
+		}
+
+		if fetchFile != "" {
+			// A specific file was requested: fetch it from every seen-today visor, no
+			// version gate and no retry pass (single explicit artifact).
+			var fileWG sync.WaitGroup
+			batch := batchSize
+			for _, v := range uptimes {
+				fileWG.Add(1)
+				go func(key string) {
+					defer fileWG.Done()
 					httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
 					defer httpC.CloseIdleConnections()
-					defer wg.Done()
 					if _, err := os.ReadDir(key); err != nil {
 						if err := os.Mkdir(key, 0750); err != nil {
 							log.Errorf("Unable to create directory for visor %s", key)
@@ -192,82 +288,32 @@ var logCmd = &cobra.Command{
 						}
 					}
 					_ = download(ctx, log, httpC, fetchFile, fetchFile, key, maxFileSize) //nolint:errcheck
-				}(v.PubKey, &wg)
-				continue
+				}(v.PubKey)
+				if batch > 0 {
+					batch--
+					if batch == 0 {
+						time.Sleep(15 * time.Second)
+						batch = batchSize
+					}
+				}
 			}
-
-			wg.Add(1)
-			go func(key string, wg *sync.WaitGroup) {
-				httpC := http.Client{Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgC), Timeout: 10 * time.Second}
-				defer httpC.CloseIdleConnections()
-				defer wg.Done()
-
-				deleteOnError := false
-				if _, err := os.ReadDir(key); err != nil {
-					if err := os.Mkdir(key, 0750); err != nil {
-						log.Errorf("Unable to create directory for visor %s", key)
-						return
-					}
-					deleteOnError = true
-				}
-				// Health check first — also the reachability gate. An unreachable or
-				// offline visor fails here and is skipped (nothing to collect, and we
-				// can't read its version). This replaces the old uptime-tracker online
-				// flag as the "is it up right now" signal.
-				if err := download(ctx, log, httpC, "health", "health.json", key, maxFileSize); err != nil {
-					log.Debugf("visor %s unreachable (health fetch failed) — skipping", key)
-					if deleteOnErrors && deleteOnError {
-						bulkFolders = append(bulkFolders, key)
-					}
-					return
-				}
-				// Authoritative version gate from the visor's OWN /health
-				// (build_info.version). Survey collection IS the version-eligibility gate
-				// downstream — version is not re-checked at calc time — so an ineligible-
-				// version visor must NOT have its survey stored. Reading the version here
-				// rather than from the uptime tracker keeps collection self-contained now
-				// that it no longer depends on the UT online snapshot.
-				healthVer := parseHealthVersion(key + "/health.json")
-				includeV := contains(incVerList, healthVer)
-				vver, verr := version.NewVersion(healthVer)
-				eligible := true
-				switch {
-				case healthVer == "" && !includeV:
-					log.Warnf("The version for visor %s is blank in /health — skipping survey", key)
-					eligible = false
-				case verr != nil && !includeV:
-					log.Warnf("The version %q for visor %s (from /health) is not valid — skipping survey", healthVer, key)
-					eligible = false
-				case verr == nil && !allVisors && vver.LessThan(minimumVersion) && !includeV:
-					log.Warnf("The version %s for visor %s does not satisfy our minimum version condition — skipping survey", healthVer, key)
-					eligible = false
-				}
-				if !logOnly && eligible {
-					// vver may be nil for unparseable versions included via
-					// --include-versions; then use the current node-info API.
-					if vver != nil && vver.LessThan(fver) {
-						download(ctx, log, httpC, "node-info.json", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
-					} else if !surveyUnchanged(ctx, log, &httpC, key) {
-						// checksum unchanged → skip; falls back to a full download if the
-						// visor doesn't support the checksum endpoint.
-						download(ctx, log, httpC, "node-info", "node-info.json", key, maxFileSize) //nolint:errcheck,gosec
-					}
-				}
-				if !surveyOnly {
-					for i := 0; i <= duration; i++ {
-						date := time.Now().AddDate(0, 0, -i).UTC().Format("2006-01-02")
-						download(ctx, log, httpC, date+".csv", date+".csv", key, maxFileSize) //nolint:errcheck,gosec
-					}
-				}
-			}(v.PubKey, &wg)
-			batchSize--
-			if batchSize == 0 {
-				time.Sleep(15 * time.Second)
-				batchSize = 50
+			fileWG.Wait()
+		} else {
+			pks := make([]string, 0, len(uptimes))
+			for _, v := range uptimes {
+				pks = append(pks, v.PubKey)
+			}
+			// Two-pass collection, mirroring the live fetch_surveys.sh: pass 1 warms the
+			// dmsg sessions (silent), pass 2 retries only the visors that missed on a
+			// cold session — so a first-contact timeout no longer looks like an offline
+			// visor and silently drops its survey.
+			failed := runPass(pks, true)
+			if len(failed) > 0 {
+				log.Infof("Retrying %d visor(s) that failed the first pass (dmsg sessions now warm)", len(failed))
+				runPass(failed, false)
 			}
 		}
 
-		wg.Wait()
 		for _, key := range bulkFolders {
 			if err := os.RemoveAll(key); err != nil {
 				log.Warnf("Unable to remove directory %s", key)


### PR DESCRIPTION
Brings the Go survey collector (`skywire cli log`) up to the robustness of the live host-only `fetch_surveys.sh`, so the reward host can retire the bash collector in favor of Go.

## Problems fixed

1. **Online-flag silent-drop.** Collection gated on the uptime tracker's instantaneous `Online` flag. A visor that met the daily uptime bar but read offline at poll time (transient transport/heartbeat churn) was silently skipped — earned uptime, no survey, **no reward**, nothing logged. (This is what cost a real operator their rewards.)
2. **Version gate coupled to the UT.** Version was read from the (possibly stale) uptime-tracker report.
3. **Cold-session false negatives.** A single-pass fetch times out on the first cold dmsg session to a never-dialed peer, so a reachable visor looks unreachable.

## Fixes

- **Collect every seen-today visor**, not just `Online` ones. The `/health` fetch is the reachability gate (a genuinely offline visor fails it) **and** the authoritative version source (`build_info.version`) — an ineligible-version visor is skipped without its survey being stored.
- **Two-pass retry** (mirrors `fetch_surveys.sh`): pass 1 warms the dmsg sessions silently and records the misses; pass 2 retries only those. So a first-contact timeout no longer drops a reachable visor's survey.
- Batch throttling honors `--batchSize` via a local counter (no longer mutates the package flag var); `bulkFolders` is now mutex-guarded (it was appended from concurrent goroutines — a pre-existing data race).

## Context

This is the interim/fallback pull path; the survey-**push** model (#3677 ingest + #3679 visor client + #3680 HV-UI) is the durable fix. But the pull stays the fallback for non-pushing visors, so it's worth making correct and Go-native — a step toward retiring the host-only `fetch_surveys.sh`/`getlogs.sh` bash under `skywire cli`.

## Test

`go build .`, `go vet`, `gofmt`, `golangci-lint` clean.