### PR TITLE
fix(dmsg): WT never advertised — single ALPN-demux listener (fixes #3739 serve path)

### DIFF
--- a/pkg/dmsg/dmsg/serve_unified_quic_wt.go
+++ b/pkg/dmsg/dmsg/serve_unified_quic_wt.go
@@ -8,10 +8,20 @@
 // wherever dmsg-over-QUIC already is (same UDP port) — instead of requiring a
 // separately-bound WTAddress. It mirrors how WS cmuxes the TCP port and how the
 // visor's WT shares its unified transport_port QUIC socket.
+//
+// A quic.Transport permits exactly ONE listener (transport.go: t.server != nil →
+// errListenerAlreadySet), so dmsg-QUIC and WT CANNOT each call Listen*/ListenEarly
+// on it — that was the original bug (the WT ListenEarly always failed with
+// "already listening", so no server ever advertised WT). Instead we take a SINGLE
+// ListenEarly whose tls.Config.GetConfigForClient returns the dmsg identity cert
+// (skywire ALPN, mutual-TLS PK binding) or the WebTransport cert ("h3", no client
+// cert — browsers present none) depending on the ClientHello's offered ALPNs; the
+// accept loop then dispatches each connection by its negotiated ALPN.
 package dmsg
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,11 +35,11 @@ import (
 )
 
 // ServeUnifiedQUIC serves dmsg-over-QUIC and (when advertisedWTURL is non-empty)
-// dmsg-over-WebTransport on the same udpConn. The two are distinguished by ALPN
-// on a shared quic.Transport: skywire's QUIC ALPN → native dmsg QUIC sessions
-// (handleQUICConn); "h3" → WebTransport (handleWTSession). A WT cert-gen or
-// listen failure is non-fatal — the server keeps serving QUIC. advertisedWTURL
-// empty makes this behave exactly like ServeQUIC (QUIC only).
+// dmsg-over-WebTransport on the same udpConn via ONE ALPN-demuxing listener:
+// skywire's QUIC ALPN → native dmsg QUIC sessions (handleQUICConn); "h3" →
+// WebTransport (handleWTSession). WT setup is best-effort — a cert/build failure
+// logs and the server keeps serving QUIC. advertisedWTURL empty makes this behave
+// exactly like ServeQUIC (QUIC only).
 func (s *Server) ServeUnifiedQUIC(udpConn net.PacketConn, advertisedUDPAddr, advertisedWTURL string) error {
 	identCert, err := skyquic.NewCertificate(s.pk, s.sk)
 	if err != nil {
@@ -38,45 +48,94 @@ func (s *Server) ServeUnifiedQUIC(udpConn net.PacketConn, advertisedUDPAddr, adv
 	tr := &quic.Transport{Conn: udpConn}
 	defer tr.Close() //nolint:errcheck,gosec
 
-	quicLis, err := tr.Listen(skyquic.TLSConfig(identCert, nil, nil), &quic.Config{
+	identTLS := skyquic.TLSConfig(identCert, nil, nil)
+	quicConf := &quic.Config{
 		EnableDatagrams: true,
 		MaxIdleTimeout:  60 * time.Second,
 		KeepAlivePeriod: 25 * time.Second,
-	})
+	}
+
+	// Try to co-host WebTransport on the SAME listener, ALPN-demuxed. Because a
+	// quic.Transport allows only one listener, dmsg-QUIC and WT share a single
+	// ListenEarly: GetConfigForClient picks the identity cert (skywire ALPN) or the
+	// WT cert ("h3") per handshake. Best-effort: on WT setup failure, serve QUIC only.
+	tlsConf := identTLS
+	var wtSrv *webtransport.Server
+	var wtHash [32]byte
+	if advertisedWTURL != "" {
+		srv, wtTLS, hash, werr := s.buildWTServer()
+		if werr != nil {
+			s.log.WithError(werr).Warn("dmsg-wt: setup failed; serving QUIC only")
+		} else {
+			wtSrv, wtHash = srv, hash
+			tlsConf = &tls.Config{ //nolint:gosec // per-ALPN sub-configs set their own MinVersion/verification
+				// Union of ALPNs so the listener accepts both; GetConfigForClient
+				// supplies the actual per-handshake cert + verification.
+				NextProtos: []string{skyquic.NextProto, skyquic.WebTransportNextProto},
+				GetConfigForClient: func(h *tls.ClientHelloInfo) (*tls.Config, error) {
+					for _, p := range h.SupportedProtos {
+						if p == skyquic.WebTransportNextProto { // "h3" → WebTransport
+							return wtTLS, nil
+						}
+					}
+					return identTLS, nil // skywire ALPN → native dmsg-QUIC (mutual TLS)
+				},
+			}
+			// WebTransport needs datagrams + partial stream-reset delivery; both are
+			// harmless for native dmsg-QUIC sharing the same listener config.
+			quicConf.EnableStreamResetPartialDelivery = true
+		}
+	}
+
+	// Regular Listen (not ListenEarly): Accept returns fully-handshaken connections,
+	// so NegotiatedProtocol is set for the ALPN dispatch below and dmsg-QUIC's
+	// mutual-TLS handshake completes normally. WebTransport rides 1-RTT here (no
+	// 0-RTT) via ServeQUICConn, which is fine for a dmsg server.
+	lis, err := tr.Listen(tlsConf, quicConf)
 	if err != nil {
 		return fmt.Errorf("dmsg-quic: listen: %w", err)
 	}
 	s.setAdvertisedUDPAddr(advertisedUDPAddr)
 	s.log.WithField("addr_udp", advertisedUDPAddr).Info("Serving dmsg over QUIC.")
-
-	if advertisedWTURL != "" {
-		s.serveWTOnTransport(tr, advertisedWTURL)
+	if wtSrv != nil {
+		s.setAdvertisedWT(advertisedWTURL, wtHash)
+		s.log.WithField("addr_wt", advertisedWTURL).Info("Serving dmsg over WebTransport (shared UDP socket).")
+		go func() {
+			<-s.done
+			_ = wtSrv.Close() //nolint:errcheck
+		}()
 	}
 
 	for {
-		qc, aerr := quicLis.Accept(context.Background())
+		qc, aerr := lis.Accept(context.Background())
 		if aerr != nil {
 			if isClosed(s.done) {
 				return nil
 			}
 			return fmt.Errorf("dmsg-quic: accept: %w", aerr)
 		}
+		// Dispatch by the ALPN the connection negotiated.
+		if wtSrv != nil && qc.ConnectionState().TLS.NegotiatedProtocol == skyquic.WebTransportNextProto {
+			go func(c *quic.Conn) { _ = wtSrv.ServeQUICConn(c) }(qc) //nolint:errcheck
+			continue
+		}
 		go s.handleQUICConn(qc)
 	}
 }
 
-// serveWTOnTransport registers a WebTransport ("h3") listener on the already-open
-// shared transport tr and serves it in the background. Best-effort: a cert or
-// listen error is logged and the caller keeps serving QUIC.
-func (s *Server) serveWTOnTransport(tr *quic.Transport, advertisedWTURL string) {
-	wtCert, wtHash, cerr := skyquic.NewWebTransportCertificate()
-	if cerr != nil {
-		s.log.WithError(cerr).Warn("dmsg-wt: cert gen failed; serving QUIC only")
-		return
+// buildWTServer constructs the WebTransport (HTTP/3) server, its TLS config and
+// the serverCertificateHashes hash used to advertise it. It does NOT listen — the
+// caller feeds it "h3"-ALPN connections demuxed off the shared QUIC listener via
+// ServeQUICConn. Returns an error only on cert generation failure.
+func (s *Server) buildWTServer() (*webtransport.Server, *tls.Config, [32]byte, error) {
+	wtCert, wtHash, err := skyquic.NewWebTransportCertificate()
+	if err != nil {
+		return nil, nil, [32]byte{}, fmt.Errorf("wt cert: %w", err)
 	}
+	wtTLS := skyquic.WebTransportTLSConfig(wtCert)
 	mux := http.NewServeMux()
 	h3 := &http3.Server{
-		TLSConfig:       skyquic.WebTransportTLSConfig(wtCert),
+		TLSConfig:       wtTLS,
 		Handler:         mux,
 		EnableDatagrams: true,
 		QUICConfig:      &quic.Config{EnableDatagrams: true, EnableStreamResetPartialDelivery: true},
@@ -95,26 +154,5 @@ func (s *Server) serveWTOnTransport(tr *quic.Transport, advertisedWTURL string) 
 		}
 		s.handleWTSession(sess)
 	})
-
-	wtLis, lerr := tr.ListenEarly(h3.TLSConfig, h3.QUICConfig)
-	if lerr != nil {
-		s.log.WithError(lerr).Warn("dmsg-wt: listen on shared transport failed; serving QUIC only")
-		return
-	}
-	s.setAdvertisedWT(advertisedWTURL, wtHash)
-	s.log.WithField("addr_wt", advertisedWTURL).Info("Serving dmsg over WebTransport (shared UDP socket).")
-	go func() {
-		<-s.done
-		_ = h3.Close()
-		_ = wtLis.Close()
-	}()
-	go func() {
-		for {
-			qc, aerr := wtLis.Accept(context.Background())
-			if aerr != nil {
-				return
-			}
-			go func(c *quic.Conn) { _ = wtSrv.ServeQUICConn(c) }(qc)
-		}
-	}()
+	return wtSrv, wtTLS, wtHash, nil
 }

--- a/pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
+++ b/pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
@@ -1,0 +1,98 @@
+//go:build !tinygo && !(js && wasm)
+
+// Package dmsg pkg/dmsg/dmsg/serve_unified_quic_wt_test.go
+package dmsg
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestServeUnifiedQUIC_QUICThroughDemux proves that co-hosting WebTransport on the
+// shared quic.Transport (ServeUnifiedQUIC with a non-empty WT URL) does NOT break
+// native dmsg-over-QUIC. The rewrite replaced the broken two-listener design (a
+// quic.Transport permits only ONE listener, so the WT ListenEarly always failed)
+// with a SINGLE ListenEarly whose GetConfigForClient hands back the dmsg identity
+// TLS config for the skywire ALPN and the WT config for "h3". This test drives two
+// QUIC clients through that demux listener and bridges a stream A→B, so a
+// regression in the skywire-ALPN (mutual-TLS) handshake selection would fail here.
+func TestServeUnifiedQUIC_QUICThroughDemux(t *testing.T) {
+	dc := disc.NewMock(0)
+	const maxSessions = 10
+
+	pkSrv, skSrv := GenKeyPair(t, "server")
+	srv := NewServer(pkSrv, skSrv, dc, &ServerConfig{MaxSessions: maxSessions, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("uquic_server"))
+
+	udpConn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	udpAddr := udpConn.LocalAddr().String()
+
+	// Serve QUIC + WebTransport on ONE socket. The non-empty WT URL exercises
+	// buildWTServer + the GetConfigForClient ALPN demux (the path that was dead).
+	chSrv := make(chan error, 1)
+	go func() { chSrv <- srv.ServeUnifiedQUIC(udpConn, udpAddr, "https://"+udpAddr+"/dmsg") }()
+
+	srvEntry := disc.NewServerEntry(pkSrv, 0, "", maxSessions)
+	srvEntry.Server.Address = ""
+	srvEntry.Server.AddressUDP = udpAddr
+	srvEntry.Protocol = "quic"
+	require.NoError(t, srvEntry.Sign(skSrv))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	quicConf := func() *Config {
+		c := DefaultConfig()
+		c.Protocol = "quic"
+		return c
+	}
+	pkA, skA := GenKeyPair(t, "client A")
+	clientA := NewClient(pkA, skA, dc, quicConf())
+	clientA.SetLogger(logging.MustGetLogger("uquic_client_A"))
+	go clientA.Serve(context.Background())
+
+	pkB, skB := GenKeyPair(t, "client B")
+	clientB := NewClient(pkB, skB, dc, quicConf())
+	clientB.SetLogger(logging.MustGetLogger("uquic_client_B"))
+	go clientB.Serve(context.Background())
+
+	require.Eventually(t, func() bool {
+		return clientA.SessionCount() > 0 && clientB.SessionCount() > 0
+	}, 10*time.Second, 200*time.Millisecond, "QUIC clients failed to connect through the WT-demux listener")
+
+	sesA, okA := clientA.Session(pkSrv)
+	require.True(t, okA, "client A has no session to the unified server")
+	require.True(t, sesA.SupportsDatagrams(), "session is not a genuine QUIC session")
+
+	// Full data path: bridge a stream A→B through the server and round-trip a payload.
+	const port = 8080
+	lis, err := clientB.Listen(port)
+	require.NoError(t, err)
+	defer lis.Close() //nolint:errcheck
+
+	connA, err := clientA.DialStream(context.TODO(), Addr{PK: pkB, Port: port})
+	require.NoError(t, err)
+	defer connA.Close() //nolint:errcheck
+	connB, err := lis.Accept()
+	require.NoError(t, err)
+	defer connB.Close() //nolint:errcheck
+
+	payload := cipher.RandByte(4096)
+	go func() { _, _ = connA.Write(payload) }() //nolint:errcheck
+	got := make([]byte, len(payload))
+	_, err = io.ReadFull(connB, got)
+	require.NoError(t, err)
+	require.Equal(t, payload, got, "payload mismatch over QUIC through the WT-demux listener")
+
+	require.NoError(t, clientA.Close())
+	require.NoError(t, clientB.Close())
+	require.NoError(t, srv.Close())
+}


### PR DESCRIPTION
Follow-up to #3739. Diagnosed live: **no fleet dmsg server advertises `address_wt`** even though several run develop-tip (which includes #3739) — they show QUIC + WS in discovery but never WT. Root cause:

`ServeUnifiedQUIC` called `tr.Listen()` (dmsg-QUIC) **and** `tr.ListenEarly()` (WT) on the **same** `quic.Transport`. A Transport allows exactly one listener — `transport.go`: `if t.server != nil { return errListenerAlreadySet }` — so the WT `ListenEarly` **always** failed, `serveWTOnTransport` hit its best-effort "serving QUIC only" branch, and `setAdvertisedWT` was never reached. WT was dead on every server; only the one server on the *old* separate-socket path advertised it. That is the upstream cause of the browser wss churn (companion client PR).

### Fix — one listener, ALPN-demuxed
- A single `tr.Listen` with `tls.Config.GetConfigForClient` returning the **dmsg identity** cert (skywire ALPN, mutual-TLS PK binding) or the **WebTransport** cert (`h3`, no client cert) per ClientHello.
- Accept loop dispatches each conn by negotiated ALPN: `h3` → `webtransport.Server.ServeQUICConn`; else → `handleQUICConn`.
- `tr.Listen` (not `ListenEarly`) so `Accept` yields fully-handshaken conns (`NegotiatedProtocol` set; dmsg mutual-TLS completes). WT rides 1-RTT — fine for a dmsg server. *(The two-listener design failing the QUIC-client handshake was caught by the new test — `ListenEarly` returns pre-handshake conns.)*

### Validation
New `TestServeUnifiedQUIC_QUICThroughDemux` runs two native QUIC clients + a bridged A→B stream through the demux listener (the regression risk — dmsg-QUIC must still handshake). Full `pkg/dmsg/dmsg` suite + `go vet` + gofmt pass. The browser-WT handshake over the shared socket gets confirmed once a server runs this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)