### PR TITLE
fix(cxo): TPD aggregator feed leak + dmsg-disc encode-cache + shared conn reaper

### DIFF
--- a/pkg/cxo/node/conn.go
+++ b/pkg/cxo/node/conn.go
@@ -119,20 +119,11 @@ func (c *Conn) run() {
 		}
 	}()
 
-	// Idle watchdog — closes the Conn when receiveMsg hasn't seen
-	// inbound traffic for idleWatchdogThreshold. Targets the
-	// half-dead-underlying-transport case where the dmsg session is
-	// gone but io.ReadFull never returns an error (no FIN/RST
-	// propagation). Without this, reconnect attempts keep hitting
-	// PR #2643's connIsAlive check returning true (closeq still open,
-	// transport.IsClosed false) and getting back the same zombie Conn.
-	// Pairs with #2643: that PR evicts on next ConnectPK; this one
-	// makes sure the Conn actually goes dead so the eviction fires.
-	c.await.Add(1)
-	go func() {
-		defer c.await.Done()
-		c.idleWatchdog()
-	}()
+	// The idle watchdog that closes a Conn after idleWatchdogThreshold
+	// of silence (half-dead-transport case: dmsg session gone but
+	// io.ReadFull never errors) is no longer per-conn. One shared
+	// Node.connReaper walks all active conns on the same interval —
+	// same detection guarantee, minus a goroutine+ticker per conn.
 
 	// If OnConnect returns error, connection will be closed.
 	var occErr error
@@ -199,43 +190,11 @@ const (
 	idleWatchdogInterval  = 30 * time.Second
 )
 
-// idleWatchdog periodically checks whether receiveMsg has observed
-// any inbound traffic recently. Closes the Conn when activity has
-// been silent past idleWatchdogThreshold, on the assumption that a
-// healthy CXO peer with an active subscription would emit at least
-// heartbeats. Closing the Conn surfaces to PR #2643's connIsAlive
-// gate on the next ConnectPK call, which evicts the cached entry
-// and re-dials fresh.
-//
-// Exits cleanly on closeq close (either Close() called externally
-// or receiveMsg observed its own error). No-op call to Close on
-// closeq-already-signaled paths; idempotent.
-func (c *Conn) idleWatchdog() {
-	t := time.NewTicker(idleWatchdogInterval)
-	defer t.Stop()
-	for {
-		select {
-		case <-c.closeq:
-			return
-		case <-t.C:
-			last := c.lastActivityNs.Load()
-			if last == 0 {
-				// Watchdog ticked before receiveMsg seeded lastActivityNs.
-				// Skip this tick — receiveMsg seeds the timestamp on
-				// entry, so by the next tick we'll have a real value
-				// (or the Conn will have closed if receive errored).
-				continue
-			}
-			idle := time.Since(time.Unix(0, last))
-			if idle < idleWatchdogThreshold {
-				continue
-			}
-			c.n.Debugf(ConnPin, "[%s] idle watchdog: %s since last inbound, closing", c.String(), idle)
-			c.Close() //nolint:errcheck,gosec
-			return
-		}
-	}
-}
+// The idle-connection watchdog now lives at the Node level as the
+// single shared Node.connReaper goroutine (node.go); the per-Conn
+// idleWatchdog method it replaced cost one goroutine + one time.Ticker
+// per connection. lastActivityNs (seeded/bumped by receiveMsg) and the
+// idleWatchdog* constants remain here as the reaper's inputs.
 
 func (c *Conn) decodeRaw(raw []byte) (seq, rseq uint32, m msg.Msg, err error) {
 

--- a/pkg/cxo/node/node.go
+++ b/pkg/cxo/node/node.go
@@ -109,6 +109,12 @@ type Node struct {
 
 	await  sync.WaitGroup // wait for goroutines
 	closeo sync.Once      // close once
+
+	// reaperStop signals the shared idle-conn reaper to exit. Closed
+	// once, in Close(). One reaper goroutine per Node replaces the
+	// former per-Conn idle watchdog (which cost one goroutine + one
+	// time.Ticker per connection — hundreds each on the TPD aggregator).
+	reaperStop chan struct{}
 }
 
 // NewNode creates new Node instance using provided
@@ -177,6 +183,7 @@ func NewNodeContainer(
 
 	n.conns = newAddrConnMap()
 	n.pkConns = newPkConnMap()
+	n.reaperStop = make(chan struct{})
 
 	n.ss = make(map[cipher.PubKey]*Swarm)
 
@@ -226,6 +233,12 @@ func NewNodeContainer(
 	}
 
 	// Pings are handled at node level; per-connection pings would improve health granularity.
+
+	// One shared idle-conn reaper for the whole Node, replacing the
+	// former per-Conn watchdog goroutine+ticker. Registered on n.await
+	// so Close() (which closes reaperStop, then Waits) reaps it.
+	n.await.Add(1)
+	go n.connReaper()
 
 	return n, err
 }
@@ -852,11 +865,57 @@ func (n *Node) Close() (err error) {
 		// Close database.
 		err = n.c.Close() //nolint:errcheck,gosec
 
+		// Stop the shared idle-conn reaper and wait for it (plus any
+		// other n.await goroutines) to exit.
+		close(n.reaperStop)
 		n.await.Wait()
 
 	})
 
 	return err
+}
+
+// connReaper is the shared idle-connection watchdog for the whole
+// Node. It replaces the former per-Conn idleWatchdog goroutine+ticker:
+// a single ticker walks every active Conn and closes any whose last
+// inbound activity is older than idleWatchdogThreshold. Closing a Conn
+// surfaces to PR #2643's connIsAlive gate on the next ConnectPK, which
+// evicts the zombie and re-dials fresh — the half-dead-transport case
+// the per-conn watchdog was built for (see the idleWatchdog* consts).
+//
+// Worst-case detection latency is unchanged (threshold + interval =
+// 120s) since the shared ticker uses the same interval. Runs until
+// reaperStop is closed (Node.Close). c.Close() is idempotent and
+// lastActivityNs is atomic, so acting on a conn that is concurrently
+// shutting down is a harmless no-op, and a conn removed from the active
+// map between snapshot and callback simply isn't visited.
+func (n *Node) connReaper() {
+	defer n.await.Done()
+	t := time.NewTicker(idleWatchdogInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-n.reaperStop:
+			return
+		case <-t.C:
+			now := time.Now()
+			n.conns.rangeActive(func(c *Conn) {
+				last := c.lastActivityNs.Load()
+				if last == 0 {
+					// receiveMsg hasn't seeded lastActivityNs yet — skip
+					// this tick; a real value lands before the next one
+					// (or the conn closes if receive errored).
+					return
+				}
+				idle := now.Sub(time.Unix(0, last))
+				if idle < idleWatchdogThreshold {
+					return
+				}
+				n.Debugf(ConnPin, "[%s] idle watchdog: %s since last inbound, closing", c.String(), idle)
+				c.Close() //nolint:errcheck,gosec
+			})
+		}
+	}
 }
 
 func (n *Node) JoinSwarm(

--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	skycipher "github.com/skycoin/skycoin/src/cipher"
@@ -98,7 +99,27 @@ type memNode struct {
 	// cached on every node along the path from the root.
 	pubHash skycipher.SHA256
 	cached  bool
+
+	// mutSeq is a monotonic stamp bumped on every invalidation of this
+	// node (see invalidatePath). It lets publishIfDirty promote the
+	// encode-cache per-subtree instead of all-or-nothing: the snapshot
+	// clone copies mutSeq, encodeNode records it on each freshSub, and
+	// promotion only re-caches a subtree whose live mutSeq still matches
+	// the snapshot's — i.e. that specific subtree wasn't re-mutated
+	// during the publish. Without this, any single concurrent Put during
+	// the (multi-second) encode discarded the WHOLE freshSubs promotion,
+	// so under sustained churn (dmsg-discovery's ~160 reg/s) the cache
+	// never persisted and every publish re-serialized nearly the whole
+	// tree — the GC-bound CPU seen in production.
+	mutSeq uint64
 }
+
+// treeMutSeq is the process-wide monotonic source for memNode.mutSeq.
+// A single shared counter is fine: mutSeq values are only ever compared
+// to the same node's own earlier value, and any re-invalidation yields a
+// strictly larger stamp, so "changed since snapshot" is detected
+// regardless of which publisher produced the intervening bump.
+var treeMutSeq atomic.Uint64
 
 func newMemNode() *memNode {
 	return &memNode{
@@ -905,29 +926,40 @@ func (p *Publisher) publishIfDirty() error {
 	}
 
 	p.mu.Lock()
-	if p.dirtyGen == gen {
-		// No mutation landed during the publish. Promote freshSubs
-		// into the LIVE tree by path so the next publish can skip
-		// the encode walk for unchanged subtrees, then clear dirty.
-		for _, fs := range freshSubs {
-			n := walkLivePath(p.root, fs.path)
-			if n == nil {
-				// Path was concurrently removed despite dirtyGen
-				// matching — only possible if mutation went
-				// through a code path that forgot to call
-				// markDirty. Defensive: skip.
-				continue
-			}
-			n.cached = true
-			n.pubHash = fs.hash
+	// Promote freshSubs into the LIVE tree by path so the next publish
+	// can skip the encode walk for unchanged subtrees. This is done
+	// PER-SUBTREE: a freshSub is promoted only if the live node's mutSeq
+	// still equals the snapshot's, i.e. that specific subtree wasn't
+	// re-mutated during the publish. The previous all-or-nothing gate
+	// (promote everything iff p.dirtyGen == gen) discarded the entire
+	// promotion whenever a single Put landed anywhere during the
+	// multi-second encode — so under sustained churn the cache never
+	// persisted and every publish re-serialized nearly the whole tree.
+	// A subtree that WAS re-mutated has a bumped mutSeq (and cleared
+	// cached via invalidatePath), so skipping its promotion is correct:
+	// the next publish re-encodes it against the new state.
+	for _, fs := range freshSubs {
+		n := walkLivePath(p.root, fs.path)
+		if n == nil {
+			// Path was concurrently removed — the subtree is gone,
+			// nothing to cache.
+			continue
 		}
+		if n.mutSeq != fs.mutSeq {
+			// Re-mutated during the publish: the encoded hash reflects
+			// stale content. Leave cached=false so it re-encodes next tick.
+			continue
+		}
+		n.cached = true
+		n.pubHash = fs.hash
+	}
+	if p.dirtyGen == gen {
+		// No mutation landed during the publish — the live tree now
+		// matches what we just published, so it's clean.
 		p.dirty = false
 	}
-	// If dirtyGen != gen: a Put / Delete landed during publish.
-	// freshSubs encodes the SNAPSHOT's view of those subtrees,
-	// which no longer matches the live tree. Discard the
-	// promotion entirely — the next tick will re-encode against
-	// the new live state.
+	// If dirtyGen != gen a Put / Delete landed during publish; leave
+	// dirty set so runLoop republishes the new state on the next tick.
 	p.mu.Unlock()
 	return nil
 }
@@ -973,6 +1005,7 @@ func cloneMemNode(n *memNode) *memNode {
 		subs:    make(map[string]*memNode, len(n.subs)),
 		pubHash: n.pubHash,
 		cached:  n.cached,
+		mutSeq:  n.mutSeq,
 	}
 	for k, v := range n.leaves {
 		out.leaves[k] = v // share immutable leaf byte slice
@@ -1099,6 +1132,11 @@ func (p *Publisher) publishRoot(root *memNode) ([]freshSub, error) {
 type freshSub struct {
 	path []string
 	hash skycipher.SHA256
+	// mutSeq is the snapshot subtree's mutSeq at encode time. Promotion
+	// re-caches this subtree in the live tree only if the live node's
+	// mutSeq still equals this — i.e. it wasn't re-mutated during the
+	// publish. See memNode.mutSeq.
+	mutSeq uint64
 }
 
 // encodeNode walks a memNode and produces a TreeNode whose Children
@@ -1150,7 +1188,7 @@ func encodeNode(up registry.Pack, n *memNode, path []string, freshSubs *[]freshS
 				if err := entry.Sub.SetValue(up, &subNode); err != nil {
 					return TreeNode{}, err
 				}
-				*freshSubs = append(*freshSubs, freshSub{path: childPath, hash: entry.Sub.Hash})
+				*freshSubs = append(*freshSubs, freshSub{path: childPath, hash: entry.Sub.Hash, mutSeq: sub.mutSeq})
 			}
 		} else {
 			// Should not happen — memNode invariants keep names in
@@ -1298,13 +1336,18 @@ func pruneAt(root *memNode, segs []string) bool {
 	return true
 }
 
-// invalidatePath clears the encode-cache flag on every node in chain.
-// Called by the mutators after any successful structural change so the
-// next publish re-encodes the affected nodes (and re-uses cached
-// hashes on every untouched sibling subtree).
+// invalidatePath clears the encode-cache flag on every node in chain
+// and stamps each with a fresh mutSeq. Called by the mutators after any
+// successful structural change so the next publish re-encodes the
+// affected nodes (and re-uses cached hashes on every untouched sibling
+// subtree). The single shared mutSeq bump per invalidation lets
+// publishIfDirty tell, per subtree, whether it was touched during a
+// publish (see memNode.mutSeq).
 func invalidatePath(chain []*memNode) {
+	gen := treeMutSeq.Add(1)
 	for _, n := range chain {
 		n.cached = false
+		n.mutSeq = gen
 	}
 }
 

--- a/pkg/transport-discovery/cxoaggregator/aggregator.go
+++ b/pkg/transport-discovery/cxoaggregator/aggregator.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+
 	skycipher "github.com/skycoin/skycoin/src/cipher"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -204,7 +205,20 @@ type Aggregator struct {
 	// coalesce into a single pending reconcile (which is idempotent
 	// and walks the full conn set anyway).
 	nudge chan struct{}
+
+	// orphanStrikes counts consecutive cleanup ticks a shared feed has
+	// had no connected conn. A feed is reclaimed (un-shared + all its
+	// Roots deleted) once it reaches orphanGraceTicks, so a visor that
+	// briefly drops and redials within the grace window keeps its feed.
+	// Only touched from cleanup() (single goroutine), so no lock.
+	orphanStrikes map[skycipher.PubKey]int
 }
+
+// orphanGraceTicks is how many consecutive cleanup ticks a feed must
+// have zero connected conns before it's reclaimed. At the 2-minute
+// default CleanupInterval this is a ~4-minute grace, long enough to
+// ride out a visor's dmsg reconnect without churning a stable feed.
+const orphanGraceTicks = 2
 
 // New constructs an Aggregator. Sets up a CXO Node, enables DMSG so
 // remote visors can dial in, and wires OnRootFilled to walk
@@ -264,12 +278,13 @@ func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
 	}
 
 	a := &Aggregator{
-		cxoNode: cxoNode,
-		sink:    sink,
-		conf:    conf,
-		log:     conf.Logger,
-		done:    make(chan struct{}),
-		nudge:   make(chan struct{}, 1),
+		cxoNode:       cxoNode,
+		sink:          sink,
+		conf:          conf,
+		log:           conf.Logger,
+		done:          make(chan struct{}),
+		nudge:         make(chan struct{}, 1),
+		orphanStrikes: make(map[skycipher.PubKey]int),
 	}
 	// Subscribe to a visor's feed the moment it dials in, rather than
 	// waiting up to ReconcileInterval (30s) for the next poll. A fresh
@@ -395,8 +410,64 @@ func (a *Aggregator) cleanup() {
 		a.log.WithError(err).Debug("CXO aggregator: RemoveRootObjects failed; will retry next tick")
 		return
 	}
+	a.reclaimOrphanFeeds(c)
 	if err := cxoutils.RemoveObjects(c); err != nil {
 		a.log.WithError(err).Debug("CXO aggregator: RemoveObjects failed; will retry next tick")
+	}
+}
+
+// reclaimOrphanFeeds un-shares and hard-deletes feeds that no longer
+// have a connected conn. RemoveRootObjects(c, 1) keeps the LAST Root of
+// every feed forever, so without this a feed whose visor has gone away
+// (notably an ephemeral wasm/browser visor with a one-shot PK) pins its
+// final Root tree — and every object it references at rc>0 — in the
+// in-memory CXDS permanently. Over time the store grows without bound as
+// visor PKs churn (the +105 MB/12min inuse + 1576-goroutine growth seen
+// in production heap deltas). DontShare unsubscribes the conns and
+// removes the feed from the node's share set; DelFeed deletes all its
+// Roots and decrements the referenced objects to rc==0 so the following
+// RemoveObjects sweep can finally reclaim them.
+//
+// Reclamation is grace-gated (orphanGraceTicks) so a visor that drops
+// and redials within a few cleanup ticks keeps its feed rather than
+// paying a full re-replication.
+func (a *Aggregator) reclaimOrphanFeeds(c *skyobject.Container) {
+	connected := make(map[skycipher.PubKey]struct{})
+	for _, conn := range a.cxoNode.Connections() {
+		if pk := conn.PeerID(); pk != (skycipher.PubKey{}) {
+			connected[pk] = struct{}{}
+		}
+	}
+
+	self := a.cxoNode.ID()
+	for _, feed := range c.Feeds() {
+		if feed == self {
+			// The node's own identity feed — never reclaim it.
+			delete(a.orphanStrikes, feed)
+			continue
+		}
+		if _, ok := connected[feed]; ok {
+			// Live feed — clear any accumulated strikes.
+			delete(a.orphanStrikes, feed)
+			continue
+		}
+		a.orphanStrikes[feed]++
+		if a.orphanStrikes[feed] < orphanGraceTicks {
+			continue
+		}
+		delete(a.orphanStrikes, feed)
+		if err := a.cxoNode.DontShare(feed); err != nil {
+			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
+				Debug("CXO aggregator: DontShare orphan feed failed; will retry next tick")
+			continue
+		}
+		if err := c.DelFeed(feed); err != nil {
+			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
+				Debug("CXO aggregator: DelFeed orphan feed failed; will retry next tick")
+			continue
+		}
+		a.log.WithField("visor", cipher.PubKey(feed)).
+			Debug("CXO aggregator: reclaimed orphan feed (no connected conn)")
 	}
 }
 


### PR DESCRIPTION
Three independent CXO fixes for the memory-growth and CPU-saturation seen on the live deployment hosts (diagnosed via heap/goroutine profiles over the resolving proxy). Each is a separate commit.

### 1. `fix(tpd)`: reclaim orphaned CXO feeds (unbounded memory leak)
The transport-discovery aggregator subscribed to every visor's feed (`Node.Share`) but never released it. `RemoveRootObjects(c,1)` keeps each feed's **last** Root forever, so a feed whose visor has gone away — notably an ephemeral wasm/browser visor with a one-shot PK — pinned its final Root tree (and every object it referenced at `rc>0`) in the in-memory CXDS permanently. As visor PKs churn the store grows without bound.

**Evidence:** live heap delta on the TPD host: inuse **1128 → 1233 MB in 12 min (~+500 MB/hr)**, goroutines **2445 → 4021** (the extra goroutines are per-head fill actors of dead feeds).

**Fix:** `cleanup()` now reclaims feeds with no connected conn — `DontShare` then `Container.DelFeed` (deletes all Roots + decrements referenced objects to `rc==0` so the existing `RemoveObjects` sweep frees them). Grace-gated (`orphanGraceTicks`) so a visor that briefly drops and redials keeps its feed.

### 2. `fix(cxo)`: treestore encode-cache survives concurrent mutations (dmsg-disc CPU)
`publishIfDirty` only promoted freshly-encoded subtree hashes into the live encode-cache when `dirtyGen` was unchanged across the whole clone+encode+save window. Under dmsg-discovery's ~160 registrations/s a mutation always lands mid-encode, so promotion was discarded every cycle → the per-node cache never persisted → every publish re-serialized nearly the whole clients-by-server tree. That full-tree re-encode is the allocation storm behind dmsg-discovery's GC-bound CPU (~61% `runtime.scanObject`).

**Fix:** per-subtree promotion. Each `memNode` carries a `mutSeq` stamped on invalidation; the snapshot copies it and `encodeNode` records it per `freshSub`. A subtree is re-cached only if its live `mutSeq` still matches the snapshot's, so untouched `<server>` subtrees keep their cached hashes; concurrently-mutated ones re-encode next tick.

### 3. `perf(cxo)`: one shared idle-conn reaper instead of per-conn watchdog
Every CXO `Conn` spawned its own `idleWatchdog` goroutine + `time.Ticker` — hundreds each on the aggregator (~400 conns). One `Node.connReaper` now walks active conns via `conns.rangeActive` on the same interval; detection latency unchanged (threshold + interval = 120s). Removes one goroutine + one ticker per connection.

## Testing
- `go test -race ./pkg/cxo/node/ ./pkg/cxo/treestore/ ./pkg/transport-discovery/cxoaggregator/ ./pkg/cxo/cxoutils/ ./pkg/cxo/skyobject/` — all pass
- `go build ./...` clean
- Validated on a live hypervisor visor: CXO feeds (tpd-uptime 5.5 MB, tpd-all-transports 5.7 MB) sync cleanly after the node-reaper change; no regression.