### PR TITLE
feat(hv-serve): serve the tpviz visualizer bundle + /api/* for the wasm visor

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -29,7 +29,12 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/skycoin/skywire/pkg/buildinfo"
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsgclient"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/tpviz"
 	"github.com/skycoin/skywire/pkg/visor"
 	"github.com/skycoin/skywire/pkg/wallet/coins"
 	"github.com/skycoin/skywire/pkg/wasmhv"
@@ -379,6 +384,38 @@ page never asks anyone to type a secret key.`,
 				}
 				walletFiles.ServeHTTP(w, r) // /wallet/<asset> → vendored dist/<asset>
 			})
+		}
+
+		// Transport-graph visualizer (pkg/tpviz): the Angular network-visualizer
+		// tab mounts /tp-viz/bundle.js and fetches /api/transports|services|
+		// uptimes|local-visor|ip-groups|dmsg/servers. The native HV serves these
+		// (pkg/visor/hypervisor.go); mirror that wiring here so the wasm visor's
+		// visualizer tab renders the real graph instead of 404ing. The wasm core
+		// answers Angular's own /api via its js seam (not this mux), and these
+		// tpviz paths are exactly the ones it 404s on, so there is no conflict.
+		// An ephemeral dmsg client (async, best-effort) sources the dmsg-only
+		// deployment discovery — clearnet SD is dead, so without it the graph has
+		// no country/service data; the UI still serves immediately and populates
+		// once dmsg connects. Mirrors `skywire-cli tp viz` standalone mode.
+		tpvSrv := tpviz.NewServer(tpviz.DefaultConfig())
+		go tpvSrv.Start()
+		go func() {
+			dlog := logging.MustGetLogger("hv-serve-tpviz")
+			pk, sk := cipher.GenerateKeyPair()
+			dmsgC, _, dErr := dmsgclient.StartDmsgEmbedded(cmd.Context(), dlog, pk, sk, false)
+			if dErr != nil {
+				dlog.WithError(dErr).Warn("tpviz dmsg client failed to start; network-graph data unavailable")
+				return
+			}
+			tpvSrv.SetDmsgHTTPClient(&http.Client{Transport: dmsghttp.MakeHTTPTransport(cmd.Context(), dmsgC)})
+			tpvSrv.SetCXOSubMgrFromDmsg(dmsgC)
+			dlog.Info("tpviz deployment discovery sourced over dmsg")
+		}()
+		tpvH := tpvSrv.Handler()
+		mux.Handle("/tp-viz/", http.StripPrefix("/tp-viz", tpvH))
+		mux.Handle("/tp-viz", http.StripPrefix("/tp-viz", tpvH))
+		for _, p := range []string{"/api/transports", "/api/services", "/api/uptimes", "/api/local-visor", "/api/ip-groups", "/api/dmsg/servers"} {
+			mux.Handle(p, tpvH)
 		}
 
 		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Completes the wasm-surface side of #3709 / #3711.

The Angular network-visualizer tab mounts `/tp-viz/bundle.js` and fetches `/api/transports|services|uptimes|local-visor|ip-groups|dmsg/servers`. The **native HV** serves those (`pkg/visor/hypervisor.go`), but **`hv serve`** — the native front that serves the standalone wasm visor's PWA — did not, so on the wasm surface the tab 404'd (it currently shows the graceful "unavailable" note added in #3711).

This mounts the native `tpviz.Server` in `hv serve`'s mux, mirroring the native HV, with an ephemeral dmsg client (async, best-effort) so the dmsg-only deployment discovery resolves — clearnet SD is dead, so without it the graph would have no country/service data. Same setup `skywire-cli tp viz` standalone mode uses.

**No conflict with the wasm core's own `/api`:** Angular's `HttpClient` requests flow through its `SkywireHttpBackend` → `skywireVisor.hvApi` js seam (the in-wasm core), *not* this native mux. Only the tpviz bundle's raw `fetch('/api/…')` hits the mux, and the six paths mounted here are exactly the ones the in-wasm core 404s on.

**Validated** (`skywire cli hv serve -a :7998`): `/tp-viz/bundle.js` → 200 (1.53 MB), `/api/services` → 1060 services / 1037 with country over dmsg (matches the native HV). `go build`, `golangci-lint`, `gofmt` clean.

Scope: fixes the `hv serve` / hosted-PWA surface. The single-file standalone (`hv gen`, `file://`) has no server and keeps the legacy in-wasm renderer.
