### PR TITLE
fix(sd): periodically republish the services CXO feed so a fresh Root is always servable

### DIFF
--- a/pkg/service-discovery/api/api.go
+++ b/pkg/service-discovery/api/api.go
@@ -152,7 +152,11 @@ func (a *API) WarmCXOFromStore(ctx context.Context) int {
 		}
 	}
 	if n > 0 {
-		a.log.WithField("entries", n).Info("CXO warm: pre-populated publisher tree from store")
+		// Debug, not Info: this now runs on a periodic republish ticker
+		// (see startServicesCXO), so an Info line per cycle would spam
+		// the log. Startup health is signaled by the one-shot
+		// "CXO services publisher running" Info line.
+		a.log.WithField("entries", n).Debug("CXO warm: (re)populated publisher tree from store")
 	}
 	return n
 }

--- a/pkg/services/sd/sd.go
+++ b/pkg/services/sd/sd.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 
@@ -196,6 +197,14 @@ func (s *service) Run(ctx context.Context) error {
 	}
 }
 
+// servicesCXORepublishInterval is how often the SD services CXO feed
+// is fully republished from the store so a fresh, fillable head Root is
+// always available to newly-connecting subscribers. Matches the TPD
+// uptime publisher cadence (60s); SD's redis state refreshes on the
+// visor heartbeat cycle so faster ticks would just republish identical
+// Roots.
+const servicesCXORepublishInterval = 60 * time.Second
+
 func (s *service) startServicesCXO(
 	ctx context.Context,
 	dmsgC *dmsg.Client,
@@ -213,10 +222,29 @@ func (s *service) startServicesCXO(
 	// the publisher's first Root carries the active service list
 	// instead of being empty until the next register/heartbeat event
 	// — without this a subscriber that connects in the post-restart
-	// gap times out at firstSyncTimeout (10s).
+	// gap times out at firstSyncTimeout.
 	sdAPI.WarmCXOFromStore(ctx)
+	// Then republish the full service list on a ticker. Reactive
+	// register/deregister events alone leave the feed with no fresh
+	// Root during content-idle windows, and a cold-redis startup can
+	// leave the initial warm empty — in both cases a fresh subscriber
+	// finds no servable head Root (LastRoot returns nothing, or a Root
+	// whose objects the cleanup sweep has since reclaimed) and times
+	// out, falling back to dmsg-http. A periodic full republish keeps a
+	// fresh, fully object-backed (fillable) head Root available at all
+	// times and self-heals a cold-start miss — the same pattern the TPD
+	// uptime / metrics / all-transports publishers use.
 	go func() {
-		<-ctx.Done()
-		pub.Close() //nolint:errcheck,gosec
+		t := time.NewTicker(servicesCXORepublishInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				pub.Close() //nolint:errcheck,gosec
+				return
+			case <-t.C:
+				sdAPI.WarmCXOFromStore(ctx)
+			}
+		}
 	}()
 }


### PR DESCRIPTION
Fixes sd-services CXO subscribers timing out (`timeout waiting for Root`), which forced the HV network views and proxy/VPN server pickers onto the dmsg-http fallback instead of the CXO path.

## Root cause
The SD host is healthy and its CXO publisher is alive (verified live via the resolving proxy: `/health` 200, `/api/services` returns real data, pprof shows `ServicesCXOPublisher.run` + `treestore.Publisher.runLoop` running, feed PK matches, allowlist open, port 53 listening, handshake succeeds). The node **does** push the head Root to new subscribers (`conn.go` `sendLastRoot` → `LastRoot(feed, activeHead)`).

The problem: the services publisher only emitted a Root **reactively** — on register/deregister events plus a one-shot `WarmCXOFromStore` at startup. So during a content-idle window, or after a cold-redis startup where the initial warm found nothing, `LastRoot` returns nothing (or a Root whose objects the cleanup sweep has since reclaimed → unfillable). The subscriber waits out its first-sync timeout and falls back. Empirically, 6/6 `cxo refresh sd-services` over 2 min timed out.

Contrast the TPD `uptime` / `metrics` / `all-transports` publishers, which run a **periodic republish ticker** (60s) and therefore always have a fresh, fillable head Root — those feeds work reliably from the same subscriber.

## Fix
Give the SD services publisher the same pattern: after the startup warm, re-warm the tree from the store every `servicesCXORepublishInterval` (60s). Each cycle re-Puts the current service set, republishing a fresh, fully object-backed head Root and self-healing a cold-start miss. The per-cycle warm log drops to Debug so the ticker doesn't spam Info.

## Testing
- `go build ./...`, `go vet`, and `go test ./pkg/services/sd/ ./pkg/service-discovery/...` all pass.
- Diagnosis captured against the live deployment; this mirrors the already-proven TPD publisher cadence.

Companion to #3799 (client-side: cold-snapshot serving + subscribe port-collision + 45s budget). #3799 made the client wait correctly; this makes the SD publisher actually have something to serve.