### PR TITLE
fix(lint): clear golangci-lint debt on develop (errcheck/misspell/unparam)

### DIFF
--- a/pkg/dmsg/dmsgserver/api.go
+++ b/pkg/dmsg/dmsgserver/api.go
@@ -125,7 +125,7 @@ func (a *ServerAPI) ListenAndServe(lAddr, pAddr, httpAddr, wsURL, wtURL string) 
 			// ServeUnifiedQUIC serves dmsg-over-QUIC AND (when wt != "")
 			// dmsg-over-WebTransport on this SAME UDP socket, ALPN-demuxed — so WT
 			// is default-on at zero extra port cost, reachable wherever dmsg-QUIC
-			// already is. wt == "" makes it QUIC-only (the prior behaviour).
+			// already is. wt == "" makes it QUIC-only (the prior behavior).
 			serr := a.dmsgServer.ServeUnifiedQUIC(udp, advertised, wt)
 			udp.Close() //nolint:errcheck,gosec
 			errCh <- fmt.Errorf("dmsg QUIC server stopped: %v", serr)

--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -853,7 +853,7 @@ func (tm *Manager) Networks() []types.Type {
 // PreferredDirectCreateOrder returns this visor's DIRECT (non-relay) transport
 // types in global preference order (tptypes.PreferenceOrder — STCPR > QUIC >
 // SUDPH > STCP > WEBRTC > WS > WT), filtered to the network clients this manager
-// actually has initialised. It is the host-aware "auto" transport-creation order:
+// actually has initialized. It is the host-aware "auto" transport-creation order:
 // a native visor yields e.g. [stcpr, quic, sudph, stcp, webrtc, ws, wt]; a
 // browser visor (no raw TCP/UDP) yields [webrtc, ws, wt]. DMSG is excluded — it
 // is the relay, tried only as a last resort by EnsureBestTransport.
@@ -911,7 +911,7 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 	order := tm.PreferredDirectCreateOrder()
 	// Already have a direct transport? A 1-hop route can use it — nothing to do.
 	for _, nt := range order {
-		if mt, _ := tm.GetTransport(remote, nt); mt != nil {
+		if mt, err := tm.GetTransport(remote, nt); err == nil && mt != nil {
 			return nil
 		}
 	}
@@ -930,7 +930,7 @@ func (tm *Manager) EnsureBestTransport(ctx context.Context, remote cipher.PubKey
 			tm.Logger.Debugf("auto-transport: created %s direct transport to %s", nt, remote)
 			return nil
 		}
-		if ctx.Err() != nil { // parent cancelled (not just this type's per-type cap) → abort
+		if ctx.Err() != nil { // parent canceled (not just this type's per-type cap) → abort
 			return ctx.Err()
 		}
 		lastErr = err

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -125,7 +125,7 @@ func (v *Visor) ServiceHealth() ([]ServiceHealthEntry, error) {
 }
 
 // doHealthProbe performs a single GET {baseURL}/health and populates a ServiceHealthEntry.
-func doHealthProbe(client *http.Client, name, baseURL, transport string) ServiceHealthEntry {
+func doHealthProbe(client *http.Client, name, baseURL, transport string) ServiceHealthEntry { //nolint:unparam
 	entry := ServiceHealthEntry{Name: name, URL: baseURL, Transport: transport}
 
 	reqURL := strings.TrimSuffix(baseURL, "/") + "/health"

--- a/pkg/visor/api_services_test.go
+++ b/pkg/visor/api_services_test.go
@@ -66,7 +66,7 @@ func TestDoHealthProbe_BuildInfoVersion(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/health", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"build_info":{"version":"v1.3.92-0-7925d659e2ec"}}`))
+		_, _ = w.Write([]byte(`{"build_info":{"version":"v1.3.92-0-7925d659e2ec"}}`)) //nolint:errcheck
 	}))
 	defer srv.Close()
 
@@ -80,7 +80,7 @@ func TestDoHealthProbe_BuildInfoVersion(t *testing.T) {
 func TestDoHealthProbe_TopLevelVersionFallback(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"version":"v1.3.88-0-54e4b7f90c01"}`))
+		_, _ = w.Write([]byte(`{"version":"v1.3.88-0-54e4b7f90c01"}`)) //nolint:errcheck
 	}))
 	defer srv.Close()
 


### PR DESCRIPTION
**Every** open PR is currently red on the `linux` / `darwin` / `windows` jobs — all three run golangci-lint (2.12.2), which flags seven pre-existing issues in files no PR touches (`pkg/transport/manager.go`, `pkg/visor/api_services*.go`, `pkg/dmsg/dmsgserver/api.go`). They reached develop through merge commits that skip CI, so every branch cut from develop inherits the failure.

Fixes:
- **errcheck (3):** check `tm.GetTransport`'s error instead of a blank discard (check-blank is on); `//nolint:errcheck` on the two httptest `w.Write` calls.
- **misspell (3):** `initialised→initialized`, `cancelled→canceled`, `behaviour→behavior` (all in comments).
- **unparam (1):** `//nolint:unparam` on `doHealthProbe` (its `transport` param is always `"dmsg"` today, but kept for the intended multi-transport probe API).

Verified locally with golangci-lint **2.12.2** (the CI version) — **0 issues**; `go build`/`go vet` clean.

Unblocks CI for all open PRs (they'll need a rebase onto this once merged).