### PR TITLE
fix(visor): svc health — DMSG Server version via discovery-routed probe

### DIFF
--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -3,7 +3,6 @@
 package visor
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
-	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/pty"
 	"github.com/skycoin/skywire/pkg/servicedisc"
@@ -116,9 +114,11 @@ func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
 		}
 	}
 
-	// ---------- DMSG servers (from session data, no HTTP probe) ----------
+	// ---------- DMSG servers ----------
+	// Pass the (possibly nil) dmsg-HTTP client so each server's version is
+	// fetched over the same discovery-routed path as the services above.
 	if v.dmsgC != nil {
-		results = append(results, v.dmsgServerHealth(nil)...)
+		results = append(results, v.dmsgServerHealth(dmsgClient)...)
 	}
 
 	return results, nil
@@ -181,7 +181,7 @@ func (v *Visor) confServiceDmsg() string {
 // measured ping RTT (0 if unmeasured). Entries are sorted by PK so the
 // UI order remains stable across polls (DMSGServers() sorts by latency
 // which flips between samples and causes visible reordering).
-func (v *Visor) dmsgServerHealth(_ *http.Client) []ServiceHealthEntry {
+func (v *Visor) dmsgServerHealth(httpClient *http.Client) []ServiceHealthEntry {
 	servers, err := v.DMSGServers()
 	if err != nil || len(servers) == 0 {
 		return nil
@@ -214,40 +214,22 @@ func (v *Visor) dmsgServerHealth(_ *http.Client) []ServiceHealthEntry {
 			LatencyMs: latStr,
 			IP:        addrByPK[s.PK],
 		}
-		// Probe /health via the existing session to get the version.
-		if v.dmsgC != nil {
+		// Fetch the version from the server's /health endpoint over dmsg via
+		// the SAME discovery-routed dmsg-HTTP client the other services use —
+		// NOT a stream pinned to this server's own session. A dmsg server
+		// serves /health on its transit dmsg client (dmsg port 80, a normal
+		// client entry in discovery); dialing the relay server's own PK
+		// through the session with THAT server finds no local client session
+		// for the PK and fails, which is why the VERSION column was empty.
+		// doHealthProbe applies the same build_info.version extraction as the
+		// deployment-service rows.
+		if httpClient != nil {
 			wg.Add(1)
 			go func(idx int, serverPK cipher.PubKey) {
 				defer wg.Done()
-				ses, ok := v.dmsgC.Session(serverPK)
-				if !ok {
-					return
-				}
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-				stream, err := ses.DialStream(ctx, dmsg.Addr{PK: serverPK, Port: 80})
-				if err != nil {
-					return
-				}
-				defer stream.Close() //nolint:errcheck
-				// Send HTTP request on the stream.
-				req, _ := http.NewRequestWithContext(ctx, "GET", "http://"+serverPK.String()+":80/health", nil) //nolint:errcheck
-				if err := req.Write(stream); err != nil {
-					return
-				}
-				resp, err := http.ReadResponse(bufio.NewReader(stream), req)
-				if err != nil {
-					return
-				}
-				body, _ := io.ReadAll(resp.Body) //nolint:errcheck
-				resp.Body.Close()                //nolint:errcheck,gosec
-				var health map[string]interface{}
-				if json.Unmarshal(body, &health) == nil {
-					if bi, ok := health["build_info"].(map[string]interface{}); ok {
-						if ver, ok := bi["version"].(string); ok {
-							out[idx].Version = ver
-						}
-					}
+				probe := doHealthProbe(httpClient, "DMSG Server", "dmsg://"+serverPK.String()+":80", "dmsg")
+				if probe.Version != "" {
+					out[idx].Version = probe.Version
 				}
 			}(i, s.PK)
 		}

--- a/pkg/visor/api_services_test.go
+++ b/pkg/visor/api_services_test.go
@@ -1,6 +1,8 @@
 package visor
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,4 +54,37 @@ func TestServiceFetchOrder(t *testing.T) {
 			require.Equal(t, tt.want, serviceFetchOrder(tt.httpURL, tt.dmsgURL))
 		})
 	}
+}
+
+// TestDoHealthProbe_BuildInfoVersion asserts the shared health probe extracts
+// the service version from build_info.version — the field path the DMSG Server
+// rows now rely on. They route their version fetch through doHealthProbe (the
+// same discovery-routed extraction as the deployment-service rows) instead of
+// the old session-pinned dmsg stream, which never reached the server's
+// transit-client /health and left the VERSION column empty.
+func TestDoHealthProbe_BuildInfoVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/health", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"build_info":{"version":"v1.3.92-0-7925d659e2ec"}}`))
+	}))
+	defer srv.Close()
+
+	entry := doHealthProbe(srv.Client(), "DMSG Server", srv.URL, "dmsg")
+	require.Equal(t, "OK", entry.Status)
+	require.Equal(t, "v1.3.92-0-7925d659e2ec", entry.Version)
+}
+
+// TestDoHealthProbe_TopLevelVersionFallback asserts the fallback to a top-level
+// "version" field when build_info is absent.
+func TestDoHealthProbe_TopLevelVersionFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"v1.3.88-0-54e4b7f90c01"}`))
+	}))
+	defer srv.Close()
+
+	entry := doHealthProbe(srv.Client(), "DMSG Server", srv.URL, "dmsg")
+	require.Equal(t, "OK", entry.Status)
+	require.Equal(t, "v1.3.88-0-54e4b7f90c01", entry.Version)
 }


### PR DESCRIPTION
## Problem

`skywire cli svc health` printed `-` in the **VERSION** column for every **DMSG Server** row, while every other service (Config Service, Transport Discovery, DMSG Discovery, Address Resolver, Route Finder, Service Discovery, Uptime Tracker) showed its real version. The dmsg servers *do* serve `/health` with `build_info.version` — it just never reached the CLI.

## Root cause

`pkg/visor/api_services.go` `dmsgServerHealth()` used a different, bespoke fetch than the working service rows. It fetched the version with a stream **pinned to the visor's existing session with that relay server**:

```go
ses, _ := v.dmsgC.Session(serverPK)
stream, err := ses.DialStream(ctx, dmsg.Addr{PK: serverPK, Port: 80})
```

A dmsg server serves its `/health` over dmsg on port 80 via its **transit dmsg client** — a normal *client* entry in discovery (`serveDmsgSurfaces` → `dmsghttp.ListenAndServe` on `DefaultDmsgHTTPPort`). Dialing `serverPK:80` *through the session with that same relay server* asks the relay to deliver the stream to a client-PK equal to its own PK connected locally — there is none (the transit client connects out to peer servers, not to itself), so the request falls through `forwardViaPeer` → `ErrReqNoNextSession` and the dial fails. The goroutine returns early and `Version` stays empty → `-`.

The deployment-service rows don't have this problem because they fetch through the visor's discovery-routed dmsg-HTTP client (`doHealthProbe(v.dmsgHTTP, …)`), which resolves the target's client entry and routes through whatever server it's actually connected to.

## Fix

Route the DMSG Server version fetch through the **same** discovery-routed `doHealthProbe` the other rows use, so it resolves each server's client entry and reaches its port-80 `/health`, applying the identical `build_info.version` extraction (plus the top-level `version` fallback the old branch lacked). The per-server ping latency, status and IP columns are untouched. Removes the now-unused `bufio` / `pkg/dmsg/dmsg` imports.

Added unit tests locking in the `build_info.version` field path and the top-level `version` fallback.

## Validation

- `go build ./cmd/...` — clean
- `gofmt -l` on changed files — empty
- `go vet ./pkg/visor/` — clean
- `go test ./pkg/visor/ -run 'TestDoHealthProbe|TestServiceFetchOrder'` — pass

The live `svc health` end-to-end needs the dmsg network; validated here by confirming the health-response parse matches `build_info.version` and that the fetch now uses the discovery-routed client path proven by the working service rows.