### PR TITLE
fix(cxo): pin-gate benign sendLastRoot "no such head" WARN

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -390,7 +390,13 @@ func (c *Conn) sendLastRoot(pk cipher.PubKey) {
 		return
 	}
 
-	c.n.Printf("[WARN] [%s] sendLastRoot %s: %v (activeHead=%d)",
+	// A peer subscribed to a feed we don't have a Root for yet
+	// (activeHead=0 / "no such head") — benign and expected during
+	// startup and for any feed we haven't published to. There's
+	// nothing to send and nothing actionable; the peer receives the
+	// Root once we publish one. Pin-gated debug instead of an always-on
+	// [WARN] so it stops spamming the visor's log at INFO.
+	c.n.Debugf(MsgSendPin, "[%s] sendLastRoot %s: %v (activeHead=%d)",
 		c.String(), pk.Hex(), err, activeHead)
 
 }


### PR DESCRIPTION
When a peer subscribes to a feed this node holds no Root for yet (`activeHead=0` / "no such head"), `Conn.sendLastRoot` logged an always-on `[WARN] ... sendLastRoot ... (activeHead=0)` via `Node.Printf`.

On a visor that is the **common case** — peers subscribe to our transport/uptime feeds before (or without) us ever publishing a Root — so the line spammed the log at INFO as a stdlib-formatted `[node] HH:MM:SS conn.go:NNN: [WARN] ...` that neither matches skywire’s log format nor signals anything actionable (the peer receives the Root once we publish one).

**Change:** downgrade it to a pin-gated `Debugf(MsgSendPin, ...)` — silent at INFO, visible when CXO send-path debug pins are enabled. The two genuinely actionable `Node.Printf` sites in `conn.go` (send-queue-full → conn dead; received-Root error) are left as-is.

Tested: `go test ./pkg/cxo/node/` passes; `go vet` clean.