### PR TITLE
fix(ci): clear lint + scorecard regressions on develop

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif

--- a/pkg/visor/api_runtime_config.go
+++ b/pkg/visor/api_runtime_config.go
@@ -79,7 +79,7 @@ func (v *Visor) SetRuntimeConfig(rawJSON []byte) error {
 
 	// Preserve the running SK when the editor submitted a blank one (the common
 	// case, since the SK is redacted). Re-marshal below so the real key — not the
-	// redacted blank — lands on disk. A deliberately-typed SK is honoured but must
+	// redacted blank — lands on disk. A deliberately-typed SK is honored but must
 	// still derive the current PK (checked next).
 	preservedSK := false
 	if newConf.SK.Null() && !v.conf.SK.Null() {

--- a/pkg/visor/api_runtime_config_test.go
+++ b/pkg/visor/api_runtime_config_test.go
@@ -36,7 +36,7 @@ func TestSetRuntimeConfig_SKRedactionRoundTrip(t *testing.T) {
 
 	initial, err := json.MarshalIndent(conf, "", "  ")
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(path, initial, 0o644))
+	require.NoError(t, os.WriteFile(path, initial, 0o600))
 
 	v := &Visor{conf: conf}
 
@@ -49,7 +49,7 @@ func TestSetRuntimeConfig_SKRedactionRoundTrip(t *testing.T) {
 
 	// SET the redacted view back (blank sk, unchanged pk): real SK preserved on disk.
 	require.NoError(t, v.SetRuntimeConfig(got))
-	onDisk, err := os.ReadFile(path)
+	onDisk, err := os.ReadFile(path) //nolint:gosec
 	require.NoError(t, err)
 	require.Contains(t, string(onDisk), sk.Hex(), "real SK must be re-injected on save")
 


### PR DESCRIPTION
The config-parity (#3738) and OpenSSF hardening (#3732) merges left develop red:
- `misspell`: `honoured` in `api_runtime_config.go` → `honored`.
- `gosec`: G306 (test WriteFile `0o644`→`0o600`) + G304 (`//nolint:gosec` on the test ReadFile with a variable path).
- **Scorecard** failed at *Set up job* — `ossf/scorecard-action@v2` doesn’t resolve (no `v2` tag); pinned to `@v2.4.4`.

`golangci-lint run ./pkg/visor/` → `0 issues`; the SK-redaction tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)