### PR TITLE
chore(security): OpenSSF Scorecard hardening (SECURITY.md, workflow permissions, CodeQL, Scorecard, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot keeps GitHub Actions versions current (and, over time, pinned).
+# Go module updates are handled deliberately via `make update-deps` + `go mod
+# vendor`, so the gomod ecosystem is intentionally left out here to avoid
+# conflicting with that vendored workflow.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# CodeQL static analysis (Go) — feeds the OpenSSF Scorecard "SAST" check and
+# surfaces findings in the repo Security tab.
+name: CodeQL
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: '27 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.5'
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          # The default autobuild can choke on the multi-binary layout; build
+          # the main module explicitly instead (vendored, no network).
+          build-mode: manual
+
+      - name: Build
+        run: go build -mod=vendor ./cmd/...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,8 @@
 name: Deploy
+
+permissions:
+  contents: read
+
 # only trigger on pull request closed events
 on:
   push:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,6 +26,9 @@ on:
 
 name: Nix
 
+permissions:
+  contents: read
+
 jobs:
   build-source:
     name: Build skywire (static musl)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: Release
+
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+# OpenSSF Scorecard — runs the supply-chain security checks on a schedule and
+# on default-branch pushes, uploads results to the Security tab, and publishes
+# them so the README badge stays current.
+name: Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '41 5 * * 1'
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/test-ipv6.yml
+++ b/.github/workflows/test-ipv6.yml
@@ -36,6 +36,9 @@ on:
 
 name: Test IPv6 dual-stack
 
+permissions:
+  contents: read
+
 jobs:
   ipv6-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ on:
   workflow_dispatch:
 name: Test
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-commit.yml
+++ b/.github/workflows/update-commit.yml
@@ -1,4 +1,8 @@
 name: Update Commit
+
+permissions:
+  contents: read
+
 on:
   workflow_run:
     workflows: ["Test"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue in Skywire, please report it through either
+of these channels:
+
+- **Telegram** — reach the maintainers on the dedicated technical channel
+  [**@skywire**](https://t.me/skywire). This is the fastest way to reach the
+  people who work on the code, and the right place for anything sensitive.
+- **GitHub issue** — open an issue at
+  <https://github.com/skycoin/skywire/issues>.
+
+We monitor both. When reporting, please include enough detail to understand and
+reproduce the issue — the affected version or commit, the relevant
+configuration, and the steps that trigger it.
+
+## Supported Versions
+
+Skywire is developed on the `develop` branch and released frequently; fixes land
+there first and roll out to the network in subsequent releases. Before
+reporting, please confirm the issue against the latest `develop` or the most
+recent release, and include the version (from `skywire cli visor version`, or
+the build info in the hypervisor UI) in your report.


### PR DESCRIPTION
Raises the low-scoring, PR-addressable [OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/skycoin/skywire) checks (currently 2.7):

| Check | Before | This PR |
|---|---|---|
| **Security-Policy** | 0 | `SECURITY.md` — disclosure via Telegram [@skywire](https://t.me/skywire) / GitHub issue |
| **Token-Permissions** | 0 | least-privilege `permissions:` on the 6 workflows that had none |
| **SAST** | 0 | CodeQL (Go) workflow on push/PR/weekly |
| **Dependency hygiene** | — | Dependabot (github-actions) + a Scorecard workflow for continuous scoring |

### Permissions detail
- `test`, `test-ipv6`, `nix`, `deploy` → `contents: read` (all read-only; deploy pushes to Docker Hub via secrets, not `GITHUB_TOKEN`).
- `release` → `contents: write` (it runs `gh release create`/`upload`).
- `update-commit` → top-level `contents: read`, keeping its existing job-level `contents: write` (it pushes the commit ref).

### Deliberately not here
- **No `LICENSE`** — the project is intentionally license-free, so the License check (0) stays by design.
- **Pinning `uses:` to commit SHAs** (Pinned-Dependencies) — left as a follow-up; the new Dependabot config will surface action bumps to pin against.
- **Branch-Protection (0)** and **Code-Review (0)** — repository-settings changes only; a PR cannot set these. They need "require PR + approvals + status checks" enabled on `develop`.

Verified: all workflow YAML parses; CodeQL’s build step (`go build -mod=vendor ./cmd/...`) compiles clean locally. The Scorecard workflow runs only on develop-push/schedule (not on PRs), and CodeQL runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)