### PR TITLE
feat(wasmhv): ctl-bridge dials /ctl/rpc so the CLI can drive a wasm-visor tab

### DIFF
--- a/pkg/wasmhv/ctl-bridge.js
+++ b/pkg/wasmhv/ctl-bridge.js
@@ -43,5 +43,25 @@
     catch (e) { post('/ctl/result', { id: c.id, ok: false, error: e.message || String(e) }); }
   };
   es.onerror = function () {};
+
+  // RPC bridge: dial /ctl/rpc so a shell can drive THIS tab's visor with the
+  // ordinary CLI (skywire cli --rpc <addr> visor info). skywireVisor.serveRPC
+  // opens the WebSocket, wraps it as a yamux session and serves the tab's
+  // net/rpc surface over it; the host fronts it with a local 127.0.0.1:<port>
+  // that shows up as the tab's "rpc" field in /ctl/tabs. Retry until the visor
+  // exposes serveRPC (worker proxy installs it on boot).
+  var rpcBridged = false;
+  function dialRPCBridge() {
+    if (rpcBridged) { return; }
+    var v = window.skywireVisor;
+    if (!v || typeof v.serveRPC !== 'function') { setTimeout(dialRPCBridge, 300); return; }
+    rpcBridged = true;
+    var url = (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ctl/rpc?tab=' + tabId;
+    Promise.resolve(v.serveRPC(url))
+      .then(function () { post('/ctl/log?tab=' + tabId, 'rpc bridge up: ' + url); })
+      .catch(function (e) { rpcBridged = false; post('/ctl/log?tab=' + tabId, 'rpc bridge error: ' + (e && e.message || e)); setTimeout(dialRPCBridge, 2000); });
+  }
+  dialRPCBridge();
+
   post('/ctl/log?tab=' + tabId, 'ctl-bridge ready ' + tabId);
 })();


### PR DESCRIPTION
`skywire cli hv serve --harness` mounts a `/ctl/*` control bridge (pkg/wasmhv/ctlbridge). It exposes:

- `/ctl/events` (SSE) — the tab subscribes to receive commands.
- `/ctl/rpc` (WebSocket) — a wasm-visor tab is meant to dial this and serve its visor RPC over it; the bridge fronts it with a local `127.0.0.1:<port>` that `skywire cli --rpc <addr>` targets (pkg/wasmrpc.NewBridge / ServeTab). `/ctl/tabs` lists each tab with an `rpc` field.

The host bridge and the wasm side (`skywireVisor.serveRPC`, cmd/wasm-visor/rpcbridge_js.go) were already implemented, but the browser glue never connected them: `ctl-bridge.js` only opened `/ctl/events` and never dialed `/ctl/rpc`. As a result the per-tab RPC bridge was never established and the tab's `rpc` field in `/ctl/tabs` stayed empty, so `skywire cli --rpc` could not reach a wasm tab.

## Fix

`ctl-bridge.js` now dials the RPC bridge once the visor exposes `serveRPC` (installed on boot; proxied from the worker in worker mode):

- builds `wss?://<host>/ctl/rpc?tab=<id>` (matching the page scheme),
- calls `skywireVisor.serveRPC(url)`, which wraps that WebSocket as a yamux session and serves the tab's `net/rpc` surface (the `app-visor.*` gateway) over it,
- retries until `serveRPC` is present and re-dials on error.

With this, `/ctl/tabs` reports a populated `rpc` field and

    skywire cli --rpc <addr> visor info

drives that specific in-browser wasm-visor tab.

## Notes

- JS-only change, embedded via `go:embed` (`CtlBridgeJS`) into the native binary. The embedded wasm blob already exposes `serveRPC`, so no wasm rebuild is required.
- Harness / DEV-only surface (`--harness`), unchanged in scope.
- Verified: `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor/` and `go build ./cmd/... ./pkg/wasmhv/...`.