### PR TITLE
fix(cxo): serve cold CXO snapshots + fix subscribe port collision (blank network-uptime page)

### DIFF
--- a/pkg/cxo/cxosub/manager.go
+++ b/pkg/cxo/cxosub/manager.go
@@ -171,6 +171,16 @@ type Manager struct {
 
 // managedFeed holds a single feed's runtime state.
 type managedFeed struct {
+	// syncMu serializes syncOnce for this feed. syncOnce binds a fixed
+	// per-feed dmsg port (feedSpec's port) for the lifetime of one
+	// subscribe→snapshot→close cycle; two concurrent syncOnce calls
+	// would collide with "dmsg listen on port N: port already occupied"
+	// and both fail. The cycleLoop goroutine and an explicit RefreshNow
+	// are independent callers, so without this lock a RefreshNow issued
+	// while the cycle's syncOnce is mid-flight breaks the feed. Held for
+	// the whole cycle so the port is free before the next caller binds it.
+	syncMu sync.Mutex
+
 	// Snapshot data — populated by syncOnce, read by Get / Walk.
 	snapMu     sync.RWMutex
 	snapshot   map[string][]byte
@@ -208,20 +218,23 @@ const TabCloseGrace = 10 * time.Second
 // publisher returns its cache-miss within ~10s.
 const FirstSyncTimeout = 10 * time.Second
 
-// allTransportsFirstSyncTimeout is the first-Root wait for the TPD
-// all-transports feed. It's the largest, deepest tree (~8MB network-wide
-// snapshot) and routinely needs well over FirstSyncTimeout to deliver its
-// first Root over dmsg — a 10s bound left it never syncing over CXO. The
-// all-transports topology is the most important feed for the transport
-// graph, so it gets the room it needs; other feeds keep the tighter default.
-const allTransportsFirstSyncTimeout = 45 * time.Second
+// largeFeedFirstSyncTimeout is the first-Root wait for the big feeds.
+// all-transports (~8MB network-wide snapshot) and sd-services (the full
+// service-discovery listing, ~1000 servers) are large, deep trees that
+// routinely need well over FirstSyncTimeout to deliver their first Root
+// over dmsg — a 10s bound left them never syncing over CXO (sd-services
+// timed out at 10s → empty proxy/vpn pickers). These feeds get the room
+// they need; the small, fast feeds keep the tighter default so a UI
+// Acquire on a dead publisher still returns its cache-miss within ~10s.
+const largeFeedFirstSyncTimeout = 45 * time.Second
 
 // FeedFirstSyncTimeout returns the first-Root wait for a feed. Per-feed so the
-// large all-transports snapshot syncs reliably without slowing a UI Acquire on
-// the small, fast feeds.
+// large snapshots sync reliably without slowing a UI Acquire on the small,
+// fast feeds.
 func FeedFirstSyncTimeout(f Feed) time.Duration {
-	if f == FeedTPDAllTransports {
-		return allTransportsFirstSyncTimeout
+	switch f {
+	case FeedTPDAllTransports, FeedSDServices:
+		return largeFeedFirstSyncTimeout
 	}
 	return FirstSyncTimeout
 }
@@ -684,6 +697,13 @@ func (m *Manager) cycleLoop(ctx context.Context, fk Feed, f *managedFeed) {
 // is left in place; callers continue serving stale data until the
 // next cycle succeeds.
 func (m *Manager) syncOnce(ctx context.Context, fk Feed, f *managedFeed) {
+	// Serialize per feed: syncOnce binds a fixed dmsg port for the
+	// duration of the subscribe→snapshot→close cycle. The cycleLoop and
+	// RefreshNow are independent callers; overlapping them collides on
+	// the port. See managedFeed.syncMu.
+	f.syncMu.Lock()
+	defer f.syncMu.Unlock()
+
 	dmsgC := m.dmsgClient()
 	if dmsgC == nil {
 		f.recordErr(errors.New("dmsg client not ready"))

--- a/pkg/visor/api_fetch_cxo.go
+++ b/pkg/visor/api_fetch_cxo.go
@@ -78,6 +78,17 @@ func (v *Visor) FetchCXO(args FetchCXOArgs) (*FetchCXOResult, error) {
 		if mgr := v.CXOSubMgr(); mgr != nil {
 			mgr.AcquireFor(TabCLIServices)
 			defer mgr.ReleaseFor(TabCLIServices)
+			// CXO is itself an over-dmsg subscription, so it should be the source of
+			// truth — not just a fast path that silently defers to the dmsg-http
+			// fallback whenever the snapshot is still cold. AcquireFor only STARTS
+			// the cycle; a short-lived caller (the CLI) would otherwise always miss
+			// on the first call and fall back. So on a cold snapshot, block briefly
+			// for the subscription's first sync (over dmsg) before reporting a miss.
+			if _, ok := v.servicesFromCXO(serviceType, "", ""); !ok {
+				ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedSDServices))
+				_, _ = mgr.RefreshNow(ctx, FeedSDServices) //nolint:errcheck
+				cancel()
+			}
 		}
 		services, ok := v.servicesFromCXO(serviceType, "", "")
 		if !ok {

--- a/pkg/visor/api_tpd_uptime_subscriber.go
+++ b/pkg/visor/api_tpd_uptime_subscriber.go
@@ -14,6 +14,7 @@
 package visor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -45,7 +46,16 @@ func (v *Visor) FetchVisorUptimeCXO(days int) ([]byte, time.Time, error) {
 	path := fmt.Sprintf("uptimes/days/%d", days)
 	body, ts, ok := mgr.Get(FeedTPDUptime, path)
 	if !ok || len(body) == 0 {
-		return nil, time.Time{}, ErrTPDUptimeNotReady
+		// Cold snapshot: AcquireFor only started the cycle. Block briefly for the
+		// first sync (over dmsg) so CXO serves this call instead of the caller
+		// falling back to dmsg-http — see the sd-services case in FetchCXO.
+		ctx, cancel := context.WithTimeout(context.Background(), feedFirstSyncTimeout(FeedTPDUptime))
+		_, _ = mgr.RefreshNow(ctx, FeedTPDUptime) //nolint:errcheck
+		cancel()
+		body, ts, ok = mgr.Get(FeedTPDUptime, path)
+		if !ok || len(body) == 0 {
+			return nil, time.Time{}, ErrTPDUptimeNotReady
+		}
 	}
 	return body, ts, nil
 }


### PR DESCRIPTION
Fixes the blank **network uptime** page (`/#/nodes/uptime`, MultiVisorUptimeComponent) and empty proxy/vpn server pickers on hypervisor visors.

## Root cause
Two commits, one dependent on the other:

1. **`fix(visor)`: FetchCXO waits for the first sync on a cold snapshot.** CXO feeds are lazy — `AcquireFor` only *starts* the subscription cycle, so a short-lived reader (CLI, or a UI request) reads before the first async sync and always misses, silently falling back to dmsg-http. CXO is itself over dmsg, so it should be the source of truth: on a cold snapshot, block briefly via `RefreshNow` (bounded by the feed's first-sync timeout) before reporting a miss.

2. **`fix(cxo)`: serialize per-feed `syncOnce`.** (1) introduced a second concurrent `syncOnce` caller. Each `syncOnce` binds a **fixed per-feed dmsg port** (52=uptime, 53=sd, …) for one subscribe→snapshot→close cycle. The cycle goroutine and `RefreshNow` had no serialization, so on a hypervisor visor — where the HV/autoconnect/tpviz keep a cycle running — a `RefreshNow` mid-cycle collided:

   ```
   create subscriber: dmsg listen on port 52: dmsg error 400 - port already occupied
   ```

   Every deployment feed then died → blank uptime page, empty pickers. `managedFeed.syncMu` (held for the whole `syncOnce`) restores the sequential-per-feed invariant the fixed-port design relies on.

   Also raises the **sd-services** first-sync budget to the 45s already used for all-transports (it's a large tree, ~1000 servers; 10s timed out on a cold subscribe).

## Testing
- `go test -race ./pkg/cxo/...` and `./pkg/visor/` pass; `go build ./...` clean.
- Validated on a live hypervisor visor: `cxo status` shows tpd-uptime (3 paths / 5.5 MB) and tpd-all-transports (5.7 MB) syncing cleanly with no port-collision; `GET /api/network/visor-uptime?days=7` → **HTTP 200, 2.37 MB**.

> Note: after this fix, sd-services can still miss if its **publisher** (the SD deployment service) isn't delivering a Root within 45s — that's a separate server-side condition, not the client collision fixed here. Pickers retain their dmsg-http / manual-PK fallback.