### PR TITLE
feat(dmsg-server): WebTransport default-on (shared UDP socket with dmsg-over-QUIC)

### DIFF
--- a/pkg/dmsg/dmsg/serve_unified_quic_wt.go
+++ b/pkg/dmsg/dmsg/serve_unified_quic_wt.go
@@ -1,0 +1,120 @@
+//go:build !tinygo && !(js && wasm)
+
+// Package dmsg pkg/dmsg/dmsg/serve_unified_quic_wt.go c1-net-dmsg
+//
+// ServeUnifiedQUIC serves BOTH dmsg-over-QUIC and dmsg-over-WebTransport on ONE
+// UDP socket, ALPN-demuxed on a shared quic.Transport. This is what makes
+// WebTransport DEFAULT-ON for a dmsg server at zero extra port cost — reachable
+// wherever dmsg-over-QUIC already is (same UDP port) — instead of requiring a
+// separately-bound WTAddress. It mirrors how WS cmuxes the TCP port and how the
+// visor's WT shares its unified transport_port QUIC socket.
+package dmsg
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/quic-go/quic-go"
+	"github.com/quic-go/quic-go/http3"
+	"github.com/quic-go/webtransport-go"
+
+	"github.com/skycoin/skywire/pkg/skyquic"
+)
+
+// ServeUnifiedQUIC serves dmsg-over-QUIC and (when advertisedWTURL is non-empty)
+// dmsg-over-WebTransport on the same udpConn. The two are distinguished by ALPN
+// on a shared quic.Transport: skywire's QUIC ALPN → native dmsg QUIC sessions
+// (handleQUICConn); "h3" → WebTransport (handleWTSession). A WT cert-gen or
+// listen failure is non-fatal — the server keeps serving QUIC. advertisedWTURL
+// empty makes this behave exactly like ServeQUIC (QUIC only).
+func (s *Server) ServeUnifiedQUIC(udpConn net.PacketConn, advertisedUDPAddr, advertisedWTURL string) error {
+	identCert, err := skyquic.NewCertificate(s.pk, s.sk)
+	if err != nil {
+		return fmt.Errorf("dmsg-quic: identity cert: %w", err)
+	}
+	tr := &quic.Transport{Conn: udpConn}
+	defer tr.Close() //nolint:errcheck,gosec
+
+	quicLis, err := tr.Listen(skyquic.TLSConfig(identCert, nil, nil), &quic.Config{
+		EnableDatagrams: true,
+		MaxIdleTimeout:  60 * time.Second,
+		KeepAlivePeriod: 25 * time.Second,
+	})
+	if err != nil {
+		return fmt.Errorf("dmsg-quic: listen: %w", err)
+	}
+	s.setAdvertisedUDPAddr(advertisedUDPAddr)
+	s.log.WithField("addr_udp", advertisedUDPAddr).Info("Serving dmsg over QUIC.")
+
+	if advertisedWTURL != "" {
+		s.serveWTOnTransport(tr, advertisedWTURL)
+	}
+
+	for {
+		qc, aerr := quicLis.Accept(context.Background())
+		if aerr != nil {
+			if isClosed(s.done) {
+				return nil
+			}
+			return fmt.Errorf("dmsg-quic: accept: %w", aerr)
+		}
+		go s.handleQUICConn(qc)
+	}
+}
+
+// serveWTOnTransport registers a WebTransport ("h3") listener on the already-open
+// shared transport tr and serves it in the background. Best-effort: a cert or
+// listen error is logged and the caller keeps serving QUIC.
+func (s *Server) serveWTOnTransport(tr *quic.Transport, advertisedWTURL string) {
+	wtCert, wtHash, cerr := skyquic.NewWebTransportCertificate()
+	if cerr != nil {
+		s.log.WithError(cerr).Warn("dmsg-wt: cert gen failed; serving QUIC only")
+		return
+	}
+	mux := http.NewServeMux()
+	h3 := &http3.Server{
+		TLSConfig:       skyquic.WebTransportTLSConfig(wtCert),
+		Handler:         mux,
+		EnableDatagrams: true,
+		QUICConfig:      &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
+	}
+	webtransport.ConfigureHTTP3Server(h3)
+	wtSrv := &webtransport.Server{
+		H3:          h3,
+		CheckOrigin: func(*http.Request) bool { return true }, // PK auth is in Noise, not origin
+	}
+	mux.HandleFunc(wtPath, func(w http.ResponseWriter, r *http.Request) {
+		sess, uerr := wtSrv.Upgrade(w, r)
+		if uerr != nil {
+			s.log.WithError(uerr).Debug("dmsg-wt: upgrade failed")
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		s.handleWTSession(sess)
+	})
+
+	wtLis, lerr := tr.ListenEarly(h3.TLSConfig, h3.QUICConfig)
+	if lerr != nil {
+		s.log.WithError(lerr).Warn("dmsg-wt: listen on shared transport failed; serving QUIC only")
+		return
+	}
+	s.setAdvertisedWT(advertisedWTURL, wtHash)
+	s.log.WithField("addr_wt", advertisedWTURL).Info("Serving dmsg over WebTransport (shared UDP socket).")
+	go func() {
+		<-s.done
+		_ = h3.Close()
+		_ = wtLis.Close()
+	}()
+	go func() {
+		for {
+			qc, aerr := wtLis.Accept(context.Background())
+			if aerr != nil {
+				return
+			}
+			go func(c *quic.Conn) { _ = wtSrv.ServeQUICConn(c) }(qc)
+		}
+	}()
+}

--- a/pkg/dmsg/dmsgserver/api.go
+++ b/pkg/dmsg/dmsgserver/api.go
@@ -88,7 +88,7 @@ func (a *ServerAPI) SetDmsgServer(srv *dmsg.Server) {
 // first bytes — raw Noise vs HTTP/1 upgrade), so one advertised ip:port carries
 // both protocols (see dmsg.Server.ServeWithWS and
 // docs/design/dmsg-server-protocol-unification.md). Empty wsURL = raw-dmsg only.
-func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL string) error {
+func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL, wtURL string) error {
 	errCh := make(chan error, 3)
 
 	dmsgLn, err := net.Listen("tcp", lAddr)
@@ -121,11 +121,15 @@ func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL string) error {
 		logging.MustGetLogger("dmsg_server").WithError(uerr).
 			Warn("dmsg-over-QUIC: failed to bind UDP listener; serving TCP only")
 	} else {
-		go func(udp net.PacketConn, advertised string) {
-			serr := a.dmsgServer.ServeQUIC(udp, advertised)
+		go func(udp net.PacketConn, advertised, wt string) {
+			// ServeUnifiedQUIC serves dmsg-over-QUIC AND (when wt != "")
+			// dmsg-over-WebTransport on this SAME UDP socket, ALPN-demuxed — so WT
+			// is default-on at zero extra port cost, reachable wherever dmsg-QUIC
+			// already is. wt == "" makes it QUIC-only (the prior behaviour).
+			serr := a.dmsgServer.ServeUnifiedQUIC(udp, advertised, wt)
 			udp.Close() //nolint:errcheck,gosec
 			errCh <- fmt.Errorf("dmsg QUIC server stopped: %v", serr)
-		}(udpConn, pAddr)
+		}(udpConn, pAddr, wtURL)
 	}
 
 	ln, err := net.Listen("tcp", httpAddr)

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -169,7 +169,12 @@ type Config struct {
 	// (Server.AddressWT), e.g. "https://1.2.3.4:8443/dmsg". Required when
 	// WTAddress is set, otherwise clients learn no URL to dial. It should use a
 	// bare IP (the browser pins the cert hash, not a hostname).
-	PublicAddressWT  string        `json:"public_address_wt,omitempty"`
+	PublicAddressWT string `json:"public_address_wt,omitempty"`
+	// DisableWT opts OUT of the default-on dmsg-over-WebTransport that otherwise
+	// rides the main UDP socket (shared with dmsg-over-QUIC, ALPN-demuxed) and is
+	// advertised automatically from the public address. Set it on a server whose
+	// UDP endpoint genuinely can't serve WT (e.g. a proxy that can't pass HTTP/3).
+	DisableWT        bool          `json:"disable_wt,omitempty"`
 	LocalAddress     string        `json:"local_address"`
 	HTTPAddress      string        `json:"health_endpoint_address"`
 	LogLevel         string        `json:"log_level"`

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -319,10 +319,29 @@ func (s *service) Run(ctx context.Context) error {
 		}
 	}
 
+	// dmsg-over-WebTransport advert (DEFAULT-ON). WT is HTTP/3-over-QUIC, so it
+	// rides the SAME UDP socket as dmsg-over-QUIC (ALPN-demuxed in
+	// ServeUnifiedQUIC) — like WS on the main TCP port, it needs no extra port and
+	// no discovery topology change. Advertise https://<public host:port>/dmsg (the
+	// same host:port as the QUIC/TCP endpoint). An explicit public_address_wt
+	// overrides; disable_wt opts out; a bare ":port"/empty advertised address
+	// (unknown public endpoint) skips it. A browser prefers this over wss and drops
+	// the redundant TLS-over-Noise once the WT session is up.
+	// Only default-on the SHARED-socket WT when no explicit WTAddress is set — a
+	// server configured with its own separate WT UDP socket keeps that path below.
+	mainWTURL := ""
+	if !cfg.DisableWT && cfg.WTAddress == "" && primaryAdvertised != "" && !strings.HasPrefix(primaryAdvertised, ":") {
+		mainWTURL = "https://" + primaryAdvertised + "/dmsg"
+		if cfg.PublicAddressWT != "" {
+			mainWTURL = cfg.PublicAddressWT
+		}
+		log.WithField("wt_url", mainWTURL).Info("dmsg-wt: advertising WebTransport on the main UDP port (shared with QUIC).")
+	}
+
 	go srvAPI.RunBackgroundTasks(runCtx)
 	log.WithField("addr", cfg.HTTPAddress).Info("Serving server API...")
 	go func() {
-		if err := srvAPI.ListenAndServe(cfg.LocalAddress, primaryAdvertised, cfg.HTTPAddress, mainWSURL); err != nil {
+		if err := srvAPI.ListenAndServe(cfg.LocalAddress, primaryAdvertised, cfg.HTTPAddress, mainWSURL, mainWTURL); err != nil {
 			log.Errorf("Serve: %v", err)
 			cancel()
 		}


### PR DESCRIPTION
Browser wasm-visors were staying on **wss** instead of upgrading to **WebTransport** because only **1 of 9** deployment dmsg servers advertised `address_wt`. Root cause: `ServeWebTransport` was never called in the auto-serve path (unlike `ServeQUIC`, which auto-binds UDP), so WT required an explicit per-server `wt_address` that 8/9 lacked.

**Fix — make WT default-on at zero extra port cost:**
- **`ServeUnifiedQUIC`**: serves dmsg-over-QUIC **and** dmsg-over-WebTransport on **one** UDP socket via a shared `quic.Transport`, ALPN-demuxed (`skywire` QUIC ALPN → native dmsg; `h3` → WebTransport). Reuses `handleQUICConn` + `handleWTSession`; auto-generates the self-signed WT cert (ECDSA-P256/13-day, `serverCertificateHashes`-pinned). Best-effort: a WT failure keeps QUIC serving.
- `ListenAndServe` gains `wtURL`; `dmsgsrv.go` derives `mainWTURL = https://<public host:port>/dmsg` **by default** (mirroring how `mainWSURL` is derived for WS) — no extra port, no discovery topology change, reachable wherever dmsg-over-QUIC already is. Skipped when an explicit `wt_address` is set (old separate-socket path) or `disable_wt` is true.

The browser client already prefers WT (`Carriers=[wt,ws]`) and drops the redundant wss TLS-over-Noise once WT is up, so this closes the wss→WT gap fleet-wide once the servers redeploy.

**Blast radius / validation:** this rewrites the dmsg-server QUIC listen setup (shared transport). Local dmsg tests (QUIC/WT/serve) pass and it builds, but the real gate is a live check post-deploy — confirm native QUIC clients AND a browser WT client both connect on the one socket, and that `all_servers` now shows `address_wt` fleet-wide. Merging per maintainer direction to live-test on the `:test` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)