### PR TITLE
fix(rewards): collector defaults UT to TPD-integrated /uptimes (standalone UT decommissioned)

### DIFF
--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -48,7 +48,7 @@ func init() {
 	logCmd.Flags().IntVar(&batchSize, "batchSize", 50, "number of visor in each batch")
 	logCmd.Flags().Int64Var(&maxFileSize, "maxfilesize", 1024, "maximum file size allowed to download during collecting logs, in KB")
 	logCmd.Flags().StringVarP(&dmsgDisc, "dmsg-disc", "D", dmsgDiscURL, "dmsg discovery url\n")
-	logCmd.Flags().StringVarP(&utAddr, "ut", "u", utURL, "uptime tracker url\n")
+	logCmd.Flags().StringVarP(&utAddr, "ut", "u", utURL, "uptime tracker url (default: TPD-integrated /uptimes)\n")
 	if os.Getenv("DMSGCURL_SK") != "" {
 		sk.Set(os.Getenv("DMSGCURL_SK")) //nolint:errcheck,gosec
 	}
@@ -64,7 +64,7 @@ func init() {
 var logCmd = &cobra.Command{
 	Use:   "log",
 	Short: "survey & transport log collection",
-	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the uptime tracker\n%[1]s/uptimes?v=v2\n%[1]s/uptimes?v=v2&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.UptimeTracker),
+	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the uptime tracker\n%[1]s/uptimes?v=v2\n%[1]s/uptimes?v=v2&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		log := logging.MustGetLogger("log-collecting")
 		fver, err := version.NewVersion("v1.3.17")

--- a/cmd/skywire-cli/commands/log/root.go
+++ b/cmd/skywire-cli/commands/log/root.go
@@ -30,8 +30,13 @@ func dmsgDiscArgs(val string) (httpURL, dmsgURL string) {
 }
 
 var (
-	dmsgDiscURL    = deployment.Prod.DmsgDiscovery
-	utURL          = deployment.Prod.UptimeTracker
+	dmsgDiscURL = deployment.Prod.DmsgDiscovery
+	// The standalone uptime tracker (deployment.Prod.UptimeTracker) is
+	// decommissioned; visor uptime now comes from the TPD-integrated
+	// /uptimes endpoint (same response shape), reachable via the local
+	// visor's CXO "tpd-uptime" feed / RPC→DMSG chain — the path
+	// `cli ut tpd` uses.
+	utURL          = deployment.Prod.TransportDiscovery
 	pubKey         string
 	duration       int
 	minv           string


### PR DESCRIPTION
### Problem

The survey collector (`skywire cli log`) defaulted `--ut` to
`deployment.Prod.UptimeTracker` — the **standalone** uptime tracker, which is
decommissioned. Its dmsg server is gone, so the UT fetch failed on the live
reward host:

```
dmsg error 202 - cannot connect to delegated server
```

This blocked the collector as a replacement for the host-only bash pipeline.

### Fix

Visor uptime now comes from the **TPD-integrated `/uptimes`** endpoint (identical
response shape), reachable via the local visor's CXO `tpd-uptime` feed and the
RPC→DMSG chain — the exact path `cli ut tpd` already uses successfully. The
default `--ut` is now `deployment.Prod.TransportDiscovery`.

Follows #3692 (UT fetched via RPC→DMSG in `--proxy` mode, not the survey proxy).

### Validation (live, reward host)

Ran the collector standalone against the running dmsgweb survey proxy:

```
skywire cli log --proxy 127.0.0.1:4443 --ut <Prod.TransportDiscovery> --minv auto
```

- UT fetched cleanly (no dmsg-202)
- `Reward min-version floor: v1.3.86 (auto, 14-day)` applied
- version-gating active (below-floor visors skipped)
- surveys collected over the proxy