### PR TITLE
fix(dmsg-server): transit client reaches its own server via loopback

### DIFF
--- a/pkg/dmsg/dmsg/self_session_test.go
+++ b/pkg/dmsg/dmsg/self_session_test.go
@@ -1,0 +1,100 @@
+// Package dmsg pkg/dmsg/dmsg/self_session_test.go
+package dmsg
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// TestSelfSession_SameKeyClientReachesOwnServer validates the load-bearing
+// assumption behind the dmsg-server transit-client loopback fix: a dmsg CLIENT
+// whose keypair is IDENTICAL to a co-located dmsg SERVER can still form a normal
+// session with that server (the Noise-XK handshake with initiator==responder
+// static key is valid, and the accept path has no self-PK guard), AND that
+// server can relay an inbound stream from a THIRD client to the same-key client's
+// listener — i.e. "reach the server → reach its co-located direct client".
+func TestSelfSession_SameKeyClientReachesOwnServer(t *testing.T) {
+	dc := disc.NewMock(0)
+
+	// One keypair shared by the server and its co-located "transit" client.
+	pk, sk := GenKeyPair(t, "self")
+
+	srv := NewServer(pk, sk, dc, &ServerConfig{MaxSessions: 10, UpdateInterval: 0}, nil)
+	srv.SetLogger(logging.MustGetLogger("self_server"))
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := lis.Addr().String()
+	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
+
+	// Server entry advertises the loopback listener (as the production fix does).
+	srvEntry := disc.NewServerEntry(pk, 0, addr, 10)
+	require.NoError(t, srvEntry.Sign(sk))
+	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	// The transit client shares the server's keypair. It must NOT register (in
+	// production it's a direct client) — MinSessions:0 = connect to all known
+	// servers, and it resolves the server entry above from the shared mock.
+	transit := NewClient(pk, sk, dc, &Config{MinSessions: 0})
+	transit.SetLogger(logging.MustGetLogger("self_transit"))
+	go transit.Serve(context.Background()) //nolint:errcheck
+
+	// The same-key client forms a session with its OWN server.
+	require.Eventually(t, func() bool {
+		_, ok := transit.Session(pk)
+		return ok
+	}, 15*time.Second, 200*time.Millisecond, "same-key transit client failed to hold a session to its own server")
+
+	// The transit client accepts inbound streams on port 80 (its /health analog).
+	const port = 80
+	lisT, err := transit.Listen(port)
+	require.NoError(t, err)
+	defer lisT.Close() //nolint:errcheck
+
+	// A third client reaches the transit client THROUGH the shared server. It
+	// seeds the transit PK as a client delegated to the server (mirrors how the
+	// deployment services are reached: seeded, no discovery lookup).
+	pkC, skC := GenKeyPair(t, "third")
+	third := NewClient(pkC, skC, dc, DefaultConfig())
+	third.SetLogger(logging.MustGetLogger("third"))
+	third.SeedEntryCache(pk, &disc.Entry{
+		Version: "0.0.1",
+		Static:  pk,
+		Client:  &disc.Client{DelegatedServers: []cipher.PubKey{pk}},
+	})
+	go third.Serve(context.Background()) //nolint:errcheck
+
+	// Accept on the transit side.
+	accepted := make(chan error, 1)
+	go func() {
+		s, aerr := lisT.AcceptStream()
+		if aerr != nil {
+			accepted <- aerr
+			return
+		}
+		defer s.Close() //nolint:errcheck
+		accepted <- nil
+	}()
+
+	var stream *Stream
+	require.Eventually(t, func() bool {
+		var derr error
+		stream, derr = third.DialStream(context.TODO(), Addr{PK: pk, Port: port})
+		return derr == nil
+	}, 15*time.Second, 200*time.Millisecond, "third client could not dial the same-key transit client through its own server")
+	defer stream.Close() //nolint:errcheck
+
+	select {
+	case aerr := <-accepted:
+		require.NoError(t, aerr, "transit client failed to accept the relayed stream")
+	case <-time.After(10 * time.Second):
+		t.Fatal("transit client never accepted the relayed stream (server did not relay to its co-located same-key client)")
+	}
+}

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -605,11 +605,28 @@ func (s *service) buildTransitDmsg(ctx context.Context, deployments []dmsgserver
 	cfg := &s.cfg.Config
 	log := s.log
 
+	// The transit client (MinSessions:0) connects to ALL servers in this list,
+	// INCLUDING itself. Point its OWN entry at the LOOPBACK listener, not the
+	// public address: dialing the public address is a NAT hairpin (a container
+	// dialing its own external IP:port back into itself), which fails on typical
+	// Docker/NAT hosts — so the server held no session for its own co-located
+	// transit client, and a remote dial to <serverPK>:80 relayed through THIS
+	// server (the discovery-resolved path svc-health uses) found no local client
+	// session and timed out (blank version column). Loopback is in-kernel — no
+	// NAT, no external port, no hairpin — so the self-session forms and the
+	// server can relay its own dmsg-side surfaces (/health, pprof, route-setup)
+	// to the co-located transit client. Reachability via the 8 peer servers is
+	// unchanged; this only ADDS the local path. Falls back to the public address
+	// if LocalAddress has no parseable port.
+	selfAddr := cfg.PublicAddress
+	if _, port, perr := net.SplitHostPort(cfg.LocalAddress); perr == nil && port != "" {
+		selfAddr = net.JoinHostPort("127.0.0.1", port)
+	}
 	serverEntry := &disc.Entry{
 		Version: "0.0.1",
 		Static:  cfg.PubKey,
 		Server: &disc.Server{
-			Address:           cfg.PublicAddress,
+			Address:           selfAddr,
 			AvailableSessions: cfg.MaxSessions,
 		},
 	}


### PR DESCRIPTION
A dmsg server runs a co-located transit dmsg **client** (same PK) serving its dmsg-side surfaces — `/health`, pprof, route-setup — on dmsg port 80. That client is a deployment service: **unregistered in discovery**, reachable via seeded delegated-servers. The transit client (`MinSessions:0` = connect to **all** servers) includes **itself**, but its self-entry used the server’s **public** address — so the self-dial was a **NAT hairpin** (a container dialing its own external IP:port back into itself), which fails on typical Docker/NAT hosts. The server therefore held **no session for its own transit client**.

**Consequence:** a remote dial to `dmsg://<serverPK>:80` that resolves the PK via discovery gets the **server** entry and routes through the server’s own session — which has no local transit-client session → timeout. That’s why `svc health` showed a **blank version** for such servers (their `/health`-over-dmsg probe timed out) despite being current + healthy — and it was per-server inconsistent.

**Fix:** point the transit client’s **own** entry at the **loopback** listener (`127.0.0.1:<local port>`) instead of the public address. Loopback is in-kernel — no NAT, no external port, no hairpin — so the self-session forms and the server can relay `<serverPK>:80` straight to its co-located transit client. Reachability via the other servers is unchanged; this only **adds** the local path, and reuses the entire tested TCP dial/handshake/register/serve path (no new session concurrency — a `net.Pipe` variant risks yamux deadlock on an unbuffered pipe).

**Validated** by `TestSelfSession_SameKeyClientReachesOwnServer`: a client sharing the server’s keypair forms a session with its own server (Noise-XK with initiator==responder static key is valid; the accept path has no self-PK guard), and a third client’s stream to `<PK>:80` is relayed through that server to the co-located same-key client’s listener. Full dmsg suite green; `GOOS=js` green. Takes effect as the dmsg-server fleet is redeployed; then `svc health` version populates for every server directly.