### PR TITLE
fix(cli): deprecate standalone uptime tracker, route CLI uptime via TPD-integrated /uptimes?v=v3

### DIFF
--- a/cmd/skywire-cli/commands/log/log.go
+++ b/cmd/skywire-cli/commands/log/log.go
@@ -64,7 +64,7 @@ func init() {
 var logCmd = &cobra.Command{
 	Use:   "log",
 	Short: "survey & transport log collection",
-	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the uptime tracker\n%[1]s/uptimes?v=v2\n%[1]s/uptimes?v=v2&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.TransportDiscovery),
+	Long:  fmt.Sprintf("Fetch health, survey, and transport logging from visors which are online in the TPD-integrated uptime tracker\n%[1]s/uptimes?v=v3\n%[1]s/uptimes?v=v3&visors=<pk1>;<pk2>;<pk3>", deployment.Prod.TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		log := logging.MustGetLogger("log-collecting")
 		fver, err := version.NewVersion("v1.3.17")
@@ -113,9 +113,9 @@ var logCmd = &cobra.Command{
 			pk, sk = cipher.GenerateKeyPair()
 		}
 
-		endpoint := utAddr + "/uptimes?v=v2"
+		endpoint := utAddr + "/uptimes?v=v3"
 		if fetchFrom != "" {
-			endpoint = utAddr + "&visors=" + fetchFrom
+			endpoint = utAddr + "/uptimes?v=v3&visors=" + fetchFrom
 		}
 
 		// Both the uptime tracker and per-visor surveys are reached over dmsg.

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -98,9 +98,9 @@ func init() {
 	testCmd.Flags().BoolVarP(&testOnlyWithTp, "transport", "p", false, "only test proxies that have an existing transport")
 	testCmd.Flags().BoolVarP(&testVerbose, "verbose", "v", false, "verbose output")
 	testCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
-	testCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	testCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.TransportDiscovery, "TPD-integrated uptime tracker url")
 	testCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
-	testCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	testCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)")
 	testCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	testCmd.Flags().StringVarP(&country, "country", "k", "", "filter proxies by country code")
 	testCmd.Flags().BoolVarP(&testConnectOnly, "connect", "c", false, "connect only mode: add transports without HTTP testing")
@@ -580,11 +580,11 @@ func init() {
 
 	listCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.TransportDiscovery, "TPD-integrated uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	listCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
-	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
@@ -607,19 +607,19 @@ var listCmd = &cobra.Command{
 				sdURL = deployment.Test.ServiceDiscovery
 			}
 			if !cmd.Flags().Changed("uturl") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("cds") {
 				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 		}
 
 		// Build full URLs
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := utURL + "/uptimes?v=v2"
+		utFullURL := clirpc.IntegratedUptimeURL(utURL)
 
 		// --- Fetch SD ---
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
@@ -695,6 +695,9 @@ var listCmd = &cobra.Command{
 		// --- Show only offline servers ---
 		if showOffline {
 			uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+			if uts == "" {
+				uts = "[]"
+			}
 
 			// Parse SD and UT data
 			var sdEntries []services.Service
@@ -839,6 +842,9 @@ var listCmd = &cobra.Command{
 
 		// --- Filtering by online status ---
 		uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+		if uts == "" {
+			uts = "[]"
+		}
 
 		// Use Go-based filtering when minVersion or maxVersion is specified (jq can't do semver comparison)
 		if minVersion != "" || maxVersion != "" {
@@ -988,13 +994,13 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				sdURL = deployment.Test.ServiceDiscovery
 			}
 			if !cmd.Flags().Changed("uturl") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("cds") {
 				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 		}
 

--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -110,12 +110,12 @@ func init() {
 
 	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
-	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.TransportDiscovery, "TPD-integrated uptime tracker url")
 	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "d", dep.TransportDiscovery, "transport discovery url")
 	RootCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "print raw json data")
 	RootCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	RootCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
-	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)")
 	RootCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
 	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	RootCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
@@ -150,7 +150,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 				sdURL = deployment.Test.ServiceDiscovery
 			}
 			if !cmd.Flags().Changed("uturl") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("tpdurl") {
 				tpdURL = deployment.Test.TransportDiscovery
@@ -159,16 +159,18 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 			if !cmd.Flags().Changed("cdt") {
 				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 		}
 
-		// Build full URLs with endpoints
+		// Build full URLs with endpoints. Uptime comes from the
+		// TPD-integrated tracker (CXO-backed v3), never the deprecated
+		// standalone uptime tracker.
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := utURL + "/uptimes?v=v2"
+		utFullURL := clirpc.IntegratedUptimeURL(utURL)
 		tpdFullURL := tpdURL + "/all-transports"
 
 		// Fetch SD
@@ -212,6 +214,9 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 		} else {
 			// Filter by online status via jq join
 			uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+			if uts == "" {
+				uts = "[]"
+			}
 			joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
 
 			// Build jq filter with optional country and version conditions

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -795,6 +795,38 @@ func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, c
 	return string(body)
 }
 
+// IntegratedUptimeURL builds the URL for the TPD-integrated uptime
+// tracker's visor-uptime endpoint: the transport-discovery base with
+// ?v=v3. v3 is the version cxoFeedForURL mirrors over CXO (feed
+// "tpd-uptime", path uptimes/days/30), so a fetch through
+// FetchCachedServiceURL / FetchIntegratedUptimes flows over the
+// CXO→DMSG→HTTP chain and NEVER dials the deprecated standalone uptime
+// tracker. An empty tpdBase falls back to
+// deployment.Prod.TransportDiscovery.
+//
+// v3 is a strict superset of v2: every entry still carries {pk, on,
+// version, daily}, with the per-day timeline bitmap added. Consumers
+// that only read the online flag or the daily percentages therefore
+// work against the v3 payload unchanged.
+func IntegratedUptimeURL(tpdBase string) string {
+	if tpdBase == "" {
+		tpdBase = deployment.Prod.TransportDiscovery
+	}
+	return strings.TrimRight(tpdBase, "/") + "/uptimes?v=v3"
+}
+
+// FetchIntegratedUptimes fetches the []VisorSummary v3 payload from the
+// TPD-integrated uptime tracker via the shared cached fetch chain
+// (CXO→DMSG→HTTP + disk cache). tpdBase is the transport-discovery base
+// URL (empty = prod). The returned JSON has the same {pk, on, ...}
+// shape v2 had, so existing jq filters keep working. Returns "" only
+// when every fetch path failed AND there was no cache to fall back on;
+// callers must treat "" as "no online data" and must not build JSON
+// from it (an empty string is not valid JSON).
+func FetchIntegratedUptimes(cmdFlags *pflag.FlagSet, tpdBase, cachefile string, cacheFilesAge int) string {
+	return FetchCachedServiceURL(cmdFlags, cachefile, IntegratedUptimeURL(tpdBase), cacheFilesAge)
+}
+
 var (
 	cliCacheOnce sync.Once
 	cliCache     *clicache.Cache

--- a/cmd/skywire-cli/commands/sd/root.go
+++ b/cmd/skywire-cli/commands/sd/root.go
@@ -108,10 +108,10 @@ func init() {
 	RootCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	RootCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
 	RootCmd.Flags().StringVarP(&tpdURL, "tpdurl", "b", dep.TransportDiscovery, "transport discovery url")
-	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	RootCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.TransportDiscovery, "TPD-integrated uptime tracker url")
 	RootCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
 	RootCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)")
-	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	RootCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)")
 	RootCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	RootCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
 	RootCmd.Flags().StringVarP(&version, "version", "e", "", "filter by version")
@@ -155,7 +155,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				tpdURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("uturl") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("cds") {
 				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
@@ -164,7 +164,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 		}
 
@@ -173,7 +173,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 		sdVpnURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVPN
 		sdVisorURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVisor
 		tpdFullURL := tpdURL + "/all-transports"
-		utFullURL := utURL + "/uptimes?v=v2"
+		utFullURL := clirpc.IntegratedUptimeURL(utURL)
 
 		// Fetch service discovery data for all service types
 		proxyData := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdProxyURL), sdProxyURL, cacheFilesAge)

--- a/cmd/skywire-cli/commands/svc/health.go
+++ b/cmd/skywire-cli/commands/svc/health.go
@@ -167,7 +167,6 @@ func queryServicesDirect(cmdFlags *pflag.FlagSet) []skyvisor.ServiceHealthEntry 
 		"DMSG Discovery":      deployment.Prod.DmsgDiscovery,
 		"Address Resolver":    deployment.Prod.AddressResolver,
 		"Route Finder":        deployment.Prod.RouteFinder,
-		"Uptime Tracker":      deployment.Prod.UptimeTracker,
 		"Service Discovery":   deployment.Prod.ServiceDiscovery,
 	}
 

--- a/cmd/skywire-cli/commands/tp/tp-add-pv.go
+++ b/cmd/skywire-cli/commands/tp/tp-add-pv.go
@@ -120,7 +120,10 @@ var addPvCmd = &cobra.Command{
 			pks, _ = script.Echo(sds).JQ(sdJQ).Replace(`"`, "").Slice() //nolint:errcheck
 		} else {
 			// Filter by online status
-			uts := clirpc.FetchCachedServiceURL(cmd.Flags(), pvCacheFileUT, pvUTURL+"/uptimes?v=v2", pvCacheFilesAge)
+			uts := clirpc.FetchIntegratedUptimes(cmd.Flags(), pvUTURL, pvCacheFileUT, pvCacheFilesAge)
+			if uts == "" {
+				uts = "[]"
+			}
 			joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
 			jqFilter := `
 			[ .ut[] | select(.on) | .pk ] as $online

--- a/cmd/skywire-cli/commands/tp/tp-tree.go
+++ b/cmd/skywire-cli/commands/tp/tp-tree.go
@@ -152,7 +152,10 @@ var treeCmd = &cobra.Command{
 		versionFilteredSet := make(map[string]bool) // pk -> true if passes version filter
 
 		if !noFilterOnline || filterByVersion {
-			utsRaw := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			utsRaw := clirpc.FetchIntegratedUptimes(cmd.Flags(), utURL, cacheFileUT, cacheFilesAge)
+			if utsRaw == "" {
+				utsRaw = "[]"
+			}
 			var uptimes []uptimeEntry
 			if err := json.Unmarshal([]byte(utsRaw), &uptimes); err != nil {
 				internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse uptime data: %w", err))

--- a/cmd/skywire-cli/commands/tp/tp-visor.go
+++ b/cmd/skywire-cli/commands/tp/tp-visor.go
@@ -116,7 +116,10 @@ Set cache file location to "" to avoid using cache files`,
 		}
 
 		// --- Filtering by online status via jq join ---
-		uts := clirpc.FetchCachedServiceURL(cmd.Flags(), vCacheFileUT, vUTURL+"/uptimes?v=v2", vCacheFilesAge)
+		uts := clirpc.FetchIntegratedUptimes(cmd.Flags(), vUTURL, vCacheFileUT, vCacheFilesAge)
+		if uts == "" {
+			uts = "[]"
+		}
 		joinedJSON := fmt.Sprintf(`{"sd": %s, "ut": %s}`, sds, uts)
 
 		// Build jq filter with optional country and version conditions

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -332,7 +332,7 @@ var tpCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), err)
 
 		if showMore {
-			utData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileUT, utURL+"/uptimes?v=v2", cacheFilesAge)
+			utData = clirpc.FetchIntegratedUptimes(cmd.Flags(), utURL, cacheFileUT, cacheFilesAge)
 			proxyData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDProxy, sdURL+"/api/services?type="+servicedisc.ServiceTypeProxy, cacheFilesAge)
 			vpnData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVPN, sdURL+"/api/services?type="+servicedisc.ServiceTypeVPN, cacheFilesAge)
 			visorData = clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFileSDVisor, sdURL+"/api/services?type="+servicedisc.ServiceTypeVisor, cacheFilesAge)

--- a/cmd/skywire-cli/commands/ut/root.go
+++ b/cmd/skywire-cli/commands/ut/root.go
@@ -130,10 +130,10 @@ func init() {
 	utCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "count the number of results")
 	utCmd.Flags().BoolVarP(&isMoreStats, "stats2", "t", false, "count of versions")
 	utCmd.Flags().IntVarP(&minUT, "min", "n", 75, "list visors meeting minimum uptime percentage\n\r")
-	utCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)\n\r")
+	utCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)\n\r")
 	utCmd.Flags().StringVar(&cacheDirTPD, "cdt", cacheDirPath(dep.TransportDiscovery), "TPD cache dir (\"\" to disable)\n\r")
 	utCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes\n\r")
-	utCmd.Flags().StringVarP(&utURL, "url", "u", dep.UptimeTracker, "specify alternative uptime tracker url\n\r")
+	utCmd.Flags().StringVarP(&utURL, "url", "u", dep.TransportDiscovery, "specify alternative (TPD-integrated) uptime tracker url\n\r")
 	utCmd.Flags().StringVar(&tpdURL, "tpdurl", dep.TransportDiscovery, "transport discovery url")
 	utCmd.Flags().StringVarP(&versionFilter, "version", "v", "", "filter visors by exact version")
 	utCmd.Flags().StringVar(&minVersion, "min-version", "", "filter visors with version >= specified (e.g. v1.3.34)")
@@ -147,18 +147,18 @@ func init() {
 var utCmd = &cobra.Command{
 	Use:   "ut",
 	Short: "Query uptime tracker",
-	Long:  fmt.Sprintf("query uptime tracker\n\n%v/uptimes?v=v2\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().UptimeTracker),
+	Long:  fmt.Sprintf("query the TPD-integrated uptime tracker\n\n%v/uptimes?v=v3\n\nCheck local visor daily uptime percent with:\n\n$ skywire-cli ut -n0 -k $(skywire-cli visor pk)\n\nSet cache dir to \"\" to avoid using cache files\n\nUse --testenv or SKYWIRETEST=1 to use test deployment services.", getDeployment().TransportDiscovery),
 	Run: func(cmd *cobra.Command, _ []string) {
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {
 			if !cmd.Flags().Changed("url") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("tpdurl") {
 				tpdURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 			if !cmd.Flags().Changed("cdt") {
 				cacheDirTPD = cacheDirPath(deployment.Test.TransportDiscovery)
@@ -166,7 +166,7 @@ var utCmd = &cobra.Command{
 		}
 
 		// Build full URLs
-		utFullURL := utURL + "/uptimes?v=v2"
+		utFullURL := clirpc.IntegratedUptimeURL(utURL)
 		tpdFullURL := tpdURL + "/all-transports"
 
 		// Resolve cache file paths up-front so we can mirror response bodies

--- a/cmd/skywire-cli/commands/visor/whois.go
+++ b/cmd/skywire-cli/commands/visor/whois.go
@@ -48,8 +48,8 @@ func init() {
 		"per-service request timeout")
 	whoisCmd.Flags().StringVar(&whoisTpdURL, "tpd", deployment.Prod.TransportDiscovery,
 		"transport-discovery URL")
-	whoisCmd.Flags().StringVar(&whoisUtURL, "ut", deployment.Prod.UptimeTracker,
-		"uptime-tracker URL")
+	whoisCmd.Flags().StringVar(&whoisUtURL, "ut", deployment.Prod.TransportDiscovery,
+		"TPD-integrated uptime-tracker URL")
 	whoisCmd.Flags().StringVar(&whoisSdURL, "sd", deployment.Prod.ServiceDiscovery,
 		"service-discovery URL")
 	RootCmd.AddCommand(whoisCmd)

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -273,11 +273,11 @@ func init() {
 
 	listCmd.Flags().BoolVar(&testEnv, "testenv", defaultTestEnv, "use test deployment")
 	listCmd.Flags().StringVarP(&sdURL, "sdurl", "a", dep.ServiceDiscovery, "service discovery url")
-	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.UptimeTracker, "uptime tracker url")
+	listCmd.Flags().StringVarP(&utURL, "uturl", "w", dep.TransportDiscovery, "TPD-integrated uptime tracker url")
 	listCmd.Flags().BoolVarP(&rawData, "raw", "r", false, "pretty print json data")
 	listCmd.Flags().BoolVarP(&noFilterOnline, "noton", "o", false, "do not filter by online status in UT")
 	listCmd.Flags().StringVar(&cacheDirSD, "cds", cacheDirPath(dep.ServiceDiscovery), "SD cache dir (\"\" to disable)")
-	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.UptimeTracker), "UT cache dir (\"\" to disable)")
+	listCmd.Flags().StringVar(&cacheDirUT, "cdu", cacheDirPath(dep.TransportDiscovery), "UT cache dir (\"\" to disable)")
 	listCmd.Flags().IntVarP(&cacheFilesAge, "cfa", "m", 5, "update cache files if older than n minutes")
 	listCmd.Flags().StringVarP(&pk, "pk", "k", "", "check "+serviceType+" service discovery for public key")
 	listCmd.Flags().StringVarP(&country, "country", "c", "", "filter by country code")
@@ -301,19 +301,19 @@ var listCmd = &cobra.Command{
 				sdURL = deployment.Test.ServiceDiscovery
 			}
 			if !cmd.Flags().Changed("uturl") {
-				utURL = deployment.Test.UptimeTracker
+				utURL = deployment.Test.TransportDiscovery
 			}
 			if !cmd.Flags().Changed("cds") {
 				cacheDirSD = cacheDirPath(deployment.Test.ServiceDiscovery)
 			}
 			if !cmd.Flags().Changed("cdu") {
-				cacheDirUT = cacheDirPath(deployment.Test.UptimeTracker)
+				cacheDirUT = cacheDirPath(deployment.Test.TransportDiscovery)
 			}
 		}
 
 		// Build full URLs
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := utURL + "/uptimes?v=v2"
+		utFullURL := clirpc.IntegratedUptimeURL(utURL)
 
 		// --- Fetch SD ---
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)
@@ -389,6 +389,9 @@ var listCmd = &cobra.Command{
 		// --- Show only offline servers ---
 		if showOffline {
 			uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+			if uts == "" {
+				uts = "[]"
+			}
 
 			// Parse SD and UT data
 			var sdEntries []services.Service
@@ -533,6 +536,9 @@ var listCmd = &cobra.Command{
 
 		// --- Filtering by online status ---
 		uts := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirUT, utFullURL), utFullURL, cacheFilesAge)
+		if uts == "" {
+			uts = "[]"
+		}
 
 		// Use Go-based filtering when minVersion or maxVersion is specified (jq can't do semver comparison)
 		if minVersion != "" || maxVersion != "" {


### PR DESCRIPTION
## Problem

The standalone **Uptime Tracker** (PK `022c424c…`, `dmsg://…:80/uptimes?v=v2`) is offline on the deployment. Every CLI command that read the "online visor" set from it broke — most visibly `skywire cli pv -t`, which dialed the dead delegated server, got `dmsg error 202 - cannot connect to delegated server`, then built invalid JSON (`{"sd":…,"ut":}`) from the empty result and printed nothing.

## Fix

Route **all** CLI uptime queries to the **TPD-integrated uptime tracker**: the transport-discovery base with `?v=v3`, which `cxoFeedForURL` already mirrors over CXO (feed `tpd-uptime`, path `uptimes/days/30`). Fetches now flow through the existing CXO→DMSG→HTTP chain and never touch the decommissioned service.

`/uptimes?v=v3` is a **strict superset** of `v2` — every entry still carries `{pk, on, version, daily}`, with the per-day timeline bitmap added (confirmed in `pkg/transport-discovery/api/endpoints.go` `getUptimesV3`). So the existing jq `select(.on) | .pk` filters and the `ut` command's daily-percentage logic keep working unchanged; there was **no v2→v3 payload adaptation needed** at any consumer.

### Shared helper (`cmd/skywire-cli/commands/rpc/root.go`)

- `IntegratedUptimeURL(tpdBase)` — builds `<tpd>/uptimes?v=v3` (empty base → prod).
- `FetchIntegratedUptimes(flags, tpdBase, cachefile, age)` — fetches the `[]VisorSummary` v3 payload via the shared cached fetch chain.

### Sites converted

- **Dead-PK sites** (were dialing `deployment.*.UptimeTracker` → the `022c424c…` PK): `pv`, `sd`, `ut`, `vpn list`, `proxy list`/`test`, `visor whois`, `log`. Repointed `--uturl`/`--url`/`--ut` flag defaults, `--testenv` overrides and cache dirs from `deployment.*.UptimeTracker` to `*.TransportDiscovery`.
- **Already-integrated-but-v2 sites** (`tp`, `tp tree`, `tp viz`/visor, `tp add pv`): bumped v2→v3 through the shared helper so they too ride the CXO feed.
- Dropped the always-red standalone-UT row from `cli svc health` (the service is decommissioned; TPD-integrated uptime rides the Transport Discovery row).
- Fixed a latent bug in `log`'s visor-filtered endpoint (it dropped the `/uptimes` path when `--pks` was set).

### Graceful degradation

Every jq-join consumer now guards an empty fetch (`uts == "" → "[]"`), so an offline tracker degrades to "no online visors" instead of emitting invalid JSON.

## Verification

`skywire cli pv -t` now works end-to-end against the live deployment — the debug trace shows it fetching `dmsg://02b307…:80/uptimes?v=v3` (feed `tpd-uptime`) and `all-transports` (feed `tpd-all-transports`), then printing the public-visor + transport-count list sorted descending. No reference to the `022c424c…` PK remains in any converted command.

- `go build ./...` passes
- `go vet ./cmd/skywire-cli/...` clean
- `cmd/skywire-cli/commands/rpc` tests pass
- `make format` (goimports-reviser) applied

## Notes / out of scope

- `rewards/runday.go` + `rewards/server/htmpl.go` still reference `/uptimes?v=v2`, but against the **live** TPD base (`deployment.Prod.TransportDiscovery`), not the dead standalone PK — left as-is to keep the reward-calc surface untouched.
- `cmd/skywire-cli/cliuptime` (`ut tpd`/`ut sd`/`ut mdisc`) already targets the live integrated discoveries and needed no change.
- `deployment/services-config.json` / `data_static_js.go` (`uptime_tracker_dmsg`) and the `DmsgURLForHTTP` mapping entry are left structurally intact — the visor's own config parsing depends on them; the CLI simply no longer dials that PK.
- `visor whois` renders its uptime block via the visor RPC `FetchUptimeTrackerData` (visor-side config), not the CLI `--ut` flag; the flag default was still repointed to purge the dead-PK reference.