### PR TITLE
fix(dmsg): browser wss churn — only converge wss→WT for WT-capable servers

### DIFF
--- a/pkg/dmsg/dmsg/client_sessions.go
+++ b/pkg/dmsg/dmsg/client_sessions.go
@@ -163,7 +163,12 @@ func (ce *Client) UpgradeBrowserSessions() int {
 		case CarrierWT:
 			hasWT = true
 		case CarrierWS:
-			wsSessions = append(wsSessions, s)
+			// Only converge wss → WT for servers that actually advertise WT. A wss
+			// to a non-WT server has no WT to converge to — dropping it just re-dials
+			// wss next tick (the churn when only a few of N servers advertise WT).
+			if s.wtCapable {
+				wsSessions = append(wsSessions, s)
+			}
 		}
 	}
 	remaining := len(ce.sessions)
@@ -415,6 +420,10 @@ func (ce *Client) dialSession(ctx context.Context, entry *disc.Entry) (cs Client
 	// exact protocol used to reach this server (and ws:// from wss://).
 	dSes.carrier = network
 	dSes.carrierAddr = dialAddr
+	// Whether this server can be upgraded wss → WT. Only these should have their
+	// bootstrap wss dropped by UpgradeBrowserSessions; a non-WT server's wss just
+	// re-dials wss on the next tick, churning the session (the 8/9-servers case).
+	dSes.wtCapable = entry.Server.AddressWT != ""
 
 	ce.sessionsMx.Lock()
 	if ce.closed {

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -41,6 +41,12 @@ type SessionCommon struct {
 	// (and, for ws, whether it was plain ws:// or secured wss://).
 	carrierAddr string
 
+	// wtCapable records whether this session's server advertises a WebTransport
+	// endpoint (AddressWT) in discovery. Only WT-capable servers should have their
+	// bootstrap wss session dropped by UpgradeBrowserSessions — dropping a wss to a
+	// server that can't do WT just re-dials wss on the next tick (churn).
+	wtCapable bool
+
 	netConn net.Conn // underlying net.Conn (TCP connection to the dmsg server)
 	// ys      *yamux.Session
 	// ss      *smux.Session


### PR DESCRIPTION
A browser (wasm) visor’s dmsg was churning — sessions constantly dropping (`"use of closed network connection"`) — which starved transport formation and produced route-finder `transport not found` spam. Root cause is `UpgradeBrowserSessions`:

It drops **all** wss sessions (down to 1) whenever **any** WebTransport session exists — `hasWT` is checked globally, not per-server. Today only **1 of 9** dmsg servers advertises WT (until #3739 reaches the fleet — the deployed servers are still v1.3.88/v1.3.91/pre-#3739 v1.3.92 and none advertise `address_wt` except one hand-configured server). So:

1. browser bootstraps wss to several servers,
2. gets WT to the one WT-capable server → `hasWT=true`,
3. drops the wss to the other **8** (no WT),
4. serve loop re-dials them WT-preferred → no `AddressWT` → wss again,
5. next tick: `hasWT` still true → drops those 8 again → **churn**.

**Fix:** stamp each session with `wtCapable` (`entry.Server.AddressWT != ""` at dial) and only converge wss sessions whose server actually advertises WT. Non-WT servers keep their wss (nothing to converge to). Correct regardless of WT coverage — once the fleet advertises WT broadly (#3739), all servers become `wtCapable` and upgrade cleanly. The **native** visor is unaffected: `UpgradeBrowserSessions` is a no-op unless `prefersWTOverWS` (browser-only).

Native build + `go vet` + `pkg/dmsg/dmsg` tests pass; the wasm-visor edge builds. Rolling a browser visor onto this to confirm the churn stops before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)