### PR TITLE
docs(rfc): GUI embedding standardization — mount vs iframe

### DIFF
--- a/docs/design/gui-embedding-standardization.md
+++ b/docs/design/gui-embedding-standardization.md
@@ -1,0 +1,131 @@
+# GUI embedding standardization — mount vs iframe
+
+Status: draft / accepted-direction. Owner: skywire.
+
+## Problem
+
+Skywire ships a dozen distinct web GUIs written in four different stacks, glued
+into the hypervisor UI (and the wasm-visor, which *is* the same Angular SPA
+re-served) by three inconsistent mechanisms. The same UI often exists twice —
+e.g. the network visualizer is both a 221-line Angular `vis-network` component
+(`/nodes/visualizer`) **and** the full `pkg/tpviz` renderer (`/tp-viz/`). That
+duplication is expensive to maintain and drifts (different features on each).
+
+We want: **one implementation per UI**, presentable **standalone**, **inside an
+SPA tab**, and **inside a WinBox window**, without gratuitous break-out server
+paths (`/tp-viz/`, `/wallet/`) that leave the single-page context.
+
+## Inventory (default build)
+
+Grouped by stack:
+
+- **Angular** (`static/skywire-manager-src` → `pkg/visor/static`, one SPA): the
+  hypervisor UI and every native tab (network-visualizer, skychat, terminal,
+  VPN, skynet, skysocks/web-proxy, rewards-tab, logs, routing, apps). Plus the
+  **vendored skycoin Angular apps**: skycoin-web wallet (used, iframed into the
+  wallet tab), skycoin node GUI (only in the `skycoin-skywire` binary), explorer
+  (dead / unreferenced).
+- **Vanilla TS/JS bundles**: **tpviz-legacy** (`pkg/tpviz/legacy/bundle.js`,
+  three.js), **skychat standalone** (`cmd/apps/skychat/.../static/index.html`,
+  fetch+SSE), **browse.js + WinBox** (`pkg/wasmhv/browseui`, the in-SPA virtual
+  browser / mini-desktop), **pty terminal** (`pkg/pty/term.html.gz`, xterm.js).
+- **Go server-rendered HTML** (`html/template`+gin): the **reward system UI**
+  (`cmd/skywire-cli/commands/rewards/server`), proxied into the SPA at
+  `/api/rewards/*`.
+- **WASM**: **`skywire web`** (`cmd/skywire/commands/web`, TinyGo `b.wasm` CLI-
+  tree browser), **tpviz-wasm** (`-tags tpvizwasm`), **wasm-visor** (its UI is
+  the reused Angular SPA).
+- **Non-web**: **systray** (fyne).
+
+Three integration patterns exist today:
+
+1. **Native Angular component** (most tabs) — single-context, but reimplemented
+   in Angular (the duplication).
+2. **`<iframe>` of a same-origin path** — the wallet (`/wallet/`), wallet-config,
+   every WinBox `url:` window.
+3. **Own path/port only** — tpviz `/tp-viz/`, pty `/pty/{pk}`, skychat-standalone,
+   reward-server, `skywire web`.
+
+## Decision rule
+
+> **Use an iframe only when the embedded thing brings its own browsing context by
+> necessity. Otherwise MOUNT it into a `<div>` (an SPA tab or a WinBox `mount:`
+> window) in the host's own JS/DOM context.**
+
+A WinBox window is **not** inherently an iframe — `browse.js` already uses both
+`url:` (→ iframe) and `mount:` (→ plain DOM) windows. The real axis is
+**mount-DOM vs iframe**, and WinBox can host either.
+
+### Iframe is justified only for:
+
+1. **Untrusted / foreign content** — arbitrary proxied `.dmsg` / `.skynet` /
+   clearnet sites (the resolving-proxy / skysocks-client-lite browser). The
+   iframe + `sandbox` *is the security boundary*. Keep.
+2. **A self-contained runtime that can't cohabit the host context** — the reward
+   server (server-rendered HTML), `skywire web` (own b.wasm runtime), and
+   **skycoin-web** (a *second* Angular runtime — two Angular apps can't share one
+   document cleanly). Iframe until/unless rewritten as a mountable module.
+
+### Everything else mounts (no iframe):
+
+First-party JS/TS bundles run in the host context via a `mount()` entry: **tpviz
+visualizer, skychat, wallet-config, pty/xterm, browse.js**. Benefits: shared
+auth/session, shared theme, direct data passing (no `postMessage`), no second
+document fetch, no framework double-load.
+
+## The `mount()` contract
+
+Each embeddable UI's bundle exposes a global (or ES module export):
+
+```ts
+window.SkywireUI["<name>"] = {
+  mount(root: HTMLElement, opts?: Record<string, unknown>): MountHandle,
+};
+interface MountHandle { unmount(): void; }
+```
+
+- `mount(root, opts)` builds all of its own DOM inside `root` (it must NOT depend
+  on a pre-existing static `index.html` structure), wires events, starts data
+  fetches, and returns a handle with `unmount()` for teardown.
+- The **standalone** page becomes a thin shell: `<div id="root"></div>` +
+  `SkywireUI["<name>"].mount(root)`. Same artifact, so standalone and embedded
+  never drift.
+- Styles are self-scoped (prefixed classes, or a shadow root) so mounting into
+  the SPA doesn't leak CSS.
+- Data endpoints stay same-origin (`/api/...`) so the mounted bundle works
+  identically standalone, in a tab, and in a WinBox window.
+
+An Angular side hosts it with one generic wrapper: load the bundle script once,
+`mount(divRef.nativeElement)` on init, `unmount()` on destroy.
+
+## Per-UI target
+
+| UI | Target | Notes |
+|---|---|---|
+| network visualizer | **mount** (tpviz) | pilot; retire the Angular reimplementation |
+| skychat | **mount** | standalone HTML → `mount()`; Angular tab hosts it |
+| wallet-config | **mount** | already a vanilla page |
+| pty terminal | **mount** | xterm.js into the tab/window |
+| browse.js / WinBox | already mount | the host itself |
+| resolving-proxy browser | **iframe** (keep) | untrusted foreign content |
+| reward server UI | **iframe** | server-rendered; or convert later |
+| `skywire web` | **iframe** | own b.wasm runtime |
+| skycoin-web wallet | **iframe** (for now) | separate Angular runtime; converging it is a large separate effort |
+| own Angular routes in WinBox (`?embed=1`) | **Angular portal** | stop iframing the SPA into itself |
+
+## Migration order
+
+1. **Pilot — network visualizer**: give `pkg/tpviz` a `mount()` entry; the
+   Angular `network-visualizer` tab loads the tpviz bundle and mounts it into its
+   `<div>` (no `/tp-viz/` iframe, no Angular reimplementation). Delete the
+   vis-network component once at parity.
+2. **skychat**: `mount()` entry for the standalone UI; Angular tab hosts it.
+3. **pty terminal**, **wallet-config**: same contract.
+4. **`?embed=1` WinBox windows** → Angular CDK portal.
+5. (Large, separate) **skycoin-web** convergence into the SPA as a lazy module.
+
+## Non-goals
+
+- Rewriting server-rendered (reward server) or own-runtime (`skywire web`,
+  skycoin-web) UIs — those stay iframed by the rule above.
+- Changing the resolving-proxy browser — its iframe isolation is required.


### PR DESCRIPTION
An architecture RFC (`docs/design/gui-embedding-standardization.md`) for how
skywire's many web GUIs embed into the single-page hypervisor / wasm-visor UI.

- **Inventory** of every GUI in the default build, grouped by stack (Angular SPA,
  vanilla-JS bundles, Go server-rendered, WASM) and by the three integration
  patterns currently in use.
- **Decision rule**: use an `<iframe>` only for untrusted/foreign content (the
  resolving-proxy browser) or a self-contained runtime (reward server, `skywire
  web`, skycoin-web's separate Angular runtime); otherwise **mount** the UI's
  bundle into a `<div>` — an SPA tab or a WinBox `mount:` window — in the host's
  own JS/DOM context. A WinBox window is not inherently an iframe.
- **`mount()` contract**, per-UI target buckets, and a migration order that
  **pilots on the network visualizer** (mount `pkg/tpviz`, retire the Angular
  `vis-network` reimplementation).

Docs-only.