### PR TITLE
fix(httpauth): authenticate dmsg requests by the noise-verified RemoteAddr PK (security + load)

### DIFF
--- a/pkg/httpauth/auth.go
+++ b/pkg/httpauth/auth.go
@@ -102,33 +102,28 @@ func verifyAuth(store NonceStore, r *http.Request, auth *Auth) error {
 
 	r.Body = io.NopCloser(&buf)
 
-	// Optimization: skip the expensive secp256k1 signature
-	// verification for DMSG connections. The DMSG noise handshake
-	// (KK pattern) already authenticated the remote PK at the
-	// transport layer — verifying the HTTP-layer signature is
-	// redundant. The nonce check above still runs for replay /
-	// ordering protection.
-	//
-	// Detection: DMSG HTTP transport sets RemoteAddr to the PK hex
-	// (not an IP:port). If it parses as a valid PK, we know the
-	// connection arrived via an authenticated DMSG stream.
-	if isDmsgConnection(r) {
-		return nil
-	}
-
+	// NOTE: verifyAuth now runs ONLY for plain-HTTP requests. DMSG requests are
+	// authenticated earlier (WithAuth) from the noise-authenticated RemoteAddr PK
+	// and never reach here, so the full signature verification below is correct
+	// for the HTTP path (no dmsg short-circuit — that skip used to trust the
+	// unverified SW-Public header over dmsg, an impersonation hole).
 	return auth.Verify(payload)
 }
 
-// isDmsgConnection checks whether the request arrived over a DMSG
-// connection by inspecting RemoteAddr. DMSG HTTP transport uses the
-// remote PK as the address; regular HTTP connections use IP:port.
-func isDmsgConnection(r *http.Request) bool {
+// dmsgRemotePK returns the noise-authenticated peer public key when the request
+// arrived over a DMSG HTTP transport — dmsghttp sets RemoteAddr to "<pk>:<port>"
+// (a regular HTTP connection uses "ip:port"), and that PK was proven by the
+// dmsg noise-KK handshake at the transport layer. ok=false for plain HTTP.
+func dmsgRemotePK(r *http.Request) (cipher.PubKey, bool) {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		host = r.RemoteAddr
 	}
 	var pk cipher.PubKey
-	return pk.Set(host) == nil
+	if pk.Set(host) != nil {
+		return cipher.PubKey{}, false
+	}
+	return pk, true
 }
 
 // PayloadWithNonce returns the concatenation of payload and nonce.

--- a/pkg/httpauth/handler.go
+++ b/pkg/httpauth/handler.go
@@ -75,6 +75,28 @@ func (w *statusWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 // public key from it's context, stored in the value ContextAuthKey.
 func WithAuth(store NonceStore, original http.Handler, shouldVerifyAuth bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Over DMSG the caller PK is authenticated by the noise-KK handshake and
+		// carried in RemoteAddr ("<pk>:<port>"), and the stream is ordered +
+		// replay-proof. So the HTTP-layer signature AND the SW-Nonce
+		// (replay/ordering) checks are redundant — the authenticated identity is
+		// that PK. Take it from RemoteAddr and skip both.
+		//
+		// This is also the SECURE choice, not just an optimization: the previous
+		// behaviour skipped only the signature over dmsg yet still acted on the
+		// UNVERIFIED SW-Public header, which let any dmsg peer impersonate any PK
+		// by forging SW-Public (e.g. bind another visor's AR record). Binding the
+		// identity to the noise-authenticated RemoteAddr closes that. Plain-HTTP
+		// requests still run the full SW-Nonce + signature verification below.
+		if shouldVerifyAuth {
+			if pk, ok := dmsgRemotePK(r); ok {
+				httputil.LogEntrySetField(r, LogAuthKey, pk)
+				//nolint:staticcheck
+				original.ServeHTTP(w, r.WithContext(context.WithValue(
+					r.Context(), ContextAuthKey, pk)))
+				return
+			}
+		}
+
 		auth, err := AuthFromHeaders(r.Header, shouldVerifyAuth)
 		if err != nil {
 			httputil.WriteJSON(w, r, http.StatusUnauthorized,

--- a/pkg/httpauth/handler_test.go
+++ b/pkg/httpauth/handler_test.go
@@ -285,3 +285,65 @@ func TestSignatureVerification(t *testing.T) {
 	require.NoError(t, Verify(payload, nonce, pub, sig))
 	require.Error(t, Verify(payload, nonce+1, pub, sig))
 }
+
+// TestServer_Wrap_DmsgIdentity locks in the DMSG auth contract: over dmsg the
+// authenticated identity is the noise-KK RemoteAddr PK — NOT the SW-Public header
+// — so a forged SW-Public cannot impersonate another visor, and no HTTP-layer
+// signature/nonce is required. Plain-HTTP requests still enforce the signature.
+func TestServer_Wrap_DmsgIdentity(t *testing.T) {
+	storeConfig := storeconfig.Config{Type: storeconfig.Memory}
+	ctx := context.TODO()
+
+	sessionPK, _ := cipher.GenerateKeyPair() // the noise-authenticated dmsg peer
+	forgedPK, _ := cipher.GenerateKeyPair()  // a different PK an attacker claims
+
+	newHandler := func(t *testing.T, gotPK *cipher.PubKey) http.Handler {
+		mock, err := NewNonceStore(ctx, storeConfig, "")
+		require.NoError(t, err)
+		m := chi.NewRouter()
+		m.Use(MakeMiddleware(mock))
+		m.Post("/foo", func(w http.ResponseWriter, r *http.Request) {
+			pk, _ := r.Context().Value(ContextAuthKey).(cipher.PubKey)
+			*gotPK = pk
+			httputil.WriteJSON(w, r, http.StatusOK, "")
+		})
+		return m
+	}
+
+	t.Run("dmsg: identity is RemoteAddr PK, forged SW-Public ignored, no valid sig", func(t *testing.T) {
+		var got cipher.PubKey
+		h := newHandler(t, &got)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/foo", bytes.NewReader([]byte("hi")))
+		r.RemoteAddr = sessionPK.Hex() + ":12345" // dmsghttp sets RemoteAddr to the PK
+		// Attacker forges SW-Public = a different visor, with a garbage signature.
+		r.Header.Set("SW-Public", forgedPK.Hex())
+		r.Header.Set("SW-Sig", cipher.Sig{}.Hex())
+		r.Header.Set("SW-Nonce", "999")
+		h.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, sessionPK, got, "identity must be the dmsg session PK, not the forged SW-Public")
+		assert.NotEqual(t, forgedPK, got)
+	})
+
+	t.Run("dmsg: authenticates with no SW-* headers at all", func(t *testing.T) {
+		var got cipher.PubKey
+		h := newHandler(t, &got)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/foo", bytes.NewReader([]byte("hi")))
+		r.RemoteAddr = sessionPK.Hex() + ":40000"
+		h.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+		assert.Equal(t, sessionPK, got)
+	})
+
+	t.Run("http: invalid signature still 401 (HTTP path unchanged)", func(t *testing.T) {
+		var got cipher.PubKey
+		h := newHandler(t, &got)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/foo", bytes.NewReader([]byte("hi")))
+		r.Header = invalidHeaders(t, []byte("hi")) // default RemoteAddr is IP:port → HTTP path
+		h.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusUnauthorized, w.Code, w.Body.String())
+	})
+}


### PR DESCRIPTION
## Security + load fix in the shared `httpauth` middleware (AR / TPD / SD / uptime-tracker)

### The hole
Over dmsg, the caller PK is authenticated by the noise-KK handshake and carried in `RemoteAddr` (`<pk>:<port>`). The shared auth path (`WithAuth`/`verifyAuth`) had a dmsg optimization that skipped the secp256k1 **signature** over dmsg — but it **still acted on the unverified `SW-Public` header** (`ContextAuthKey`), and nothing bound `SW-Public` to the dmsg session PK. Since the nonce is public (`/security/nonces/<pk>` is unauthenticated), the signature was the *only* real proof — and it was skipped. So **any dmsg peer could impersonate any visor** by forging `SW-Public`, e.g. `POST /bind/wt` as another visor → AR transport-record spoofing → traffic redirection / MITM. Same surface in TPD (transport register/report), SD (the `PKFromCtx == entry.PubKey` guard is defeated), and uptime-tracker.

Verified on the live production AR (logs show `/resolve|/bind ... from <pk>:<port>` and `SW-Nonce mismatch` 401s).

### The fix
Over dmsg, take the authenticated identity from the **noise-verified `RemoteAddr` PK** and skip **both** the signature and the `SW-Nonce` (both redundant over an ordered, replay-proof, authenticated stream). Plain-HTTP requests are **unchanged** — full `SW-Nonce` + signature. One change in shared `httpauth` fixes all four services; backward-compatible (honest clients set `SW-Public` = their own PK = `RemoteAddr`).

### Load
This is load-*reducing*, not the naive "re-verify the signature over dmsg" (which would re-add the expensive secp256k1 work the earlier optimization removed). It also eliminates the `SW-Nonce`-desync **401 → `/security/nonces` refetch → retry** churn that concurrent clients (esp. the browser wasm visor racing the monotonic per-key nonce) generate — so AR/TPD load should drop. Baseline captured (AR ~42% CPU, TPD ~50%); I'll compare after redeploy and roll back if anything regresses.

### Tests
`pkg/httpauth` — forged `SW-Public` over dmsg resolves to the **session** PK (not the header); dmsg authenticates with **no** `SW-*` headers; plain HTTP still 401s on a bad signature. AR/TPD/SD api tests pass.