### PR TITLE
feat(cli): pv -y — break public-visor transport counts down by type

### DIFF
--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -19,6 +19,7 @@ import (
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/servicedisc"
 	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 	version        string
 	isStats        bool
 	showTransports bool
+	showByType     bool
 	minTransports  int
 	testEnv        bool
 )
@@ -118,6 +120,7 @@ func init() {
 	RootCmd.Flags().StringVarP(&version, "version", "v", "", "filter by version")
 	RootCmd.Flags().BoolVarP(&isStats, "stats", "s", false, "return only a count of the results")
 	RootCmd.Flags().BoolVarP(&showTransports, "transports", "t", false, "show transport count per visor")
+	RootCmd.Flags().BoolVarP(&showByType, "bytype", "y", false, "break the transport count down by type (implies -t): total + per-type columns")
 	RootCmd.Flags().IntVarP(&minTransports, "min", "n", 0, "minimum transport count (requires -t)")
 	RootCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
 	clirpc.RegisterFetchFlags(RootCmd)
@@ -138,6 +141,10 @@ Set cache dir to "" to disable caching for that service.
 
 Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment().ServiceDiscovery, serviceType),
 	Run: func(cmd *cobra.Command, _ []string) {
+		// --bytype is a richer form of --transports; it needs the same TPD fetch.
+		if showByType {
+			showTransports = true
+		}
 		// Handle --testenv flag: override URLs and cache dirs that weren't explicitly set
 		if testEnv && !isTestEnv() {
 			// --testenv was specified at runtime (not via SKYWIRETEST env)
@@ -254,15 +261,24 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("failed to parse transport discovery data: %w", err))
 		}
 
-		// Count transports per PK
+		// Count transports per PK (and per type when --bytype is set).
 		tpCount := make(map[string]int)
+		tpByType := make(map[string]map[types.Type]int)
 		for _, entry := range entries {
 			// Skip self-transports
 			if entry.Edges[0] == entry.Edges[1] {
 				continue
 			}
-			tpCount[entry.Edges[0].String()]++
-			tpCount[entry.Edges[1].String()]++
+			for _, edge := range entry.Edges {
+				pk := edge.String()
+				tpCount[pk]++
+				if showByType {
+					if tpByType[pk] == nil {
+						tpByType[pk] = make(map[types.Type]int)
+					}
+					tpByType[pk][entry.Type]++
+				}
+			}
 		}
 
 		// Build result with transport counts
@@ -287,6 +303,21 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 			internal.PrintOutput(cmd.Flags(), struct {
 				Count int `json:"count"`
 			}{Count: len(results)}, fmt.Sprintf("%d\n", len(results)))
+			return
+		}
+
+		if showByType {
+			// Stable columns in preference order (stcpr squicr sudph stcp
+			// webrtc swsr swtr dmsg), each printed even when zero, so the
+			// output is a fixed-width table friendly to awk/graphing.
+			order := types.PreferenceOrder()
+			for _, r := range results {
+				line := fmt.Sprintf("%s total=%d", r.pk, r.count)
+				for _, t := range order {
+					line += fmt.Sprintf(" %s=%d", t, tpByType[r.pk][t])
+				}
+				fmt.Println(line)
+			}
 			return
 		}
 


### PR DESCRIPTION
`pv -t` shows only a total transport count per public visor. Add **`-y`/`--bytype`** (implies `-t`) to break it down by transport type — so you can see e.g. that a visor’s 451 transports are 437 sudph + 14 stcpr, or that another’s 137 are a diverse stcpr/squicr/sudph/webrtc mix.

Output is a fixed-column table in preference order, each type printed even when zero — friendly to `awk`/graphing:

```
<pk> total=451 stcpr=14 squicr=0 sudph=437 stcp=0 webrtc=0 swsr=0 swtr=0 dmsg=0
```

Aggregated from the same TPD `/all-transports` data `pv -t` already fetches (each `transport.Entry` carries its `Type`); `total` equals the sum of the per-type columns. Combine with `-m0` for live data (e.g. `watch -n10 skywire cli pv -t -y -m0`).

Validated: `go build .`; live `pv -t -y -n50 -m0` prints the table; `total` == sum-of-types confirmed by awk.