### PR TITLE
fix(router): skip route finder when visor has no transports

### DIFF
--- a/pkg/router/router_dial.go
+++ b/pkg/router/router_dial.go
@@ -218,6 +218,20 @@ func (r *router) DialRoutes(
 	if forceLocal {
 		maxFetchAttempts = 1
 	}
+
+	// Fast-fail when this visor holds ZERO transports and no background
+	// transport-creation is pending (hookDone == nil). The route-finder
+	// needs a local first-hop transport to return any route, so querying it
+	// 6× here is pure waste + log spam ("Route finder failed ... transport
+	// not found"). A browser/wasm visor with no transports yet hits this via
+	// app route setup. We must NOT short-circuit when hookDone != nil: that's
+	// the cold-start race where a background hook is creating the FIRST
+	// transport for a cold peer, and the loop below waits on it once.
+	if hookDone == nil && r.tm != nil && r.tm.TransportCount() == 0 {
+		log.Debug("No local transports and no pending transport creation; skipping route finder")
+		return nil, fmt.Errorf("no transports available; route setup skipped")
+	}
+
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		var forwardPath, reversePath []routing.Hop
 		var err error


### PR DESCRIPTION
## Problem

`DialRoutes` queries the route finder even when the visor holds **zero transports**. Because the finder can never return a route without a local first-hop transport, it fails immediately, and the retry loop re-queries it 6× with fresh queries, producing repeated log spam:

```
WARN [router]: Route finder failed (attempt N/6), retrying with fresh query... error="transport not found"
```

A browser/wasm visor with no transports yet triggers this via app route setup — 6 wasted round-trips plus noise, guaranteed to fail.

## Fix

Fast-fail before the retry loop in `pkg/router/router_dial.go` when:

- the transport manager reports **0 transports** (`r.tm.TransportCount() == 0`), **AND**
- **no background transport-creation is pending** (`hookDone == nil`).

In that case there is provably no route to find, so we return early with a clear error (`no transports available; route setup skipped`) instead of hammering the finder.

## Conservatism

The cold-start RACE path is explicitly preserved: when `hookDone != nil`, a background route-setup hook is creating the FIRST transport for a cold peer, and the retry loop still runs and waits on that hook once. The gate only triggers when there is nothing in flight that could create a transport.