### PR TITLE
fix(ci): clear misspell lint regression + regenerate Test badge on develop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,14 @@ on:
       - 'docs/**'
       - 'LICENSE'
       - '.gitignore'
+  push:
+    branches: [develop]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+  workflow_dispatch:
 name: Test
 
 jobs:

--- a/pkg/httpauth/handler.go
+++ b/pkg/httpauth/handler.go
@@ -82,7 +82,7 @@ func WithAuth(store NonceStore, original http.Handler, shouldVerifyAuth bool) ht
 		// that PK. Take it from RemoteAddr and skip both.
 		//
 		// This is also the SECURE choice, not just an optimization: the previous
-		// behaviour skipped only the signature over dmsg yet still acted on the
+		// behavior skipped only the signature over dmsg yet still acted on the
 		// UNVERIFIED SW-Public header, which let any dmsg peer impersonate any PK
 		// by forging SW-Public (e.g. bind another visor's AR record). Binding the
 		// identity to the noise-authenticated RemoteAddr closes that. Plain-HTTP


### PR DESCRIPTION
The README **Test** badge is red for two independent reasons, both fixed here:

1. **A real lint gate is failing on develop.** `misspell` (a hard gate in `.golangci.yml`) flags `behaviour` at `pkg/httpauth/handler.go:85` (British spelling introduced in #3725) → every CI run goes red. Fixed to `behavior`; `golangci-lint run ./pkg/httpauth/...` → `0 issues`.

2. **The badge can never refresh.** `test.yml` triggered only on `pull_request`, whose head ref is the PR branch — so the develop-HEAD run stayed frozen at the last failing one (a since-fixed flaky Docker e2e from April). Added `push: branches:[develop]` + `workflow_dispatch` so a develop push (or manual run) regenerates the badge green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)