### PR TITLE
feat(dmsg): advertise the server build version in its discovery entry

### DIFF
--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -58,6 +58,12 @@ type EntityCommon struct {
 
 	updateInterval time.Duration // Minimum duration between discovery entry updates.
 
+	// serverVersion, when non-empty, overrides the disc.Entry.Version a dmsg
+	// SERVER advertises (default "0.0.1") with its real build version. Set once
+	// from ServerConfig.Version in NewServer; read-only afterward. Empty for
+	// clients and for servers that don't set it (keeps "0.0.1").
+	serverVersion string
+
 	// advertisedMx guards the advertised{UDP,WS,WT}Addr / advertisedWTCertHash
 	// fields below. They are written by the Serve{QUIC,WS,WebTransport}
 	// goroutines, which start after Serve's entry-update loop is already reading
@@ -522,6 +528,9 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 		entry = disc.NewServerEntry(c.pk, 0, addr, availableSessions)
 		entry.Server.AddressV6 = addrV6
 		entry.Server.DHTBootstrap = c.dhtBootstrap
+		if c.serverVersion != "" {
+			entry.Version = c.serverVersion
+		}
 		if err := entry.Sign(c.sk); err != nil {
 			return err
 		}
@@ -548,9 +557,10 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 		wtCertHashHex = hex.EncodeToString(advWTCertHash[:])
 	}
 	wtDelta := entry.Server.AddressWT != advWTAddr || entry.Server.CertHashWT != wtCertHashHex
+	versionDelta := c.serverVersion != "" && entry.Version != c.serverVersion
 
 	// No update needed if entry has no delta AND update is not due.
-	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !wtDelta && !due {
+	if _, due := c.updateIsDue(); !sessionsDelta && !addrDelta && !addrV6Delta && !udpDelta && !wsDelta && !wtDelta && !versionDelta && !due {
 		return nil
 	}
 
@@ -592,6 +602,10 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 		entry.Server.AddressWT = advWTAddr
 		entry.Server.CertHashWT = wtCertHashHex
 		log = log.WithField("addr_wt", entry.Server.AddressWT)
+	}
+	if versionDelta {
+		entry.Version = c.serverVersion
+		log = log.WithField("entry_version", entry.Version)
 	}
 	// Propagate DHT bootstrap status to discovery entry.
 	entry.Server.DHTBootstrap = c.dhtBootstrap

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -34,6 +34,16 @@ type ServerConfig struct {
 	AuthPassphrase string
 	Peers          []PeerEntry
 
+	// Version, when non-empty, is advertised as this server's discovery
+	// entry Version (disc.Entry.Version) in place of the vestigial "0.0.1"
+	// protocol constant — nothing checks the entry version for protocol
+	// compatibility (only that it is non-empty), so the field is free to
+	// carry the server's real build version, which then shows in the
+	// discovery /all_servers listing and `skywire cli mdisc servers`. The
+	// caller (pkg/services/dmsgsrv) sets it to buildinfo.Version(), keeping
+	// pkg/dmsg decoupled from skywire's buildinfo. Empty preserves "0.0.1".
+	Version string
+
 	// AnnounceAsPeer makes this server send a signed PeerAnnounce on
 	// every outbound peer link it dials, asking the remote to treat
 	// this server as a forwardable peer. Used by a non-public server
@@ -128,6 +138,7 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 
 	s := new(Server)
 	s.EntityCommon.init(pk, sk, dc, log, conf.UpdateInterval)
+	s.EntityCommon.serverVersion = conf.Version
 	s.m = m
 	s.ready = make(chan struct{})
 	s.done = make(chan struct{})

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -86,6 +86,17 @@ type Config struct {
 	MetricsAddr string `json:"metrics_addr,omitempty"`
 }
 
+// dmsgEntryVersion returns the build version to advertise in the dmsg server's
+// discovery entry, or "" when the binary carries no meaningful version (dev
+// builds) so the entity keeps the "0.0.1" default. Uses runtime/debug build
+// info via buildinfo — the same source the /health endpoint reports.
+func dmsgEntryVersion() string {
+	if v := buildinfo.Version(); v != "" && v != "unknown" {
+		return v
+	}
+	return ""
+}
+
 // LoadFile reads a standalone dmsg-server JSON config file (the
 // existing `skywire dmsg server start /path/to/file.json` shape).
 // Returned for callers (the multi-service factory) that want to
@@ -193,8 +204,13 @@ func (s *service) Run(ctx context.Context) error {
 	}
 
 	srvConf := dmsg.ServerConfig{
-		MaxSessions:             cfg.MaxSessions,
-		UpdateInterval:          cfg.UpdateInterval,
+		MaxSessions:    cfg.MaxSessions,
+		UpdateInterval: cfg.UpdateInterval,
+		// Advertise the real build version in the server's discovery entry
+		// (disc.Entry.Version) instead of the vestigial "0.0.1" protocol
+		// constant, so `mdisc servers` / discovery consumers see it. Empty
+		// (unknown build) preserves "0.0.1".
+		Version:                 dmsgEntryVersion(),
 		AuthPassphrase:          s.cfg.AuthPassphrase,
 		Peers:                   peers,
 		AnnounceAsPeer:          cfg.AnnounceAsPeer,


### PR DESCRIPTION
dmsg `disc.Entry.Version` was a vestigial protocol constant `"0.0.1"` — **nothing checks it for protocol compatibility** (`Entry.Validate` only requires it non-empty; `ValidateIteration` checks Sequence+Timestamp; the sole other reader is `entryContentEqual`, CXO republish change-detection). So `mdisc servers` and every discovery consumer showed `0.0.1` for every server, never the real build version — only obtainable via a separate, sometimes-unreachable `/health`-over-dmsg probe.

Carry the build version there instead:
- `dmsg.ServerConfig` gains a `Version` field (empty preserves `"0.0.1"`).
- `pkg/services/dmsgsrv` sets it to `buildinfo.Version()` (runtime/debug build info — same source `/health` reports), keeping `pkg/dmsg` **decoupled** from skywire’s `buildinfo`.
- The registration cycle stamps it on both create and update paths (a `versionDelta` makes an already-registered entry converge on the next heartbeat after an upgrade).

Now `skywire cli mdisc servers` shows each server’s real version straight from `/all_servers`, no probe. **`cli svc health` deliberately keeps its DIRECT `/health` probe** of every service and dmsg server — that direct check is what catches an *unreachable* server (the issue we are separately chasing), which reading the entry version would mask.

`GOOS=js` build of `pkg/dmsg` stays green (no buildinfo import leaked in); dmsg entity/server tests pass. Takes effect as the dmsg-server fleet is redeployed.