### PR TITLE
test(wasm-headless): fail fast with a diagnostic instead of hanging; retry once

### DIFF
--- a/scripts/wasm-headless/harness.mjs
+++ b/scripts/wasm-headless/harness.mjs
@@ -22,8 +22,22 @@ if (!wasmPath || !execPath || !seedPk || !seedWs) {
 }
 
 const BOOT_TIMEOUT_MS = 90_000;
+const DMSG_TIMEOUT_MS = 60_000;
 const die = (msg) => { console.error('FAIL:', msg); process.exit(1); };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+// Race a promise against a timeout so a never-settling call fails loudly here
+// instead of leaving Node with an unsettled top-level await (which exits with an
+// opaque "Detected unsettled top-level await" / code 13 and no diagnostic).
+const withTimeout = (p, ms, what) => Promise.race([
+  Promise.resolve(p),
+  sleep(ms).then(() => { throw new Error(`${what} did not settle within ${ms}ms`); }),
+]);
+const safeStatus = () => {
+  try {
+    const st = globalThis.skywireVisor.status();
+    return typeof st === 'string' ? st : JSON.stringify(st);
+  } catch (e) { return `<status() threw: ${e}>`; }
+};
 
 // wasm_exec.js is a classic script that attaches `Go` to globalThis.
 vm.runInThisContext(fs.readFileSync(execPath, 'utf8'), { filename: 'wasm_exec.js' });
@@ -45,11 +59,25 @@ console.log('wasm loaded; skywireVisor API present');
 
 // Boot with a fresh key against the local seed; empty disc ⇒ the deployment
 // default is tried and degrades to seed-only (non-fatal) in this offline run.
-const pk = await globalThis.skywireVisor.boot('', seedPk, seedWs, '');
+// boot() must be raced against a timeout: if a discovered deployment dmsg server
+// is dialed and hangs (unreachable from CI), the promise can stay pending
+// forever and Node would exit with an opaque unsettled-top-level-await (code 13)
+// instead of a diagnosable failure.
+let pk;
+try {
+  pk = await withTimeout(globalThis.skywireVisor.boot('', seedPk, seedWs, ''), BOOT_TIMEOUT_MS, 'skywireVisor.boot()');
+} catch (e) {
+  die(`${e.message} — likely a dmsg session dial hang (a discovered deployment ` +
+      `server unreachable from this environment); the local ws seed alone should ` +
+      `let boot() settle. last status=${safeStatus()}`);
+}
 console.log('booted as', pk);
 if (!/^[0-9a-f]{66}$/.test(String(pk))) die(`boot returned a non-PK: ${pk}`);
 
-// The critical-path assertion: a live dmsg session over the ws seed.
+// The critical-path assertion: a live dmsg session over the ws seed. Give this
+// its own budget rather than sharing the boot deadline (which boot() may have
+// mostly consumed).
+const dmsgDeadline = Date.now() + DMSG_TIMEOUT_MS;
 for (;;) {
   const st = globalThis.skywireVisor.status();
   const o = typeof st === 'string' ? JSON.parse(st) : st;
@@ -57,7 +85,7 @@ for (;;) {
     console.log(`dmsg connected (${o.dmsg_sessions} session[s])`);
     break;
   }
-  if (Date.now() > deadline) die(`dmsg never connected: ${JSON.stringify(o)}`);
+  if (Date.now() > dmsgDeadline) die(`dmsg never connected within ${DMSG_TIMEOUT_MS}ms: ${JSON.stringify(o)}`);
   await sleep(250);
 }
 
@@ -67,7 +95,12 @@ const dec = (b) => {
   if (typeof b === 'string') return b;
   try { return new TextDecoder().decode(b); } catch { return String(b); }
 };
-const about = await globalThis.skywireVisor.hvApi('GET', '/api/about', null);
+let about;
+try {
+  about = await withTimeout(globalThis.skywireVisor.hvApi('GET', '/api/about', null), DMSG_TIMEOUT_MS, 'hvApi(/api/about)');
+} catch (e) {
+  die(`${e.message} — the in-wasm hypervisor core did not answer. last status=${safeStatus()}`);
+}
 const aboutBody = dec(about?.body ?? about);
 let aboutObj;
 try { aboutObj = JSON.parse(aboutBody); } catch { die(`/api/about not JSON: ${aboutBody.slice(0, 120)}`); }

--- a/scripts/wasm-headless/run.sh
+++ b/scripts/wasm-headless/run.sh
@@ -41,4 +41,19 @@ SEEDWS=$(grep '^SEEDWS=' "$OUT" | cut -d= -f2-)
 echo "seed: $SEEDPK @ $SEEDWS"
 
 echo "== running Node harness =="
-node scripts/wasm-headless/harness.mjs "$WASM" "$EXECJS" "$SEEDPK" "$SEEDWS"
+# The smoke exercises a real dmsg session, so transient reachability blips can
+# fail a single run. Retry once against the same (still-running) local seed
+# before declaring failure; the harness itself now fails fast with a diagnostic
+# rather than hanging, so a retry is cheap.
+ATTEMPTS=2
+for i in $(seq 1 "$ATTEMPTS"); do
+  if node scripts/wasm-headless/harness.mjs "$WASM" "$EXECJS" "$SEEDPK" "$SEEDWS"; then
+    exit 0
+  fi
+  if (( i < ATTEMPTS )); then
+    echo "== harness attempt $i failed; retrying (dmsg reachability can flake) =="
+    sleep 2
+  fi
+done
+echo "== harness failed after $ATTEMPTS attempts =="
+exit 1


### PR DESCRIPTION
## What

Hardens the Tier-B headless wasm-visor smoke (`scripts/wasm-headless/`) so it fails **loudly and fast** instead of hanging, and rides out transient dmsg blips with one retry. Test infra only — the wasm blob and product code are unchanged.

## Why

`harness.mjs` awaited `skywireVisor.boot()` with no timeout (the 90s budget only guarded the polling loops). When a discovered deployment dmsg server is dialed and hangs (unreachable from CI), the `boot()` promise never settles and Node exits with an opaque **"Detected unsettled top-level await" (code 13)** and no diagnostic. That surfaces as a confusing, flaky-looking failure on PRs that don't touch the wasm blob at all (e.g. UI-only changes where the blob is byte-identical).

## Changes

- **`harness.mjs`**: race `boot()`, the dmsg-connect wait, and `hvApi()` against explicit timeouts (`withTimeout`). A hang now fails with a clear message pointing at the likely cause (a dmsg session dial to an unreachable server) plus the last `status()`. The dmsg-connect wait gets its own budget instead of sharing the boot deadline.
- **`run.sh`**: retry the harness once against the still-running local seed, since the smoke exercises a real dmsg session and transient reachability can fail a single run. The harness now fails fast, so a retry is cheap.

## Verification

- `node --check` / `bash -n` clean.
- Ran the full smoke locally: **PASS** — boot → dmsg(ws) 2 sessions → `/api/about` OK. The happy path is unaffected; only the failure mode changes (clear diagnostic + one retry instead of an opaque hang).