### PR TITLE
fix(cli): pv fetches uptimes/days/1, not days/30 (online filter only)

### DIFF
--- a/cmd/skywire-cli/commands/pv/pv.go
+++ b/cmd/skywire-cli/commands/pv/pv.go
@@ -168,7 +168,9 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`, getDeployment(
 		// TPD-integrated (CXO-backed v3), so there is no separate uptime
 		// endpoint or cache — never the deprecated standalone tracker.
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := clirpc.IntegratedUptimeURL(tpdURL)
+		// pv only filters by the online flag, so request the 1-day uptime
+		// window (still carries .on) instead of the 30-day daily bitmap.
+		utFullURL := clirpc.IntegratedUptimeURLDays(tpdURL, 1)
 		tpdFullURL := tpdURL + "/all-transports"
 
 		// Fetch SD

--- a/cmd/skywire-cli/commands/rpc/root.go
+++ b/cmd/skywire-cli/commands/rpc/root.go
@@ -554,7 +554,16 @@ func cxoFeedForURL(rawURL string) (feed, path string, ok bool) {
 		// gain anything from CXO over the existing chain since the
 		// payload is small.
 		if v := queryParam(rawURL, "v"); v == "v3" {
-			return "tpd-uptime", "uptimes/days/30", true
+			// Honor an explicit &days=N (the publisher writes {1,7,30});
+			// default to 30 when omitted, for back-compat with the graph
+			// commands. Online-filter callers (pv/sd/proxy) pass days=1 —
+			// they read only .on, so the 30-day daily bitmap per visor is
+			// ~30x the payload they never look at.
+			days := queryParamInt(rawURL, "days", 30)
+			if days != 1 && days != 7 && days != 30 {
+				days = 30
+			}
+			return "tpd-uptime", fmt.Sprintf("uptimes/days/%d", days), true
 		}
 		return "", "", false
 	}
@@ -809,10 +818,21 @@ func FetchCachedServiceURL(cmdFlags *pflag.FlagSet, cachefile, thisurl string, c
 // that only read the online flag or the daily percentages therefore
 // work against the v3 payload unchanged.
 func IntegratedUptimeURL(tpdBase string) string {
+	return IntegratedUptimeURLDays(tpdBase, 30)
+}
+
+// IntegratedUptimeURLDays is IntegratedUptimeURL with an explicit uptime
+// window: days ∈ {1,7,30}, the buckets the TPD publishes (uptimes/days/<n>).
+// Callers that only read the online flag (pv / sd / proxy filtering) pass
+// days=1 — the .on flag is present in every window, so pulling the 30-day
+// daily bitmap for every visor is pure over-fetch. Daily-percentage callers
+// (the `ut` command) pass a wider window. An unknown value falls back to 30
+// in cxoFeedForURL.
+func IntegratedUptimeURLDays(tpdBase string, days int) string {
 	if tpdBase == "" {
 		tpdBase = deployment.Prod.TransportDiscovery
 	}
-	return strings.TrimRight(tpdBase, "/") + "/uptimes?v=v3"
+	return fmt.Sprintf("%s/uptimes?v=v3&days=%d", strings.TrimRight(tpdBase, "/"), days)
 }
 
 // FetchIntegratedUptimes fetches the []VisorSummary v3 payload from the


### PR DESCRIPTION
`pv` only filters public visors by the **online flag**, but its `/uptimes?v=v3` fetch mapped to the CXO leaf `uptimes/days/30` — pulling **30 days of per-visor daily timeline bitmaps it never reads** (~30× the payload it needs). The TPD already publishes `{1,7,30}`-day windows and the `.on` flag is present in all of them.

- `cxoFeedForURL`’s `/uptimes` branch now honors an explicit `&days=N` (mirroring the `/metrics` branch it sits next to), defaulting to 30 for back-compat with the graph commands.
- Add `IntegratedUptimeURLDays(base, days)`; `IntegratedUptimeURL` stays `days=30`.
- `pv` uses `days=1`.

Verified: `pv -t -m0` now fetches `feed=tpd-uptime path=uptimes/days/1` and prints the same online-filtered visor/transport-count list. The daily-percentage consumer (`ut`) is unchanged (`days=30`). (`sd`/`proxy`/`vpn` online-filter callers could adopt `days=1` too — trivial follow-up.)