### PR TITLE
chore(readme): remove retired Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/skycoin/skywire)](https://goreportcard.com/report/github.com/skycoin/skywire)
 ![Test](https://github.com/skycoin/skywire/actions/workflows/test.yml/badge.svg)
 ![Deploy](https://github.com/skycoin/skywire/actions/workflows/deploy.yml/badge.svg)
 [![GitHub release](https://img.shields.io/github/release/skycoin/skywire.svg)](https://github.com/skycoin/skywire/releases/)


### PR DESCRIPTION
goreportcard.com is being **sunset** — its homepage says "sunset" and our README badge now literally renders **"retired"**. This removes it.

A pkg.go.dev *Go Reference* badge is not a substitute: skywire ships **no license file** (intentionally), so pkg.go.dev returns *"Documentation not displayed due to license restrictions"* — that badge would be broken too. The remaining badges (Test, Deploy, release, AUR ×2, OpenSSF Scorecard, go.mod version, Telegram) cover the useful signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)