### PR TITLE
fix(rewards): fetch TPD /metrics over dmsg, not the default HTTP client

### DIFF
--- a/cmd/skywire-cli/commands/rewards/server/server.go
+++ b/cmd/skywire-cli/commands/rewards/server/server.go
@@ -1816,6 +1816,14 @@ func serveStandalone(r1 *gin.Engine) {
 	}
 	defer stopDmsg()
 
+	// Give the stats handlers a dmsg-capable HTTP client so their TPD /metrics
+	// fetches resolve the deployment's dmsg://<pk>:80 URLs. Without this they used
+	// the default client and failed with `unsupported protocol scheme "dmsg"`.
+	statsDmsgHTTPClient = &http.Client{
+		Transport: dmsghttp.MakeHTTPTransport(ctx, dmsgClient),
+		Timeout:   45 * time.Second,
+	}
+
 	lis, err := dmsgClient.Listen(dmsgPort) //nolint: gosec
 	if err != nil {
 		log.WithError(err).Fatal("Failed to listen on DMSG port")

--- a/cmd/skywire-cli/commands/rewards/server/stats.go
+++ b/cmd/skywire-cli/commands/rewards/server/stats.go
@@ -1174,12 +1174,27 @@ func formatBytesChart(b uint64) string {
 }
 
 // fetchTPDBandwidthMetrics fetches bandwidth metrics from TPD for the given number of days
+// statsDmsgHTTPClient carries a dmsghttp RoundTripper so the stats handlers can
+// fetch the deployment's dmsg://<pk>:80 service URLs (TPD /metrics, …). Set once the
+// reward server's dmsg client is up (see server.go). Nil in standalone/test
+// contexts, where statsHTTPGet falls back to the default client.
+var statsDmsgHTTPClient *http.Client
+
+// statsHTTPGet GETs url with the dmsg-capable client when available — required for
+// dmsg://<pk>:80 deployment URLs, which the default client rejects with
+// "unsupported protocol scheme dmsg" — otherwise the default client.
+func statsHTTPGet(url string) (*http.Response, error) {
+	if statsDmsgHTTPClient != nil {
+		return statsDmsgHTTPClient.Get(url) //nolint:noctx
+	}
+	return http.Get(url) //nolint:noctx,gosec
+}
+
 func fetchTPDBandwidthMetrics(days int) ([]tpdTransportMetric, error) {
 	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
 	url := fmt.Sprintf("%s/metrics?days=%d&bandwidth=true&latency=false", tpdURL, days)
 
-	//nolint:gosec
-	resp, err := http.Get(url)
+	resp, err := statsHTTPGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
@@ -1337,7 +1352,7 @@ func getTPDNetworkSummary() (*tpdNetworkSummary, error) {
 	tpdURL := strings.TrimSuffix(deployment.Prod.TransportDiscovery, "/")
 	url := fmt.Sprintf("%s/metrics?days=1&bandwidth=true&latency=true&edges=true", tpdURL)
 
-	resp, err := http.Get(url) //nolint:gosec
+	resp, err := statsHTTPGet(url)
 	if err != nil {
 		return nil, fmt.Errorf("TPD request failed: %w", err)
 	}


### PR DESCRIPTION
## Problem

The reward server's `/stats` page errors at the top:

> Error fetching TPD network summary: TPD request failed: Get `dmsg://<pk>:80/metrics?...`: **unsupported protocol scheme "dmsg"**

`getTPDNetworkSummary` and `fetchTPDBandwidthMetrics` fetch `deployment.Prod.TransportDiscovery` — a `dmsg://<pk>:80` URL — with a bare `http.Get`. The default client has no dmsghttp RoundTripper, so it rejects the `dmsg` scheme outright.

## Fix

The reward server already builds a dmsg client at serve time. Route these two fetches through a dmsghttp-backed client (`statsDmsgHTTPClient`, set from that dmsg client), falling back to the default client when unset (standalone/test). Removes the now-stale plain-HTTP `gosec` suppressions.

## Not in scope

The other error on that page — `dmsg error 202 - cannot connect to delegated server` on the UT version stats — is a dmsg-**reachability** issue (that fetch already goes over dmsg), not this scheme bug. Tracked separately (relates to the delegated-server/peering thread).

## Test

`go build .`, `go vet`, `gofmt`, `golangci-lint` clean.