### PR TITLE
fix(cli): sd/proxy/vpn fetch uptimes/days/1, not days/30

### DIFF
--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -619,7 +619,7 @@ var listCmd = &cobra.Command{
 
 		// Build full URLs
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := clirpc.IntegratedUptimeURL(utURL)
+		utFullURL := clirpc.IntegratedUptimeURLDays(utURL, 1)
 
 		// --- Fetch SD ---
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)

--- a/cmd/skywire-cli/commands/sd/root.go
+++ b/cmd/skywire-cli/commands/sd/root.go
@@ -173,7 +173,7 @@ Use --testenv or SKYWIRETEST=1 to use test deployment services.`,
 		sdVpnURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVPN
 		sdVisorURL := sdURL + "/api/services?type=" + servicedisc.ServiceTypeVisor
 		tpdFullURL := tpdURL + "/all-transports"
-		utFullURL := clirpc.IntegratedUptimeURL(utURL)
+		utFullURL := clirpc.IntegratedUptimeURLDays(utURL, 1)
 
 		// Fetch service discovery data for all service types
 		proxyData := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdProxyURL), sdProxyURL, cacheFilesAge)

--- a/cmd/skywire-cli/commands/vpn/vvpn.go
+++ b/cmd/skywire-cli/commands/vpn/vvpn.go
@@ -313,7 +313,7 @@ var listCmd = &cobra.Command{
 
 		// Build full URLs
 		sdFullURL := sdURL + "/api/services?type=" + serviceType
-		utFullURL := clirpc.IntegratedUptimeURL(utURL)
+		utFullURL := clirpc.IntegratedUptimeURLDays(utURL, 1)
 
 		// --- Fetch SD ---
 		sds := clirpc.FetchCachedServiceURL(cmd.Flags(), cacheFile(cacheDirSD, sdFullURL), sdFullURL, cacheFilesAge)


### PR DESCRIPTION
Follow-up to #3772. `sd`, `proxy list`, and `vpn list` filter public services purely by the online flag, but their `/uptimes?v=v3` fetch mapped to the 30-day CXO leaf — pulling daily timeline bitmaps they never read. Switch all three to `IntegratedUptimeURLDays(utURL, 1)`; the `.on` flag is present in the 1-day window. The daily-percentage command (`ut`) stays `days=30`.