### PR TITLE
feat(rewards): accept visor survey PUSH over dmsg (POST /node-info)

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/cmd.go
+++ b/cmd/skywire-cli/commands/rewards/server/cmd.go
@@ -75,6 +75,7 @@ func init() {
 	ServerCmd.Flags().StringVar(&skycoinNode, "skycoin-node", scriptExecString("${SKYCOINNODE:-http://127.0.0.1:6420}"), "Skycoin mainnet node URL for reward transaction broadcasts")
 	ServerCmd.Flags().StringVar(&loginChainFlags, "login-chain-flags", scriptExecString("${LOGINCHAIN_FLAGS}"), "override flags for login chain skycoin daemon subprocess\n(default: --block-publisher --localhost-only --download-peerlist=false\n--disable-default-peers --disable-csrf --host-whitelist=fiber.skywire.dev)")
 	ServerCmd.Flags().BoolVar(&healthOnly, "health-only", false, "serve only /health endpoint for testing")
+	ServerCmd.Flags().StringVar(&surveyPushMinVersion, "survey-min-version", scriptExecString("${SURVEY_MIN_VERSION}"), "min skywire version a PUSHed survey may report to be stored/eligible\n(empty = accept any parseable version; the getlogs.sh prune over log_backups\nremains the authoritative floor). Set to the current reward floor to give\nvisors an accurate eligible/ineligible signal for the hypervisor UI.")
 	ServerCmd.Flags().StringVar(&canonicalDomain, "canonical", scriptExecString("${CANONICAL:-https://theskywirenetwork.net}"), "canonical domain for SEO (e.g. https://theskywirenetwork.net)")
 }
 

--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -118,6 +118,12 @@ func buildRouter() *gin.Engine {
 	r1.GET("/health", healthHandler)
 	r1.GET("/health/health", healthHandler) // accessible when visor's /health takes priority
 	if !healthOnly {
+		// Visor survey PUSH ingest (POST /node-info + GET /node-info/stored-checksum),
+		// served over the same dmsg listener a visor already reaches. A visor stores
+		// its own survey here instead of the reward system pulling it. See
+		// survey_ingest.go.
+		registerSurveyIngestRoutes(r1, wd)
+
 		// endpoint for testing minimum response time of curl via socks5 proxy / stand-in for latency test
 		// https://dev.to/tigt/making-the-worlds-fastest-website-and-other-mistakes-56na
 		// This is the fastest web page. You may not like it, but this is what peak performance looks like.

--- a/cmd/skywire-cli/commands/rewards/server/survey_ingest.go
+++ b/cmd/skywire-cli/commands/rewards/server/survey_ingest.go
@@ -1,0 +1,149 @@
+// Package clirewardsserver cmd/skywire-cli/commands/rewards/server/survey_ingest.go c4-vis-cli
+//
+// Visor survey PUSH ingest. A visor POSTs its node-info survey to the reward
+// system over dmsg instead of the reward system pulling it hourly. The survey is
+// stored under the visor's DMSG-AUTHENTICATED source PK (RemoteAddr), so a visor
+// can only ever write its own survey. The response tells the visor whether it is
+// reward-eligible so the visor can surface that in the hypervisor UI (a rejected
+// push becomes a red mark in the node-list reward column, distinct from the
+// hyphen shown when no reward address is set).
+//
+// Storage target is log_backups/<pk>/node-info.json — the calc's authoritative
+// source — so a pushed survey is available to the next calc run immediately,
+// independent of the pull cycle's rsync (which matters because the pull is being
+// reduced to a low-frequency fallback). The existing getlogs.sh age-out + the
+// authoritative version prune over log_backups still apply.
+package clirewardsserver
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	version "github.com/hashicorp/go-version"
+
+	"github.com/skycoin/skywire/pkg/rewards"
+)
+
+// maxSurveyBytes caps a pushed survey. A real node-info survey is a few KB; this
+// bounds a misbehaving/hostile sender.
+const maxSurveyBytes = 512 * 1024
+
+// surveyPushMinVersion, when non-empty, is the minimum skywire version a pushed
+// survey may report to be stored (reward version-eligibility gate). Empty = accept
+// any parseable version and let the authoritative getlogs.sh prune over log_backups
+// enforce the live floor. Set via --survey-min-version so the operator can track the
+// current reward floor and give the visor an accurate eligible/ineligible signal.
+var surveyPushMinVersion string
+
+// registerSurveyIngestRoutes wires the visor survey-PUSH endpoints onto r1.
+func registerSurveyIngestRoutes(r1 *gin.Engine, wd string) {
+	surveyDir := filepath.Join(wd, "log_backups")
+
+	// POST /node-info — store the sender's own survey. Response contract:
+	//   200 {"stored":true,"eligible":true}
+	//   403 {"stored":false,"eligible":false,"reason":"..."}  (ineligible version)
+	//   403 {"error":"..."}   (sender pushed a survey whose PK isn't its own)
+	//   401/400/413 for auth / malformed / oversized.
+	r1.POST("/node-info", func(c *gin.Context) {
+		remotePK := rewards.RemotePK(c)
+		if remotePK.Null() {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated: no dmsg source pk"})
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxSurveyBytes+1))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "read body"})
+			return
+		}
+		if len(body) > maxSurveyBytes {
+			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{"error": "survey too large"})
+			return
+		}
+		var meta struct {
+			PubKey         string `json:"pk"`
+			SkywireVersion string `json:"skywire_version"`
+		}
+		if err := json.Unmarshal(body, &meta); err != nil {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid survey json"})
+			return
+		}
+		// The survey must be the sender's own: its self-reported PK must equal the
+		// dmsg-authenticated source PK. This is misbehavior, not an eligibility state.
+		if !strings.EqualFold(meta.PubKey, remotePK.Hex()) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "survey pk does not match sender"})
+			return
+		}
+		// Version gate: survey collection is the reward version-eligibility gate, so
+		// an ineligible version is refused (and reported so the visor can show it).
+		if surveyPushMinVersion != "" {
+			if ok, reason := versionEligible(meta.SkywireVersion, surveyPushMinVersion); !ok {
+				c.JSON(http.StatusForbidden, gin.H{"stored": false, "eligible": false, "reason": reason})
+				return
+			}
+		}
+		// Store under the AUTHENTICATED pk, atomically (tmp + rename) so a concurrent
+		// reader/calc never sees a half-written survey.
+		pkDir := filepath.Join(surveyDir, remotePK.Hex())
+		if err := os.MkdirAll(pkDir, 0750); err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "store"})
+			return
+		}
+		dst := filepath.Join(pkDir, "node-info.json")
+		tmp := dst + ".tmp"
+		if err := os.WriteFile(tmp, body, 0644); err != nil { //nolint:gosec // survey is world-readable like the pulled ones
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "write"})
+			return
+		}
+		if err := os.Rename(tmp, dst); err != nil {
+			_ = os.Remove(tmp) //nolint:errcheck
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "commit"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"stored": true, "eligible": true})
+	})
+
+	// GET /node-info/stored-checksum — the sha256 the reward system currently holds
+	// for the REQUESTER's own survey (keyed by the authenticated pk), so a visor can
+	// skip an unchanged push (conditional PUT). Empty sha256 = nothing stored yet.
+	r1.GET("/node-info/stored-checksum", func(c *gin.Context) {
+		remotePK := rewards.RemotePK(c)
+		if remotePK.Null() {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthenticated"})
+			return
+		}
+		data, err := os.ReadFile(filepath.Join(surveyDir, remotePK.Hex(), "node-info.json")) //nolint:gosec
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{"sha256": ""})
+			return
+		}
+		sum := sha256.Sum256(data)
+		c.JSON(http.StatusOK, gin.H{"sha256": hex.EncodeToString(sum[:])})
+	})
+}
+
+// versionEligible reports whether reported (the survey's skywire_version) is at
+// least min. The build suffix (e.g. -abcdef1 or -dirty) is stripped, mirroring
+// getlogs.sh. A bad min is treated as no gate (eligible); an unparseable reported
+// version is ineligible.
+func versionEligible(reported, min string) (bool, string) {
+	base := strings.SplitN(reported, "-", 2)[0]
+	rv, err := version.NewVersion(base)
+	if err != nil {
+		return false, "unparseable version " + reported
+	}
+	mv, err := version.NewVersion(min)
+	if err != nil {
+		return true, ""
+	}
+	if rv.LessThan(mv) {
+		return false, "version " + base + " below reward floor " + min
+	}
+	return true, ""
+}

--- a/pkg/rewards/server.go
+++ b/pkg/rewards/server.go
@@ -52,6 +52,15 @@ func IsWhitelisted(c *gin.Context, wlkeys []cipher.PubKey) bool {
 	return false
 }
 
+// RemotePK returns the DMSG-authenticated source public key of the current
+// request (from RemoteAddr), or a null key if it can't be parsed. Exported for
+// handlers that must attribute a request to its sender — e.g. the survey-push
+// endpoint stores a pushed survey under the sender's own PK so a visor can only
+// write its own.
+func RemotePK(c *gin.Context) cipher.PubKey {
+	return extractPK(c)
+}
+
 func extractPK(c *gin.Context) cipher.PubKey {
 	host := c.Request.RemoteAddr
 	if h, _, err := net.SplitHostPort(host); err == nil {


### PR DESCRIPTION
## What

The receiving half of the **survey-push** model. A visor POSTs its node-info survey to the reward system over dmsg, instead of the reward system pulling it hourly. Served on the reward server's **existing inbound dmsg listener** (`server.go:1813`) — no new infra.

## Why

Survey collection was gated on the uptime tracker's instantaneous `Online` flag, so a visor that met daily uptime but read offline at poll time was silently dropped — earned uptime, no survey, no reward, nothing logged. (See sibling PRs #3675 observability + #3676 pull-side fix.) Push fixes it at the source: the visor is authoritative about its own survey and no longer depends on a pull snapshot.

## How

- **`POST /node-info`** stores the survey under the sender's **dmsg-authenticated source PK** (`RemoteAddr` via the new exported `rewards.RemotePK`) — a visor can only ever write **its own** survey. The survey's self-reported `pk` must match the authenticated sender or it's rejected.
- **Version gate:** an ineligible `skywire_version` is refused with an explicit `{"eligible":false,"reason":...}`, so the visor can surface reward-ineligibility in the hypervisor UI (a rejected push → red mark, distinct from the hyphen shown when no reward address is set). Floor via `--survey-min-version`; empty = accept any parseable version, with the authoritative `getlogs.sh` prune over `log_backups` unchanged.
- **`GET /node-info/stored-checksum`** returns the sha256 the reward system holds for the **requester's own** survey, so a visor skips an unchanged push (conditional PUT — the efficient "only transfer on change" without CXO's per-feed machinery).
- Stored **atomically** (tmp+rename) into `log_backups/<pk>/node-info.json` — the calc's authoritative source — so a push is available to the next calc run immediately, independent of the pull cycle's rsync (which matters because the pull is being reduced to a low-frequency fallback).

## Scope / follow-ups

- Visor-side **push client** (daily + on-change conditional POST to `reward_system_dmsg`) and the **HV-UI eligibility indicator** land in follow-up PRs.
- The visor's GET `/node-info` pull endpoint is **unchanged** (kept for manual checks).
- Security: a survey is stored only under an authenticated PK; a spam PK with no uptime earns nothing (the calc pays only uptime-qualified PKs), so unsolicited pushes are harmless and age out.

## Test

`go build .`, `go vet`, `gofmt`, `golangci-lint` clean.