### PR TITLE
fix(address-resolver): /resolve of an unresolvable type returns 404, not 500

### DIFF
--- a/pkg/address-resolver/api/api.go
+++ b/pkg/address-resolver/api/api.go
@@ -523,7 +523,12 @@ func (a *API) resolve(w http.ResponseWriter, r *http.Request) {
 	}
 
 	receiverVisorData, err := a.store.Resolve(ctx, types.Type(tpType), receiverPK)
-	if errors.Is(err, store.ErrNoEntry) {
+	// ErrNoEntry: no record for this PK. ErrUnknownTransportType: a type the AR
+	// doesn't resolve at all (e.g. webrtc, which dials by PK over dmsg signaling
+	// and has no AR record) — the redis store reports this where the mem store
+	// reports ErrNoEntry. Both mean "nothing to resolve here" and must be 404,
+	// not a 500 server-fault (the AR-500 regression this endpoint has hit before).
+	if errors.Is(err, store.ErrNoEntry) || errors.Is(err, store.ErrUnknownTransportType) {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/pkg/address-resolver/api/api_test.go
+++ b/pkg/address-resolver/api/api_test.go
@@ -152,6 +152,32 @@ func TestTransports(t *testing.T) {
 	require.Contains(t, data.Stcpr, pk.Hex())
 }
 
+// ---- resolve ---------------------------------------------------------------
+
+func TestResolve_StatusMapping(t *testing.T) {
+	sender, _ := cipher.GenerateKeyPair()
+	receiver, _ := cipher.GenerateKeyPair()
+
+	t.Run("unresolvable transport type -> 404 (not 500)", func(t *testing.T) {
+		// webrtc dials by PK over dmsg signaling and has no AR record. The redis
+		// store reports ErrUnknownTransportType (was a 500); the mem store reports
+		// ErrNoEntry. The handler maps both to 404 so neither trips the AR-500 path.
+		a := newTestAPI(t)
+		rec := httptest.NewRecorder()
+		a.resolve(rec, authReq(t, http.MethodGet, "/resolve/webrtc/"+receiver.Hex(), nil,
+			&sender, map[string]string{"type": "webrtc", "pk": receiver.Hex()}))
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("no entry -> 404", func(t *testing.T) {
+		a := newTestAPI(t)
+		rec := httptest.NewRecorder()
+		a.resolve(rec, authReq(t, http.MethodGet, "/resolve/stcpr/"+receiver.Hex(), nil,
+			&sender, map[string]string{"type": "stcpr", "pk": receiver.Hex()}))
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
 // ---- bind ------------------------------------------------------------------
 
 func TestBind(t *testing.T) {


### PR DESCRIPTION
On the live deployment the address-resolver logs ~750 HTTP 500s for `GET /resolve/webrtc/<pk>`. Root cause: `webrtc` dials by PK over dmsg signaling and has **no** address-resolver record, so the redis store rejects it with `ErrUnknownTransportType`, which the resolve handler mapped to `500 Internal Server Error`.

That is not a server fault — there is simply nothing to resolve. It also inflates the AR 500 error rate (the metric alerting keys on). The requests come from older fleet visors; current native and wasm dial paths never resolve `webrtc`.

**Fix:** the resolve handler now treats `ErrUnknownTransportType` the same as `ErrNoEntry` → `404 Not Found`. This matches the mem store, which already returns `ErrNoEntry` for the same case — a difference `normalize_test.go` explicitly documents as "never the 500-causing path" (from the earlier WT/QUIC-rename 500 regression).

Adds `TestResolve_StatusMapping` covering `webrtc → 404` and `no-entry → 404`. No store behavior changed; the mapping is centralized in the handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)