### PR TITLE
chore(deps): bump @angular/common, compiler, core to 21.2.19

### DIFF
--- a/static/skywire-manager-src/package-lock.json
+++ b/static/skywire-manager-src/package-lock.json
@@ -10,9 +10,9 @@
       "dependencies": {
         "@angular/animations": "^21.2.4",
         "@angular/cdk": "^21.2.2",
-        "@angular/common": "^21.2.17",
-        "@angular/compiler": "^21.2.17",
-        "@angular/core": "^21.2.17",
+        "@angular/common": "^21.2.19",
+        "@angular/compiler": "^21.2.19",
+        "@angular/core": "^21.2.19",
         "@angular/forms": "^21.2.4",
         "@angular/material": "^21.2.2",
         "@angular/platform-browser": "^21.2.4",
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.17.tgz",
-      "integrity": "sha512-hqAQxRfi5ldFE42suAXRcY+JCANrUh7fuSQ/DtZ7L896id5BT/exuv6dWNBC1PyAfQmRbpD5Pt6/pd+tNLyhDQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.19.tgz",
+      "integrity": "sha512-Rvo/VXI0kUmfQT7+OeAjv526OJlf/WrLnJq1Tz84Jkyv9bs9SOMTCT6m4+boo8gxVNdrcxvGU3Q0o2jZzKceSg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1431,14 +1431,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.17",
+        "@angular/core": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.17.tgz",
-      "integrity": "sha512-p+NdjYiwAz9Zmu2yul0LlMXaFjMISVVa24+/MVMoKFeQeI82QE8jDywPlnOSHQHvdCcQVpS7saeEriZzX3JuBQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.19.tgz",
+      "integrity": "sha512-vuF5i1t14ftJiHXVVLgDYLWkT99QuajphcUHy1VZaMX3FiqSGXRV62g+R2RMxL0OJ5C1ai8xTHKPx9n1lQFyFg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1622,9 +1622,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.17",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.17.tgz",
-      "integrity": "sha512-wYHpwIdnUnjQFOJJNqRcGx7LS3u64jT+R9L0TnMR/ViBM9dQgGYImlSikkftg2yrFCNo5aKRxhG2LLskQurVdg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-PVoXD1kBexOJLkFzKx2zBY/0oZJXGru0eGn2hu0q5n3vkZlYsR1yRolfGenK1gZE48Qibiw/ttg/X/pAIPEZGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1633,7 +1633,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.17",
+        "@angular/compiler": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },

--- a/static/skywire-manager-src/package.json
+++ b/static/skywire-manager-src/package.json
@@ -15,9 +15,9 @@
   "dependencies": {
     "@angular/animations": "^21.2.4",
     "@angular/cdk": "^21.2.2",
-    "@angular/common": "^21.2.17",
-    "@angular/compiler": "^21.2.17",
-    "@angular/core": "^21.2.17",
+    "@angular/common": "^21.2.19",
+    "@angular/compiler": "^21.2.19",
+    "@angular/core": "^21.2.19",
     "@angular/forms": "^21.2.4",
     "@angular/material": "^21.2.2",
     "@angular/platform-browser": "^21.2.4",


### PR DESCRIPTION
Bumps @angular/common, @angular/compiler and @angular/core from 21.2.17 to 21.2.19 — a patch bump within the existing `^21.2` range. Angular's core packages are version-locked to each other, so they move together in one PR.

Supersedes dependabot #3671, #3673, #3674 (replicated as a single commit rather than three separate bumps; no cross-package peer-dep skew). package-lock.json updated for the three entries only (14 lines).