### PR TITLE
feat: real-origin mesh browser — isolated per-site origins on native HV UI + wasm visor

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -13,6 +13,8 @@ var (
 	serveAddr     string
 	serveHarness  bool
 	serveTLS      bool
+	serveTLSCert  string
+	serveTLSKey   string
 	servePassword string
 	serveVariant  string
 	serveWallet   bool
@@ -22,6 +24,8 @@ func init() {
 	serveCmd.Flags().StringVarP(&serveAddr, "addr", "a", ":7999", "HTTP listen address")
 	serveCmd.Flags().BoolVar(&serveHarness, "harness", false, "mount the /ctl/* operator control bridge (drive the in-tab visor from a shell); DEV ONLY — never expose publicly")
 	serveCmd.Flags().BoolVar(&serveTLS, "tls", false, "serve over HTTPS with a self-signed localhost cert (a real https origin for local testing — wss works, ws:// is mixed-content-blocked exactly as in prod). Accept the browser cert warning once; the cert is persisted across restarts")
+	serveCmd.Flags().StringVar(&serveTLSCert, "tls-cert", "", "PEM cert to serve TLS with instead of the self-signed localhost cert — e.g. a locally-trusted *.mesh.localhost cert (mkcert) so real-origin browse iframes load without a per-host accept. Requires --tls-key")
+	serveCmd.Flags().StringVar(&serveTLSKey, "tls-key", "", "PEM key paired with --tls-cert")
 	serveCmd.Flags().StringVar(&servePassword, "password", "", "gate the served PWA behind an access password (cookie login). Empty = open. Use over --tls / behind TLS so the password isn't sent in clear")
 	serveCmd.Flags().StringVarP(&serveVariant, "variant", "W", "", "which embedded wasm-visor to serve: 'go' (larger, full crypto/tls+net/http) or 'tinygo' (~4x smaller — better for the PWA, with the documented TinyGo feature gaps). Empty = the build default. A standard-Go build embeds both; a TinyGo build has only 'tinygo'")
 	serveCmd.Flags().BoolVar(&serveWallet, "wallet", true, "serve the bundled skycoin-web wallet at /wallet/ (custody stays browser-side — the host never sees keys). --wallet=false serves a wallet-less PWA")
@@ -52,6 +56,8 @@ page never asks anyone to type a secret key.`,
 		if err := visor.ServeWasm(cmd.Context(), visor.WasmServeConfig{
 			Addr:     serveAddr,
 			TLS:      serveTLS,
+			TLSCert:  serveTLSCert,
+			TLSKey:   serveTLSKey,
 			Harness:  serveHarness,
 			Wallet:   serveWallet,
 			Variant:  serveVariant,

--- a/pkg/visor/hypervisor_handlers_browse.go
+++ b/pkg/visor/hypervisor_handlers_browse.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 
@@ -79,6 +80,35 @@ func serveJS(w http.ResponseWriter, b []byte) {
 	_, _ = w.Write(b) //nolint:errcheck
 }
 
+// browseOriginInjectJS returns a JS snippet that sets window.__SKYWIRE_BROWSE_ORIGIN__
+// so browse.js loads mesh sites from the native real-origin reverse-proxy
+// (meshproxy) instead of the sandboxed-srcdoc transcoder — but ONLY when
+// BrowseOrigin (the mesh_proxy module) is enabled. The origin is
+// <pk>[.<net>]<suffix>:<port> on the meshproxy's loopback listener; the native
+// visor reverse-proxies it over dmsg/skynet server-side (no SW/bridge needed).
+// Empty string when disabled → the transcoder fallback stays in effect.
+func browseOriginInjectJS(v *Visor) string {
+	bo := v.conf.BrowseOrigin
+	if bo == nil || !bo.Enable {
+		return ""
+	}
+	addr := bo.Addr
+	if addr == "" {
+		addr = defaultMeshProxyAddr
+	}
+	port := ""
+	if _, p, err := net.SplitHostPort(addr); err == nil {
+		port = p
+	}
+	scheme := "http"
+	if bo.TLSCert != "" && bo.TLSKey != "" {
+		scheme = "https"
+	}
+	suffix := normalizeMeshSuffix(bo.Suffix) // guaranteed leading dot
+	return `window.__SKYWIRE_BROWSE_ORIGIN__={suffix:` + strconv.Quote(suffix) +
+		`,scheme:` + strconv.Quote(scheme) + `,port:` + strconv.Quote(port) + `};`
+}
+
 // serveInjectedIndex serves index.html with the browse engine + launcher scripts
 // (and window.__SKYWIRE_LOCAL_PK__) injected before </body>. Falls back to the
 // plain file server if index.html can't be read.
@@ -105,7 +135,7 @@ func (hv *Hypervisor) serveInjectedIndex(w http.ResponseWriter, r *http.Request,
 	// references the content-hashed chunk filenames — it changes iff the UI does.
 	ver := uiVersionHash(b)
 	inject := []byte(`<script>window.__SKYWIRE_LOCAL_PK__=` + strconv.Quote(hv.visor.conf.PK.Hex()) +
-		`;window.__SKYWIRE_UI_VERSION__=` + strconv.Quote(ver) + `;</script>` +
+		`;window.__SKYWIRE_UI_VERSION__=` + strconv.Quote(ver) + `;` + browseOriginInjectJS(hv.visor) + `</script>` +
 		`<script src="browse.js"></script><script src="skywire-browse-launcher.js"></script>` +
 		`<script>` + uiAutoReloadJS + `</script>`)
 	out := bytes.Replace(b, []byte("</body>"), append(inject, []byte("</body>")...), 1)

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -123,6 +123,8 @@ var (
 	embFwdProxy vinit.Module
 	// Embedded skynetweb resolver (localhost SOCKS5 for .skynet browsing)
 	embSkynetWeb vinit.Module
+	// Native real-origin browse proxy (loopback reverse-proxy origin over dmsg)
+	meshProxy vinit.Module
 	// Embedded SMTP→skywire bridge (localhost SMTP listener for *.skynet recipients)
 	embSkymailBridge vinit.Module
 	// UI server module (serves tp-viz)
@@ -197,6 +199,12 @@ func registerModules(logger *logging.MasterLogger) {
 	rt = maker("router", initRouter, &tr, &dmsgC, &dmsgHTTP, &embRouteSetup, &routerListener)
 	// skynetweb depends on the router being up, unlike dmsgweb.
 	embSkynetWeb = maker("embedded_skynetweb", initEmbeddedSkynetWeb, &rt)
+	// Native real-origin browse proxy: reverse-proxies mesh sites over dmsg AND
+	// skynet from an isolated loopback origin. Depends on the router module (rt) —
+	// which transitively brings up dmsgC (assigns v.dmsgHTTP) AND sets v.router
+	// (needed for the skynet transport). Without the rt dep the skynet round-
+	// tripper would be built before v.router exists.
+	meshProxy = maker("mesh_proxy", initMeshProxy, &rt)
 	launch = maker("launcher", initLauncher, &ebc, &disc, &dmsgC, &tr, &rt)
 	// cli depends on tr so v.tpM is set when initCLI wires up the
 	// shared VStreamMux for transport-RPC (registered as the manager's
@@ -251,7 +259,7 @@ func registerModules(logger *logging.MasterLogger) {
 	// + SD dmsg client) and skyFwd (dmsg forwarder). See init_coinnode.go.
 	coinNodesMod = maker("coin_nodes", initCoinNodes, &dmsgC, &skyFwd)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -153,7 +153,7 @@ func (v *Visor) skynetHTTPTransport() http.RoundTripper {
 				return nil, fmt.Errorf("skynet dial: %w", err)
 			}
 			if err := skynetweb.PerformHandshake(conn, uint16(port)); err != nil {
-				_ = conn.Close()
+				_ = conn.Close() //nolint:errcheck
 				return nil, fmt.Errorf("skynet handshake: %w", err)
 			}
 			return conn, nil
@@ -306,7 +306,7 @@ func serveMeshHTTP(ctx context.Context, addr string, h http.Handler, certFile, k
 	srv := &http.Server{Handler: h} //nolint:gosec // local loopback reverse proxy
 	go func() {
 		<-ctx.Done()
-		_ = srv.Close()
+		_ = srv.Close() //nolint:errcheck
 	}()
 	if certFile != "" && keyFile != "" {
 		err = srv.ServeTLS(lis, certFile, keyFile)
@@ -355,7 +355,7 @@ func (v *Visor) ServeMeshProxy(ctx context.Context, cfg *visorconfig.BrowseOrigi
 	}
 	switch strings.ToLower(cfg.Mode) {
 	case "port":
-		return v.serveMeshPortMode(ctx, addr, cfg, aliases)
+		return v.serveMeshPortMode(ctx, addr, cfg)
 	default: // "subdomain" or ""
 		return v.serveMeshSubdomain(ctx, addr, cfg, aliases)
 	}
@@ -434,7 +434,7 @@ func (m *meshPortManager) originFor(host string) (string, error) {
 	dest := pk
 	rp, rerr := m.v.newMeshReverseProxy(func(string) (cipher.PubKey, string, string, error) { return dest, vhost, network, nil })
 	if rerr != nil {
-		_ = lis.Close()
+		_ = lis.Close() //nolint:errcheck
 		return "", rerr
 	}
 	srv := &http.Server{Handler: rp} //nolint:gosec // local loopback reverse proxy
@@ -453,7 +453,7 @@ func (m *meshPortManager) originFor(host string) (string, error) {
 	}()
 	go func() {
 		<-m.parentCtx.Done()
-		_ = srv.Close()
+		_ = srv.Close() //nolint:errcheck
 	}()
 	return e.url, nil
 }
@@ -479,7 +479,7 @@ func (m *meshPortManager) evictLocked(key string) {
 	if !ok {
 		return
 	}
-	_ = e.srv.Close()
+	_ = e.srv.Close() //nolint:errcheck
 	delete(m.byKey, key)
 	delete(m.byPort, e.port)
 	for i, k := range m.order {
@@ -503,7 +503,7 @@ func (m *meshPortManager) touchLocked(key string) {
 // serveMeshPortMode runs the port-mode "portal" on addr: GET /open?host=<host>
 // resolves the mesh host to a dedicated 127.0.0.1:<port> origin and 302-redirects
 // there (so an iframe pointed at .../open?host=… lands on the isolated origin).
-func (v *Visor) serveMeshPortMode(ctx context.Context, addr string, cfg *visorconfig.BrowseOriginConfig, aliases map[string]cipher.PubKey) error {
+func (v *Visor) serveMeshPortMode(ctx context.Context, addr string, cfg *visorconfig.BrowseOriginConfig) error {
 	if v.dmsgHTTP == nil || v.dmsgHTTP.Transport == nil {
 		return fmt.Errorf("dmsg HTTP client not ready")
 	}
@@ -536,7 +536,9 @@ func (v *Visor) serveMeshPortMode(ctx context.Context, addr string, cfg *visorco
 			http.Error(w, "mesh proxy: "+err.Error(), http.StatusBadGateway)
 			return
 		}
-		http.Redirect(w, r, u, http.StatusFound)
+		// u is not user-controlled: originFor resolves h to a PK and returns this
+		// manager's own scheme://127.0.0.1:<port> origin from the local pool.
+		http.Redirect(w, r, u, http.StatusFound) //nolint:gosec // G710: redirect target is a local loopback origin we minted, not tainted input
 	})
 	return serveMeshHTTP(ctx, addr, mux, cfg.TLSCert, cfg.TLSKey)
 }

--- a/pkg/visor/meshproxy.go
+++ b/pkg/visor/meshproxy.go
@@ -1,0 +1,542 @@
+// Package visor pkg/visor/meshproxy.go c3-vis-core
+// meshproxy — the RFC "real-origin" native browse path (see
+// pkg/wasmhv/browseui/RFC-real-origin-browser.md). Instead of the WinBox
+// browser fetching a page and re-implementing the network stack inside a
+// sandboxed opaque srcdoc, this serves mesh (dmsg) sites from a REAL local
+// origin so the BROWSER does native subresource loading, redirects, cookies,
+// WASM, and streaming — skywire only proxies the transport (over dmsg), exactly
+// like pkg/dmsgweb does for a real external browser via SOCKS5. Content flows
+// through THIS visor's own transports; the listeners are loopback-only.
+//
+// Two origin shapes (BrowseOrigin.Mode), both giving each mesh site its OWN
+// isolated browser origin:
+//
+//   - "subdomain" (default): ONE listener; each site is the origin
+//     <vhost>.<base32pk><suffix> (suffix ".mesh.localhost" resolves to loopback
+//     in every target browser, so no public cert is needed; set a real domain +
+//     TLS for hosted/https parity). Routed by the Host header.
+//   - "port": each site gets its OWN 127.0.0.1:<port> origin from a small pool.
+//     No DNS/wildcard dependency (works anywhere), weaker isolation (cookies are
+//     domain-scoped, not port-scoped). A "portal" on Addr resolves a mesh host
+//     to its per-site port via GET /open?host=<resolver-host> → 302.
+//
+// Optional TLS (BrowseOrigin.TLSCert/TLSKey) serves either mode over HTTPS with
+// a real or locally-trusted cert — for local https parity with the hosted
+// <pk>.<domain> origin (same scheme, secure context, real-domain cookies).
+//
+// It is a SEPARATE listener from the hypervisor UI (:8000) on purpose: untrusted
+// mesh content must never share an origin with the control surface, and these
+// listeners serve ONLY the reverse proxy — no /api, no UI.
+package visor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	"github.com/skycoin/skywire/pkg/skyenv"
+	"github.com/skycoin/skywire/pkg/skynetweb"
+	"github.com/skycoin/skywire/pkg/visor/visorconfig"
+)
+
+// defaultMeshProxySuffix marks a browse-frame origin for the native localhost
+// case. `*.localhost` resolves to loopback in all target browsers and each label
+// is a distinct, isolated origin — so no public cert is needed. Configurable via
+// BrowseOrigin.Suffix (e.g. ".haltingstate.net" or a user's own domain).
+//
+// The suffix MUST include the leading dot: skynetweb.ParseResolverHost strips it
+// verbatim, and without the dot "foo.<pk>.mesh.localhost" strips to "foo.<pk>."
+// (trailing dot → empty final label → PK parse fails).
+const defaultMeshProxySuffix = ".mesh.localhost"
+
+// defaultMeshProxyAddr is the loopback listen address used when
+// BrowseOrigin.Addr is unset. Loopback-only: untrusted mesh content must never
+// share a listener reachable off-box with anything else.
+const defaultMeshProxyAddr = "127.0.0.1:8461"
+
+// meshProxyDefaultPort is the dmsg HTTP port dialed on the destination visor when
+// the host carries no explicit port. Mesh HTTP services (incl. skynet port-80
+// forwards) conventionally answer here. TODO(realorigin): allow an explicit dmsg
+// port label so non-80 forwards are addressable.
+const meshProxyDefaultPort = 80
+
+// Port-mode loopback pool defaults (per-site 127.0.0.1:<port> origins).
+const (
+	defaultMeshPortBase = 8470
+	defaultMeshPortSpan = 64
+)
+
+type meshCtxKey int
+
+const (
+	meshFrameHostKey meshCtxKey = iota
+	meshVhostKey
+	meshErrKey
+	meshNetKey // selected transport: "dmsg" | "skynet" | "" (auto)
+)
+
+// meshResolveFn maps an inbound browse-frame Host to the destination visor PK,
+// upstream vhost (for the outbound Host header) and the selected transport
+// ("dmsg"/"skynet"/"" = auto). Subdomain mode parses the Host per request; port
+// mode returns a fixed dest baked into the per-site listener.
+type meshResolveFn func(inHost string) (dest cipher.PubKey, vhost, network string, err error)
+
+// meshTransport dispatches each browse request to the dmsg or skynet round-
+// tripper by the network stashed in the request context. "" (auto) tries skynet
+// first (a visor mirrors :80 over skynet AND dmsg) and falls back to dmsg. skynet
+// is nil when the router isn't available (e.g. before routing is up) → dmsg only.
+type meshTransport struct {
+	dmsg   http.RoundTripper
+	skynet http.RoundTripper
+}
+
+func (t *meshTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	network, _ := req.Context().Value(meshNetKey).(string)
+	switch network {
+	case "dmsg":
+		return t.dmsg.RoundTrip(req)
+	case "skynet":
+		if t.skynet == nil {
+			return nil, fmt.Errorf("skynet transport unavailable (router not ready)")
+		}
+		return t.skynet.RoundTrip(req)
+	default: // auto: skynet first, dmsg fallback
+		if t.skynet != nil {
+			if resp, err := t.skynet.RoundTrip(req); err == nil {
+				return resp, nil
+			}
+			// rewind the body (if replayable) before the dmsg attempt
+			if req.GetBody != nil {
+				if b, e := req.GetBody(); e == nil {
+					req.Body = b
+				}
+			}
+		}
+		return t.dmsg.RoundTrip(req)
+	}
+}
+
+// skynetHTTPTransport is a streaming http.RoundTripper over skynet: it dials a
+// skywire route to the destination's forwarding server, performs the skynet
+// port-handshake, then speaks HTTP/1.1 over the route conn. The outbound URL host
+// (set in Rewrite) is "<hexpk>:<port>", which DialContext parses to (PK, port).
+func (v *Visor) skynetHTTPTransport() http.RoundTripper {
+	return &http.Transport{
+		DisableCompression: true,
+		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+			if v.router == nil {
+				return nil, fmt.Errorf("skynet: router not ready")
+			}
+			host, portStr, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			var pk cipher.PubKey
+			if err := pk.Set(host); err != nil {
+				return nil, fmt.Errorf("skynet: bad dest %q: %w", host, err)
+			}
+			port, err := strconv.ParseUint(portStr, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("skynet: bad port %q: %w", portStr, err)
+			}
+			conn, err := v.router.DialRoutes(ctx, pk, 0, routing.Port(skyenv.SkyForwardingServerPort), nil)
+			if err != nil {
+				return nil, fmt.Errorf("skynet dial: %w", err)
+			}
+			if err := skynetweb.PerformHandshake(conn, uint16(port)); err != nil {
+				_ = conn.Close()
+				return nil, fmt.Errorf("skynet handshake: %w", err)
+			}
+			return conn, nil
+		},
+	}
+}
+
+// meshTransport builds the dmsg+skynet dispatching round-tripper. Caller must
+// have verified v.dmsgHTTP.Transport is non-nil.
+func (v *Visor) meshRoundTripper() *meshTransport {
+	// The skynet transport is always constructed; its DialContext guards v.router
+	// at dial time (nil until routing is up), so a router that comes up after this
+	// proxy is built still works.
+	return &meshTransport{dmsg: v.dmsgHTTP.Transport, skynet: v.skynetHTTPTransport()}
+}
+
+// peelNetLabel strips an optional "<net>" selector label ("dmsg"/"skynet") that
+// sits immediately before the origin suffix, returning the remaining host-core
+// and the selected network ("" = auto). core is the host with the suffix already
+// removed, e.g. "magnetosphere.net.<pk>.skynet" → ("magnetosphere.net.<pk>", "skynet").
+func peelNetLabel(core string) (rest, network string) {
+	for _, n := range []string{"skynet", "dmsg"} {
+		if strings.HasSuffix(core, "."+n) {
+			return strings.TrimSuffix(core, "."+n), n
+		}
+	}
+	return core, ""
+}
+
+// newMeshReverseProxy builds the httputil.ReverseProxy that forwards a browse-
+// frame request over dmsg and streams the response back verbatim, using resolve
+// to pick the destination.
+func (v *Visor) newMeshReverseProxy(resolve meshResolveFn) (*httputil.ReverseProxy, error) {
+	if v.dmsgHTTP == nil || v.dmsgHTTP.Transport == nil {
+		return nil, fmt.Errorf("dmsg HTTP client not ready")
+	}
+	return &httputil.ReverseProxy{
+		Transport: v.meshRoundTripper(), // dmsg/skynet dispatcher (streaming)
+		// Rewrite (not Director): does NOT auto-add X-Forwarded-* (privacy) and lets
+		// us stash per-request state in the outbound context instead of leaking
+		// X-Mesh-* headers to the upstream site.
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			dest, vhost, network, err := resolve(hostWithoutPort(pr.In.Host))
+			ctx := pr.In.Context()
+			if err != nil {
+				pr.Out.URL.Scheme = "http"
+				pr.Out.URL.Host = "invalid.mesh"
+				pr.Out = pr.Out.WithContext(context.WithValue(ctx, meshErrKey, err.Error()))
+				return
+			}
+			pr.Out.URL.Scheme = "http"
+			pr.Out.URL.Host = fmt.Sprintf("%s:%d", dest.Hex(), meshProxyDefaultPort)
+			// Upstream sees the real vhost (name-based backends like caddy need it).
+			if vhost != "" {
+				pr.Out.Host = vhost
+			} else {
+				pr.Out.Host = dest.Hex()
+			}
+			ctx = context.WithValue(ctx, meshFrameHostKey, pr.In.Host)
+			ctx = context.WithValue(ctx, meshVhostKey, vhost)
+			ctx = context.WithValue(ctx, meshNetKey, network)
+			pr.Out = pr.Out.WithContext(ctx)
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			ctx := resp.Request.Context()
+			frameHost, _ := ctx.Value(meshFrameHostKey).(string)
+			vhost, _ := ctx.Value(meshVhostKey).(string)
+			rewriteMeshLocation(resp, frameHost, vhost)
+			return nil // headers pass through verbatim (the whole point vs. the old bridge)
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			if me, _ := r.Context().Value(meshErrKey).(string); me != "" {
+				http.Error(w, "mesh proxy: "+me, http.StatusBadGateway)
+				return
+			}
+			http.Error(w, "mesh proxy: "+err.Error(), http.StatusBadGateway)
+		},
+	}, nil
+}
+
+// subdomainResolver parses <vhost>.<base32pk>[.<net>]<suffix> per request, where
+// <net> is an optional "dmsg"/"skynet" transport selector (default auto).
+// aliases maps a bare name label (e.g. "home") to a PK, mirroring the dmsgweb
+// resolver.
+func subdomainResolver(suffix string, aliases map[string]cipher.PubKey) meshResolveFn {
+	return func(inHost string) (cipher.PubKey, string, string, error) {
+		if !strings.HasSuffix(inHost, suffix) {
+			return cipher.PubKey{}, "", "", fmt.Errorf("host %q has no suffix %q", inHost, suffix)
+		}
+		core, network := peelNetLabel(strings.TrimSuffix(inHost, suffix))
+		vhost, _, dest, _, err := skynetweb.ParseResolverHost(core+suffix, suffix, aliases)
+		return dest, vhost, network, err
+	}
+}
+
+// rewriteMeshLocation rewrites a redirect Location whose host is the upstream
+// vhost (or is relative) into a frame-origin-relative URL, so the browser stays
+// within this reverse-proxy origin instead of leaving to clearnet. A Location to
+// a genuinely different host is left as-is.
+func rewriteMeshLocation(resp *http.Response, frameHost, vhost string) {
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return
+	}
+	loc := resp.Header.Get("Location")
+	if loc == "" || frameHost == "" {
+		return
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		return
+	}
+	if u.Host == "" || strings.EqualFold(u.Host, vhost) {
+		np := u.Path
+		if np == "" {
+			np = "/"
+		}
+		if u.RawQuery != "" {
+			np += "?" + u.RawQuery
+		}
+		resp.Header.Set("Location", np) // relative → browser resolves against the frame origin
+	}
+}
+
+func hostWithoutPort(h string) string {
+	if host, _, err := net.SplitHostPort(h); err == nil {
+		return host
+	}
+	return h
+}
+
+// normalizeMeshSuffix returns the suffix with a guaranteed leading dot, defaulting
+// to .mesh.localhost when empty.
+func normalizeMeshSuffix(s string) string {
+	if s == "" {
+		return defaultMeshProxySuffix
+	}
+	if !strings.HasPrefix(s, ".") {
+		return "." + s
+	}
+	return s
+}
+
+// serveMeshHTTP listens on addr and serves h until ctx is done, over HTTPS when
+// both certFile and keyFile are set, otherwise plain HTTP.
+func serveMeshHTTP(ctx context.Context, addr string, h http.Handler, certFile, keyFile string) error {
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("mesh proxy listen %s: %w", addr, err)
+	}
+	srv := &http.Server{Handler: h} //nolint:gosec // local loopback reverse proxy
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close()
+	}()
+	if certFile != "" && keyFile != "" {
+		err = srv.ServeTLS(lis, certFile, keyFile)
+	} else {
+		err = srv.Serve(lis)
+	}
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+// initMeshProxy is the vinit module entry: it starts the native real-origin
+// browse proxy when v.conf.BrowseOrigin is enabled. Modeled on
+// initDmsgForwardProxy — nil-guard the optional config block and return nil when
+// disabled so init proceeds. Unlike forward-proxy, ServeMeshProxy blocks until
+// ctx is done, so it runs in its own goroutine. Registered depending on the dmsg
+// module (which assigns v.dmsgHTTP) so the round-tripper is ready before this runs.
+func initMeshProxy(ctx context.Context, v *Visor, log *logging.Logger) error {
+	bo := v.conf.BrowseOrigin
+	if bo == nil || !bo.Enable {
+		return nil
+	}
+	mode := bo.Mode
+	if mode == "" {
+		mode = "subdomain"
+	}
+	log.WithField("mode", mode).WithField("addr", bo.Addr).
+		WithField("suffix", bo.Suffix).WithField("tls", bo.TLSCert != "" && bo.TLSKey != "").
+		Info("starting real-origin browse proxy")
+	go func() {
+		if err := v.ServeMeshProxy(ctx, bo, v.browseAliases()); err != nil {
+			log.WithError(err).Warn("real-origin browse proxy stopped")
+		}
+	}()
+	return nil
+}
+
+// ServeMeshProxy runs the browse-origin listener(s) until ctx is done, dispatched
+// by cfg.Mode ("subdomain" default, or "port"). aliases maps friendly labels to
+// PKs (same set the dmsgweb resolver uses).
+func (v *Visor) ServeMeshProxy(ctx context.Context, cfg *visorconfig.BrowseOriginConfig, aliases map[string]cipher.PubKey) error {
+	addr := cfg.Addr
+	if addr == "" {
+		addr = defaultMeshProxyAddr
+	}
+	switch strings.ToLower(cfg.Mode) {
+	case "port":
+		return v.serveMeshPortMode(ctx, addr, cfg, aliases)
+	default: // "subdomain" or ""
+		return v.serveMeshSubdomain(ctx, addr, cfg, aliases)
+	}
+}
+
+// serveMeshSubdomain runs the single Host-routed reverse-proxy origin. The browse
+// iframe targets <scheme>://<vhost>.<base32pk><suffix>[:port]/ against addr.
+func (v *Visor) serveMeshSubdomain(ctx context.Context, addr string, cfg *visorconfig.BrowseOriginConfig, aliases map[string]cipher.PubKey) error {
+	rp, err := v.newMeshReverseProxy(subdomainResolver(normalizeMeshSuffix(cfg.Suffix), aliases))
+	if err != nil {
+		return err
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/", rp)
+	return serveMeshHTTP(ctx, addr, mux, cfg.TLSCert, cfg.TLSKey)
+}
+
+// --- port mode ---------------------------------------------------------------
+
+type meshPortEntry struct {
+	key  string
+	url  string
+	srv  *http.Server
+	port int
+}
+
+// meshPortManager hands each mesh site its own 127.0.0.1:<port> reverse-proxy
+// origin from a bounded pool, with LRU eviction when the pool is full.
+type meshPortManager struct {
+	v         *Visor
+	parentCtx context.Context
+	cert, key string
+	scheme    string
+	base      int
+	span      int
+
+	mu     sync.Mutex
+	byKey  map[string]*meshPortEntry
+	byPort map[int]*meshPortEntry
+	order  []string // LRU: front = least-recently-used
+}
+
+// originFor resolves a resolving-proxy host (<pk>.dmsg / alias.dmsg / bare pk /
+// <name>.<pk>.dmsg) to its dedicated loopback origin URL, creating the per-site
+// listener on first use and reusing it thereafter.
+func (m *meshPortManager) originFor(host string) (string, error) {
+	pk, _, vhost, err := m.v.resolveBrowseHost(host, 0)
+	if err != nil {
+		return "", err
+	}
+	network := ""
+	switch lh := strings.ToLower(host); {
+	case strings.Contains(lh, ".skynet"):
+		network = "skynet"
+	case strings.Contains(lh, ".dmsg"):
+		network = "dmsg"
+	}
+	key := pk.Hex() + "|" + vhost + "|" + network
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e, ok := m.byKey[key]; ok {
+		m.touchLocked(key)
+		return e.url, nil
+	}
+	port, lis, err := m.listenFreeLocked()
+	if err != nil {
+		if len(m.order) == 0 {
+			return "", err
+		}
+		m.evictLocked(m.order[0]) // pool full → drop LRU and retry once
+		port, lis, err = m.listenFreeLocked()
+		if err != nil {
+			return "", err
+		}
+	}
+	dest := pk
+	rp, rerr := m.v.newMeshReverseProxy(func(string) (cipher.PubKey, string, string, error) { return dest, vhost, network, nil })
+	if rerr != nil {
+		_ = lis.Close()
+		return "", rerr
+	}
+	srv := &http.Server{Handler: rp} //nolint:gosec // local loopback reverse proxy
+	e := &meshPortEntry{key: key, url: fmt.Sprintf("%s://127.0.0.1:%d/", m.scheme, port), srv: srv, port: port}
+	m.byKey[key] = e
+	m.byPort[port] = e
+	m.order = append(m.order, key)
+	go func() {
+		var serr error
+		if m.cert != "" && m.key != "" {
+			serr = srv.ServeTLS(lis, m.cert, m.key)
+		} else {
+			serr = srv.Serve(lis)
+		}
+		_ = serr // per-site listener closed on evict or ctx cancel
+	}()
+	go func() {
+		<-m.parentCtx.Done()
+		_ = srv.Close()
+	}()
+	return e.url, nil
+}
+
+// listenFreeLocked binds the first free port in [base, base+span). Caller holds m.mu.
+func (m *meshPortManager) listenFreeLocked() (int, net.Listener, error) {
+	for p := m.base; p < m.base+m.span; p++ {
+		if _, used := m.byPort[p]; used {
+			continue
+		}
+		lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+		if err != nil {
+			continue // port taken by something else; try the next
+		}
+		return p, lis, nil
+	}
+	return 0, nil, fmt.Errorf("mesh port pool exhausted (%d..%d)", m.base, m.base+m.span-1)
+}
+
+// evictLocked closes and forgets one entry. Caller holds m.mu.
+func (m *meshPortManager) evictLocked(key string) {
+	e, ok := m.byKey[key]
+	if !ok {
+		return
+	}
+	_ = e.srv.Close()
+	delete(m.byKey, key)
+	delete(m.byPort, e.port)
+	for i, k := range m.order {
+		if k == key {
+			m.order = append(m.order[:i], m.order[i+1:]...)
+			break
+		}
+	}
+}
+
+// touchLocked marks key most-recently-used. Caller holds m.mu.
+func (m *meshPortManager) touchLocked(key string) {
+	for i, k := range m.order {
+		if k == key {
+			m.order = append(append(m.order[:i:i], m.order[i+1:]...), key)
+			return
+		}
+	}
+}
+
+// serveMeshPortMode runs the port-mode "portal" on addr: GET /open?host=<host>
+// resolves the mesh host to a dedicated 127.0.0.1:<port> origin and 302-redirects
+// there (so an iframe pointed at .../open?host=… lands on the isolated origin).
+func (v *Visor) serveMeshPortMode(ctx context.Context, addr string, cfg *visorconfig.BrowseOriginConfig, aliases map[string]cipher.PubKey) error {
+	if v.dmsgHTTP == nil || v.dmsgHTTP.Transport == nil {
+		return fmt.Errorf("dmsg HTTP client not ready")
+	}
+	base := cfg.PortBase
+	if base == 0 {
+		base = defaultMeshPortBase
+	}
+	span := cfg.PortSpan
+	if span <= 0 {
+		span = defaultMeshPortSpan
+	}
+	scheme := "http"
+	if cfg.TLSCert != "" && cfg.TLSKey != "" {
+		scheme = "https"
+	}
+	mgr := &meshPortManager{
+		v: v, parentCtx: ctx, cert: cfg.TLSCert, key: cfg.TLSKey, scheme: scheme,
+		base: base, span: span,
+		byKey: map[string]*meshPortEntry{}, byPort: map[int]*meshPortEntry{},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/open", func(w http.ResponseWriter, r *http.Request) {
+		h := r.URL.Query().Get("host")
+		if h == "" {
+			http.Error(w, "missing ?host=", http.StatusBadRequest)
+			return
+		}
+		u, err := mgr.originFor(h)
+		if err != nil {
+			http.Error(w, "mesh proxy: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		http.Redirect(w, r, u, http.StatusFound)
+	})
+	return serveMeshHTTP(ctx, addr, mux, cfg.TLSCert, cfg.TLSKey)
+}

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -551,6 +551,8 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 			if err := ServeWasm(parentCtx, WasmServeConfig{
 				Addr:     ws.Addr,
 				TLS:      ws.TLS,
+				TLSCert:  ws.TLSCert,
+				TLSKey:   ws.TLSKey,
 				Harness:  ws.Harness,
 				Wallet:   !ws.NoWallet,
 				Variant:  ws.Variant,

--- a/pkg/visor/visorconfig/config_compat.go
+++ b/pkg/visor/visorconfig/config_compat.go
@@ -40,6 +40,7 @@ type v1JSON struct {
 	LogServer     *LogServer           `json:"log_server,omitempty"`
 	DmsgWeb       *DmsgWebConfig       `json:"dmsg_web,omitempty"`
 	SkynetWeb     *SkynetWebConfig     `json:"skynet_web,omitempty"`
+	BrowseOrigin  *BrowseOriginConfig  `json:"browse_origin,omitempty"`
 	SkymailBridge *SkymailBridgeConfig `json:"skymail_bridge,omitempty"`
 	Rewards       *RewardsConfig       `json:"rewards,omitempty"`
 	STCP          *tnspec.STCPConfig   `json:"skywire-tcp,omitempty"`
@@ -103,6 +104,7 @@ func (v *V1) UnmarshalJSON(data []byte) error {
 	v.LogServer = mirror.LogServer
 	v.DmsgWeb = mirror.DmsgWeb
 	v.SkynetWeb = mirror.SkynetWeb
+	v.BrowseOrigin = mirror.BrowseOrigin
 	v.SkymailBridge = mirror.SkymailBridge
 	v.Rewards = mirror.Rewards
 	v.STCP = mirror.STCP

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -119,7 +119,9 @@ type HypervisorConfig struct {
 // See pkg/visor.ServeWasm.
 type WasmServeConf struct {
 	Addr     string `json:"addr"`                // e.g. ":8443"; empty = disabled
-	TLS      bool   `json:"tls,omitempty"`       // HTTPS with a self-signed localhost cert
+	TLS      bool   `json:"tls,omitempty"`       // HTTPS with a self-signed localhost cert (or TLSCert/TLSKey if set)
+	TLSCert  string `json:"tls_cert,omitempty"`  // optional PEM cert — a locally-trusted *.mesh.localhost cert (mkcert) so real-origin browse iframes load without a per-host accept
+	TLSKey   string `json:"tls_key,omitempty"`   // optional PEM key, paired with TLSCert
 	Harness  bool   `json:"harness,omitempty"`   // mount the /ctl/* operator control bridge (DEV ONLY — never expose publicly)
 	NoWallet bool   `json:"no_wallet,omitempty"` // default serves the bundled skycoin-web wallet; set true to omit it
 	Variant  string `json:"variant,omitempty"`   // "" = build default; "go" | "tinygo"

--- a/pkg/visor/visorconfig/v1.go
+++ b/pkg/visor/visorconfig/v1.go
@@ -22,6 +22,7 @@ type V1 struct {
 	LogServer     *LogServer           `json:"log_server,omitempty"`
 	DmsgWeb       *DmsgWebConfig       `json:"dmsg_web,omitempty"`
 	SkynetWeb     *SkynetWebConfig     `json:"skynet_web,omitempty"`
+	BrowseOrigin  *BrowseOriginConfig  `json:"browse_origin,omitempty"`
 	SkymailBridge *SkymailBridgeConfig `json:"skymail_bridge,omitempty"`
 	Rewards       *RewardsConfig       `json:"rewards,omitempty"`
 	STCP          *tnspec.STCPConfig   `json:"skywire-tcp,omitempty"`
@@ -349,6 +350,53 @@ type DmsgWebConfig struct {
 	ForwardProxy bool `json:"forward_proxy,omitempty"`
 	// ForwardPort is the dmsg port the forward-proxy listens on. Default 84.
 	ForwardPort uint16 `json:"forward_port,omitempty"`
+}
+
+// BrowseOriginConfig enables the native "real-origin" browse proxy: a loopback
+// HTTP reverse-proxy origin that serves mesh (dmsg) sites so the BROWSER does
+// native subresource loading, cookies, redirects, WASM and streaming — skywire
+// only proxies the transport over dmsg (see pkg/visor/meshproxy.go and
+// pkg/wasmhv/browseui/RFC-real-origin-browser.md). Content flows through THIS
+// visor's OWN transports; it is a local listener, never a shared/central relay.
+//
+// The browse iframe points at http://<vhost>.<base32pk><suffix>:<port>/, which
+// the browser resolves to loopback (for .mesh.localhost) or to wherever the
+// operator's DNS points (a hosted domain). This is the native counterpart of the
+// wasm surface's Service-Worker browse origin.
+type BrowseOriginConfig struct {
+	// Enable must be true for the reverse-proxy origin to start.
+	Enable bool `json:"enable"`
+	// Mode selects how each mesh site gets its own isolated browser origin:
+	//   "subdomain" (default) — ONE listener on Addr; each site is the origin
+	//     "<vhost>.<base32pk><Suffix>" routed by Host header. Needs *.<Suffix> to
+	//     resolve to loopback (*.mesh.localhost does in every target browser) or,
+	//     for a hosted domain, real wildcard DNS.
+	//   "port" — each site gets its OWN "127.0.0.1:<port>" origin from a small
+	//     pool (PortBase..PortBase+PortSpan). No DNS/wildcard dependency at all;
+	//     works anywhere. Weaker isolation than subdomain (cookies are domain-
+	//     scoped, not port-scoped), so prefer subdomain unless *.localhost can't
+	//     resolve in the target environment.
+	Mode string `json:"mode,omitempty"`
+	// Addr is the listen address for subdomain mode, and the "portal" listener
+	// (GET /open?host=… → 302 to the per-site port) for port mode. Default
+	// "127.0.0.1:8461". Loopback-only unless you front it with real TLS.
+	Addr string `json:"addr,omitempty"`
+	// Suffix is the subdomain-mode origin domain; must start with "." — default
+	// ".mesh.localhost" (loopback, no public cert needed). Set to a wildcard
+	// domain you control (e.g. ".haltingstate.net") or your own domain to serve
+	// a hosted browse origin behind real TLS.
+	Suffix string `json:"suffix,omitempty"`
+	// TLSCert / TLSKey, when BOTH set, serve the browse origin over HTTPS with
+	// this cert/key — a real cert for <Suffix>, or a locally-trusted one (e.g.
+	// from mkcert) for local https parity with the hosted origin (same scheme,
+	// real secure-context, real-domain cookie isolation). Empty = plain HTTP
+	// (fine for *.mesh.localhost, which is a secure context without TLS).
+	TLSCert string `json:"tls_cert,omitempty"`
+	TLSKey  string `json:"tls_key,omitempty"`
+	// PortBase / PortSpan bound the per-site loopback port pool used in "port"
+	// mode (least-recently-used eviction when full). Defaults 8470 / 64.
+	PortBase int `json:"port_base,omitempty"`
+	PortSpan int `json:"port_span,omitempty"`
 }
 
 // SkynetWebConfig enables the embedded `.skynet` resolving proxy — the

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -51,7 +51,9 @@ import (
 // WasmServeConfig configures ServeWasm. Mirrors the `hv serve` flags.
 type WasmServeConfig struct {
 	Addr     string          // HTTP listen address (e.g. ":8443")
-	TLS      bool            // serve HTTPS with a self-signed localhost cert
+	TLS      bool            // serve HTTPS (self-signed localhost cert, or TLSCert/TLSKey if set)
+	TLSCert  string          // optional cert file (PEM) — a locally-trusted *.mesh.localhost cert (mkcert) so B-origin iframes load without a per-host accept; empty = built-in self-signed
+	TLSKey   string          // optional key file (PEM), paired with TLSCert
 	Harness  bool            // mount the /ctl/* operator control bridge (DEV ONLY)
 	Wallet   bool            // serve the bundled skycoin-web wallet at /wallet/
 	Variant  string          // "" = build default; "go" | "tinygo"
@@ -104,6 +106,9 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	vh.Write(wasmhv.WorkerJS)
 	vh.Write(wasmhv.BrowseJS)
 	vh.Write(wasmhv.AutoUpdateJS)
+	vh.Write(wasmhv.BrowseSWJS)
+	vh.Write(wasmhv.BrowseBootstrapHTML)
+	vh.Write(wasmhv.BrowseResponderJS)
 	wasmVer := hex.EncodeToString(vh.Sum(nil))[:16]
 	// etag is the fingerprint as an HTTP entity tag. The version-bound assets
 	// below are served no-cache + ETag so every load REVALIDATES: unchanged →
@@ -112,7 +117,30 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// serving the previous 9.5MB blob from its HTTP cache while /wasm-version
 	// already reports the new hash.)
 	etag := `"` + wasmVer + `"`
-	index := injectWasmBoot(indexB, wasmVer, cfg.Harness)
+
+	// Real-origin browse origin (RFC §4a/§4b): the browse iframe loads a mesh site
+	// from an isolated origin B (<pkslug>.mesh.localhost) on THIS listener (host-
+	// routed below). Compute scheme+port once so the injected client config and the
+	// bootstrap substitutions agree; B and V share this listener + TLS cert.
+	browseScheme := "http"
+	if cfg.TLS {
+		browseScheme = "https"
+	}
+	bport := ""
+	if _, p, e := net.SplitHostPort(cfg.Addr); e == nil {
+		bport = p
+	}
+	vHostPort := "localhost"
+	if bport != "" {
+		vHostPort = "localhost:" + bport
+	}
+	// Injected so browse.js enters real-origin mode and builds <pk>.mesh.localhost
+	// :<port> origins for the WinBox browser iframe.
+	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:\".mesh.localhost\",scheme:" + strconv.Quote(browseScheme) + ",port:" + strconv.Quote(bport) + "};"
+	index := injectWasmBoot(indexB, wasmVer, cfg.Harness, browseOriginJS)
+
+	browseBootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__V_ORIGIN__"), []byte(browseScheme+"://"+vHostPort))
+	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(".mesh.localhost"))
 
 	mux := http.NewServeMux()
 	serveBytes := func(path, ct string, body []byte) {
@@ -185,6 +213,12 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	serveBytes("/manifest.webmanifest", "application/manifest+json", wasmhv.PWAManifest)
 	serveBytes("/icon-192.png", "image/png", wasmhv.PWAIcon192)
 	serveBytes("/icon-512.png", "image/png", wasmhv.PWAIcon512)
+	// Real-origin mesh browser (RFC §4b): the transport SW (served on the B origin,
+	// scope "/") and the V-origin mesh-fetch responder. The B navigation shell is
+	// host-routed below (it needs per-request substitution). browse-sw.js and
+	// browse-responder.js are static — the same bytes work on every origin.
+	serveBytes("/browse-sw.js", "text/javascript", wasmhv.BrowseSWJS)
+	serveBytes("/browse-responder.js", "text/javascript", wasmhv.BrowseResponderJS)
 	swJS := bytes.ReplaceAll(wasmhv.ServiceWorkerJS, []byte("__BUILD__"), []byte(wasmVer))
 	mux.HandleFunc("/sw.js", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/javascript")
@@ -277,6 +311,21 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		handler = wasmPasswordGate(mux, cfg.Password, cfg.TLS)
 		log.Info("wasm-serve access-password gate enabled")
 	}
+	// Host-route isolated browse origins B (<pkslug>.mesh.localhost): a request to
+	// B for the transport SW falls through to the mux (same bytes, any host); every
+	// other B request is served the real-origin bootstrap shell, which registers
+	// the SW, injects the mesh page into B, and thereafter the SW intercepts
+	// subresources. Non-B hosts (the visor origin V = localhost) are untouched.
+	base := handler
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isMeshBrowseHost(r.Host) && r.URL.Path != "/browse-sw.js" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-store")
+			_, _ = w.Write(browseBootstrap) //nolint:errcheck
+			return
+		}
+		base.ServeHTTP(w, r)
+	})
 	srv := &http.Server{
 		Addr:              cfg.Addr,
 		Handler:           handler,
@@ -289,7 +338,16 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	}()
 
 	if cfg.TLS {
-		cert, err := wasmLocalhostTLSCert()
+		var cert tls.Certificate
+		var err error
+		if cfg.TLSCert != "" && cfg.TLSKey != "" {
+			// Operator-supplied cert (e.g. a locally-trusted *.mesh.localhost cert
+			// from mkcert, or a real wildcard cert) — B-origin iframes load with no
+			// per-host accept.
+			cert, err = tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+		} else {
+			cert, err = wasmLocalhostTLSCert()
+		}
 		if err != nil {
 			return fmt.Errorf("tls cert: %w", err)
 		}
@@ -370,10 +428,18 @@ func walletDmsgFetchShim() string {
 // injectWasmBoot inserts the hv-boot.js bootstrap (+ browse/autoupdate,
 // and either the harness ctl-bridge or the PWA manifest/SW) right after
 // <head> so it runs before Angular's deferred module scripts.
-func injectWasmBoot(index []byte, wasmVer string, harness bool) []byte {
+func injectWasmBoot(index []byte, wasmVer string, harness bool, browseOriginJS string) []byte {
 	s := string(index)
-	tag := "\n<script src=\"hv-boot.js\"></script>\n" +
+	tag := "\n"
+	if browseOriginJS != "" {
+		// Set BEFORE browse.js loads so the WinBox browser picks real-origin mode.
+		tag += "<script>" + browseOriginJS + "</script>\n"
+	}
+	tag += "<script src=\"hv-boot.js\"></script>\n" +
 		"<script src=\"browse.js\"></script>\n" +
+		// Mesh-fetch responder: lets embedded <pk>.mesh.localhost browse iframes
+		// reach THIS app's first-party skywireVisor (RFC §4b real-origin browser).
+		"<script src=\"browse-responder.js\"></script>\n" +
 		"<script>" + wasmhv.BrowseLauncherJS + "</script>\n" +
 		"<script>window.__SKYWIRE_WASM_VERSION__=" + strconv.Quote(wasmVer) + ";</script>\n" +
 		"<script src=\"autoupdate.js\"></script>\n"
@@ -395,6 +461,18 @@ func injectWasmBoot(index []byte, wasmVer string, harness bool) []byte {
 	return []byte(tag + s)
 }
 
+// isMeshBrowseHost reports whether an HTTP Host header targets an isolated
+// real-origin browse origin B (<...>.mesh.localhost[:port]) rather than the visor
+// origin V (localhost). Browsers resolve *.localhost to loopback, so these hit
+// the same wasm-serve listener and are distinguished only by Host.
+func isMeshBrowseHost(h string) bool {
+	host := h
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	return strings.HasSuffix(host, ".mesh.localhost")
+}
+
 // wasmLocalhostTLSCert returns a self-signed localhost cert for
 // --wasm-serve-tls, persisted under the temp dir and reused across
 // restarts. NOT for production.
@@ -403,8 +481,15 @@ func wasmLocalhostTLSCert() (tls.Certificate, error) {
 	certPath, keyPath := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
 
 	if c, err := tls.LoadX509KeyPair(certPath, keyPath); err == nil {
+		// Reuse the cached cert only if it's unexpired AND already carries the
+		// *.mesh.localhost SAN (real-origin browse origins B share this one cert
+		// with the visor origin V); otherwise fall through and regenerate.
 		if leaf, e := x509.ParseCertificate(c.Certificate[0]); e == nil && time.Now().Before(leaf.NotAfter) {
-			return c, nil
+			for _, n := range leaf.DNSNames {
+				if n == "*.mesh.localhost" {
+					return c, nil
+				}
+			}
 		}
 	}
 
@@ -424,8 +509,11 @@ func wasmLocalhostTLSCert() (tls.Certificate, error) {
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
-		DNSNames:              []string{"localhost"},
-		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		// localhost = the visor origin V; *.mesh.localhost + mesh.localhost = the
+		// isolated real-origin browse origins B (<pkslug>.mesh.localhost), so one
+		// cert covers V and every B under the same wasm-serve listener.
+		DNSNames:    []string{"localhost", "mesh.localhost", "*.mesh.localhost"},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
 	}
 	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
 	if err != nil {

--- a/pkg/wasmhv/browse-bootstrap.html
+++ b/pkg/wasmhv/browse-bootstrap.html
@@ -1,0 +1,164 @@
+<!doctype html>
+<!-- pkg/wasmhv/browse-bootstrap.html c4-app-skynet
+     Bootstrap shell for the real-origin mesh browser (RFC §4b). Served by
+     wasm-serve for NAVIGATIONS to an isolated browse origin B
+     ("<vhost>.<base32pk>[.<net>].mesh.localhost" or a hosted <pk>.<domain>). It:
+       1. registers browse-sw.js (the transport SW for B),
+       2. embeds a hidden helper iframe on the VISOR origin V (which reaches the
+          in-tab SharedWorker wasm visor and mediates fetches — the trust
+          boundary; B can only ask it to "fetch a mesh URL", never touch the key),
+       3. relays SW mesh-fetch messages ↔ the helper (same-origin SW <-> the shell
+          page <-> cross-origin V helper via postMessage with targetOrigin checks),
+       4. fetches the real mesh page over the visor's transports and writes it into
+          THIS real origin (document.write — a genuine origin, unlike the old
+          sandboxed srcdoc), after which all subresources flow through the SW.
+     __V_ORIGIN__ and __SUFFIX__ are substituted by wasm-serve at request time. -->
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>mesh://loading…</title>
+<style>
+  html,body{margin:0;height:100%;background:#0b0d17;color:#c7cbe6;font:14px/1.5 system-ui,sans-serif}
+  #mesh-boot{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;flex-direction:column;gap:10px}
+  #mesh-boot .sp{width:26px;height:26px;border:3px solid #2b3163;border-top-color:#7c83ff;border-radius:50%;animation:spin 1s linear infinite}
+  @keyframes spin{to{transform:rotate(360deg)}}
+  #mesh-boot small{opacity:.6}
+</style>
+<div id="mesh-boot"><div class="sp"></div><div id="mesh-msg">Connecting to the mesh…</div><small id="mesh-host"></small></div>
+<script>
+(function () {
+  'use strict';
+  var V_ORIGIN = "__V_ORIGIN__";      // visor origin (holds the SharedWorker visor + key)
+  var SUFFIX   = "__SUFFIX__" || ".mesh.localhost";
+
+  function fail(msg) {
+    var m = document.getElementById('mesh-msg'); if (m) { m.textContent = msg; }
+    var b = document.getElementById('mesh-boot'); if (b) { b.querySelector('.sp').style.display = 'none'; }
+  }
+
+  // meshTarget derives the resolving-proxy host (for skywireVisor.fetchDmsg) from
+  // this origin's hostname: "<vhost>.<base32pk>[.<net>].mesh.localhost" →
+  // "<vhost>.<base32pk>.dmsg" (or ".skynet"). fetchDmsg resolves base32/hex PKs,
+  // aliases and name-vhost forms Go-side.
+  function meshTarget() {
+    var host = location.hostname;
+    if (host.slice(-SUFFIX.length) === SUFFIX) host = host.slice(0, -SUFFIX.length);
+    var net = 'dmsg';
+    if (/\.skynet$/.test(host)) { net = 'skynet'; host = host.replace(/\.skynet$/, ''); }
+    else if (/\.dmsg$/.test(host)) { net = 'dmsg'; host = host.replace(/\.dmsg$/, ''); }
+    return { host: host + '.' + net, net: net };
+  }
+
+  var tgt = meshTarget();
+  var hostEl = document.getElementById('mesh-host'); if (hostEl) hostEl.textContent = tgt.host;
+
+  // --- bridge to the PARENT visor app (V) ----------------------------------
+  // This browse origin B is embedded as an iframe INSIDE the visor app V (the
+  // WinBox browser). We post 'mesh-hello' to window.parent (V); V's injected
+  // browse-responder replies with a MessagePort we post {fetch} to. V validates
+  // and calls its OWN first-party skywireVisor.* — we never get the key. (We do
+  // NOT create a helper iframe on V: under Storage Partitioning a cross-origin
+  // helper iframe lands in a different partition and can't reach V's booted
+  // SharedWorker visor. The first-party parent can.)
+  var helperReady = null;
+  var helperPort = null;
+  function ensureHelper() {
+    if (helperReady) return helperReady;
+    helperReady = new Promise(function (resolve, reject) {
+      if (!(window.parent && window.parent !== window)) {
+        reject(new Error('mesh browser must be embedded in the visor app'));
+        return;
+      }
+      var to = setTimeout(function () { reject(new Error('visor parent timeout')); }, 30000);
+      window.addEventListener('message', function onmsg(e) {
+        if (e.origin !== V_ORIGIN) return;               // only trust V
+        if (!e.data || e.data.type !== 'mesh-helper-ready') return;
+        if (!e.ports || !e.ports[0]) return;
+        clearTimeout(to);
+        helperPort = e.ports[0];
+        window.removeEventListener('message', onmsg);
+        resolve(helperPort);
+      });
+      // retry the hello a few times in case the parent's responder isn't wired yet
+      var tries = 0;
+      (function hello() {
+        if (helperPort || tries > 30) return;
+        tries++;
+        try { window.parent.postMessage({ type: 'mesh-hello' }, V_ORIGIN); } catch (e) {}
+        setTimeout(hello, 300);
+      })();
+    });
+    return helperReady;
+  }
+
+  // helperFetch sends one request to the V helper and resolves {status,headers,body}.
+  var nextId = 1, pending = {};
+  function helperFetch(reqObj, transfer) {
+    return ensureHelper().then(function (port) {
+      if (!port.__wired) {
+        port.__wired = true;
+        port.onmessage = function (ev) {
+          var d = ev.data || {}; var cb = pending[d.id];
+          if (cb) { delete pending[d.id]; cb(d); }
+        };
+      }
+      return new Promise(function (resolve) {
+        var id = nextId++; pending[id] = resolve;
+        port.postMessage({ id: id, req: reqObj }, transfer || []);
+      });
+    });
+  }
+
+  // --- SW registration + relay ---------------------------------------------
+  // The SW (browse-sw.js) posts {type:'mesh-fetch'} with a MessageChannel port
+  // for each subresource; we relay to the helper and reply on that port.
+  navigator.serviceWorker && window.addEventListener('message', function () {}); // noop guard
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.addEventListener('message', function (e) {
+      var d = e.data || {};
+      if (d.type !== 'mesh-fetch' || !e.ports || !e.ports[0]) return;
+      var replyPort = e.ports[0];
+      var r = d.req || {};
+      var transfer = r.body ? [r.body] : [];
+      helperFetch({ host: tgt.host, net: tgt.net, url: r.url, method: r.method, headers: r.headers, body: r.body }, transfer)
+        .then(function (res) {
+          var t = res.body ? [res.body] : [];
+          replyPort.postMessage(res, t);
+        })
+        .catch(function (err) { replyPort.postMessage({ error: String(err) }); });
+    });
+  }
+
+  function registerSW() {
+    if (!('serviceWorker' in navigator)) return Promise.resolve(null);
+    return navigator.serviceWorker.register('/browse-sw.js', { scope: '/' })
+      .then(function () { return navigator.serviceWorker.ready; })
+      .catch(function () { return null; }); // fall through; top page still injects
+  }
+
+  // --- boot ----------------------------------------------------------------
+  // Register the SW + prime the helper, then fetch THIS path's mesh HTML through
+  // the visor and write it into the real origin.
+  window.__mb = { step: 'start', helperReady: false, topStatus: null, topLen: 0, err: null };
+  Promise.all([
+    registerSW().then(function () { window.__mb.step = 'sw-registered'; }),
+    ensureHelper().then(function () { window.__mb.helperReady = true; window.__mb.step = 'helper-ready'; })
+  ]).then(function () {
+    window.__mb.step = 'fetching-top';
+    var path = location.pathname + location.search;
+    return helperFetch({ host: tgt.host, net: tgt.net, url: location.href, method: 'GET', headers: {}, body: null, path: path });
+  }).then(function (res) {
+    window.__mb.step = 'top-returned';
+    window.__mb.topStatus = res && res.status;
+    window.__mb.topLen = (res && res.body) ? res.body.byteLength : 0;
+    if (!res || res.error) { window.__mb.err = (res && res.error) || 'no response'; fail('mesh: ' + ((res && res.error) || 'no response')); return; }
+    if ((res.status | 0) >= 400) { fail('mesh: HTTP ' + res.status); return; }
+    var html = '';
+    if (res.body) { try { html = new TextDecoder('utf-8').decode(new Uint8Array(res.body)); } catch (e) { html = ''; } }
+    // Replace the shell with the real page ON THIS ORIGIN. Subresources it
+    // requests are relative/absolute to B and get intercepted by the SW.
+    document.open();
+    document.write(html);
+    document.close();
+  }).catch(function (err) { try { window.__mb.err = String(err); window.__mb.step = 'catch'; } catch (e) {} fail('mesh: ' + String(err)); });
+})();
+</script>

--- a/pkg/wasmhv/browse-responder.js
+++ b/pkg/wasmhv/browse-responder.js
@@ -1,0 +1,73 @@
+// pkg/wasmhv/browse-responder.js c4-app-skynet
+// Mesh-fetch responder, injected into the VISOR app origin V (the page that hosts
+// the WinBox browser and holds the first-party, booted globalThis.skywireVisor).
+// It is the trust boundary for the real-origin mesh browser (RFC §4b): a browse
+// origin B (<pk>.mesh.localhost), embedded as an iframe inside V, posts
+// {type:'mesh-hello'}; we validate its origin, hand back a private MessagePort,
+// and service fetch requests on it via V's OWN skywireVisor — B never gets the
+// key, only a "fetch this mesh URL" capability.
+//
+// This replaces the old cross-origin helper iframe, which Storage Partitioning
+// put in a different partition than V's SharedWorker visor (so it couldn't reach
+// the booted visor). The first-party parent (V) has no such problem.
+(function () {
+  'use strict';
+  if (window.__meshResponderInstalled) { return; }
+  window.__meshResponderInstalled = true;
+
+  // isBrowseOrigin: only serve real-origin browse frames. Local: *.mesh.localhost.
+  // Hosted browse domains would be added here (kept in sync with the server's
+  // isMeshBrowseHost / the configured browse suffix).
+  function isBrowseOrigin(origin) {
+    try {
+      var h = new URL(origin).hostname;
+      return /\.mesh\.localhost$/.test(h);
+    } catch (e) { return false; }
+  }
+
+  function pathOf(u, fb) {
+    try { var x = new URL(u); return x.pathname + x.search; } catch (e) { return fb || '/'; }
+  }
+
+  function toArrayBuffer(body) {
+    if (!body) { return null; }
+    if (body instanceof ArrayBuffer) { return body; }
+    if (body.buffer) { return body.buffer.slice(body.byteOffset || 0, (body.byteOffset || 0) + body.byteLength); }
+    return null;
+  }
+
+  function serve(req) {
+    var v = globalThis.skywireVisor;
+    if (!v || !v.fetchDmsg) { return Promise.reject(new Error('visor not ready')); }
+    var method = req.method || 'GET';
+    var headers = req.headers || {};
+    var bodyU8 = req.body ? new Uint8Array(req.body) : null;
+    if (req.net === 'skysocks') {
+      // clearnet egress via skysocks-lite (empty exit = auto pool w/ failover)
+      return v.fetchClearnet('', method, req.url, bodyU8, '', headers);
+    }
+    // mesh over dmsg (wasm has no separate skynet round-tripper today → dmsg
+    // serves dmsg + auto).
+    return v.fetchDmsg(req.host, method, pathOf(req.url, req.path), bodyU8, headers);
+  }
+
+  window.addEventListener('message', function (e) {
+    var d = e.data || {};
+    if (d.type !== 'mesh-hello') { return; }
+    if (!isBrowseOrigin(e.origin) || !e.source) { return; }
+    var mc = new MessageChannel();
+    mc.port1.onmessage = function (ev) {
+      var q = ev.data || {};
+      serve(q.req || {}).then(function (r) {
+        r = r || {};
+        var ab = toArrayBuffer(r.body);
+        mc.port1.postMessage({ id: q.id, status: r.status || 200, headers: r.headers || {}, body: ab }, ab ? [ab] : []);
+      }).catch(function (err) {
+        mc.port1.postMessage({ id: q.id, error: String((err && err.message) || err) });
+      });
+    };
+    // Hand the browse frame its private request port (targetOrigin = the frame's
+    // own origin, so only it receives the capability).
+    e.source.postMessage({ type: 'mesh-helper-ready' }, e.origin, [mc.port2]);
+  });
+})();

--- a/pkg/wasmhv/browse-sw.js
+++ b/pkg/wasmhv/browse-sw.js
@@ -1,0 +1,107 @@
+// pkg/wasmhv/browse-sw.js c4-app-skynet
+// Transport Service Worker for the real-origin mesh browser (RFC §4b:
+// pkg/wasmhv/browseui/RFC-real-origin-browser.md). It runs on an ISOLATED browse
+// origin B = "<pkslug>.mesh.localhost" (or a hosted <pk>.<domain>), NOT on the
+// visor origin V. Its whole job is to be the network layer for B: every
+// subresource/fetch/XHR the rendered mesh page makes is intercepted here and
+// fulfilled through the IN-TAB wasm visor's own transports — the page never talks
+// to a server for content, and B (untrusted mesh content) can never reach V's
+// identity key.
+//
+// It is DISTINCT from pkg/wasmhv/sw.js (the PWA app-shell cache for V). This one
+// is a transport relay, scoped to B.
+//
+// Bridge chain (see the bootstrap shell, browse-bootstrap.html):
+//   SW.fetch → postMessage(controlling B page, MessageChannel) → the B page
+//   relays to a hidden V-origin helper iframe (postMessage w/ targetOrigin) →
+//   the iframe calls skywireVisor.fetchDmsg / fetchClearnet (its SharedWorker
+//   visor) → response streams back the same chain → SW builds a Response.
+//
+// Navigations are NOT handled here — they hit the server shell, which injects the
+// real mesh HTML into B via document.write (a real origin, unlike the old
+// sandboxed srcdoc). Only non-navigation requests are relayed, so there is no
+// "who serves the first page" chicken-and-egg.
+
+'use strict';
+
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (e) {
+  e.waitUntil(self.clients.claim());
+});
+
+// bridgeFetch asks a controlling B page to fulfil req through the wasm visor and
+// resolves to a Response. Uses a per-request MessageChannel so concurrent
+// subresource loads don't collide.
+function bridgeFetch(req, clientId) {
+  return (async function () {
+    var client = null;
+    if (clientId) {
+      client = await self.clients.get(clientId);
+    }
+    if (!client) {
+      var all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+      client = all && all[0];
+    }
+    if (!client) {
+      return new Response('mesh browser: no controlling page to relay through', { status: 503 });
+    }
+
+    var bodyBuf = null;
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      try { bodyBuf = await req.clone().arrayBuffer(); } catch (e) { bodyBuf = null; }
+    }
+    var headers = {};
+    req.headers.forEach(function (v, k) { headers[k] = v; });
+
+    return await new Promise(function (resolve) {
+      var mc = new MessageChannel();
+      var settled = false;
+      var timer = setTimeout(function () {
+        if (settled) return;
+        settled = true;
+        resolve(new Response('mesh browser: upstream timeout', { status: 504 }));
+      }, 60000);
+
+      mc.port1.onmessage = function (ev) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        var r = ev.data || {};
+        if (r.error) {
+          resolve(new Response('mesh browser: ' + r.error, { status: 502 }));
+          return;
+        }
+        // r.headers is a plain object; r.body is an ArrayBuffer (transferred).
+        var h = new Headers();
+        if (r.headers) {
+          Object.keys(r.headers).forEach(function (k) {
+            // strip hop-by-hop / framing headers the browser must recompute
+            var lk = k.toLowerCase();
+            if (lk === 'content-length' || lk === 'transfer-encoding' || lk === 'connection') return;
+            try { h.set(k, r.headers[k]); } catch (e) { /* invalid header name */ }
+          });
+        }
+        resolve(new Response(r.body || null, { status: r.status || 200, headers: h }));
+      };
+
+      client.postMessage({
+        type: 'mesh-fetch',
+        req: { url: req.url, method: req.method, headers: headers, body: bodyBuf }
+      }, bodyBuf ? [mc.port2, bodyBuf] : [mc.port2]);
+    });
+  })();
+}
+
+self.addEventListener('fetch', function (e) {
+  var req = e.request;
+  // Navigations are served by the server shell (which injects the real mesh HTML
+  // into this origin). Everything else — subresources, fetch(), XHR, imports,
+  // streaming media — is relayed through the in-tab visor.
+  if (req.mode === 'navigate') {
+    return;
+  }
+  e.respondWith(bridgeFetch(req, e.clientId));
+});

--- a/pkg/wasmhv/browseui/RFC-real-origin-browser.md
+++ b/pkg/wasmhv/browseui/RFC-real-origin-browser.md
@@ -1,0 +1,280 @@
+# RFC: Align the skynet iframe browser with a real browser (real-origin transparent proxy)
+
+Status: draft / for discussion
+Scope: `pkg/wasmhv/browseui/browse.js`, `pkg/visor/api_browse.go`,
+`pkg/visor/hypervisor_handlers_browse.go`, `cmd/wasm-visor/*_js.go`, and the
+reference implementation `pkg/dmsgweb`.
+
+## 1. Problem
+
+The WinBox "skynet browser" does not proxy a browser — it **re-implements a
+browser in JavaScript**. A top-level navigation fetches the HTML through a
+backend call, parses it off-DOM, rewrites/inlines its subresources, injects a
+CSP, and drops the result into an iframe as **`srcdoc` with
+`sandbox="allow-scripts allow-forms"` and no `allow-same-origin`** — i.e. a
+**null/opaque origin with no URL**. Every web-platform behaviour after that is
+approximated in JS: `fetch`/XHR are monkeypatched, links/forms/history are
+re-dispatched via `postMessage`, storage/cookies/serviceWorker are stubbed, and
+subresources are pre-fetched and turned into `data:` URIs.
+
+Re-implementing the web platform in a sandbox is inherently lossy. The bugs we
+keep hitting are all facets of one architecture:
+
+- `magnetosphere.net.<pk>.dmsg` → **`200`/`3xx` with 0 bytes**: the single-shot
+  fetcher never follows the `Location` of Caddy's HTTP→HTTPS redirect, and the
+  render guard only error-pages `>= 400`, so the empty redirect body renders as
+  a blank page.
+- `skycoin.com` → **`502` bursts**: an SPA's request storm maps 1:1 onto
+  unbounded concurrent per-request dmsg/skysocks round-trips, and any failure in
+  the bridge is turned into a synthetic `502`.
+- WASM sites blank even though the CSP grants `wasm-unsafe-eval`: the site's own
+  `.wasm`/bundle fetches don't complete faithfully through the bridge.
+
+### Root divergences (ranked by how much breakage each explains)
+
+1. **Opaque-origin sandboxed `srcdoc` instead of a real origin.** Master cause:
+   no cookies, no `localStorage`/`sessionStorage` persistence, no service
+   workers, `history.pushState` throws, no secure context, no cross-site
+   isolation. Breaks every login/session/PWA.
+2. **Request/response transcoding with no redirect following and lossy
+   headers.** The bridge keeps only status + `Content-Type` + body; multi-value
+   headers (`Set-Cookie`) collapse, `Location`/caching/`Content-Disposition` are
+   dropped, MIME is guessed from the path extension when absent, 3xx is never
+   followed.
+3. **DOM/URL rewriting + `fetch`/XHR monkeypatching instead of a real network
+   stack.** `import()`/ES-modules can't be intercepted, `srcset`/responsive
+   images are dropped, streaming/range is impossible, `window.location`/popups
+   break, forms can't do multipart/file upload.
+4. **No WebSocket / SSE / streaming + `connect-src 'none'` fail-closed CSP.**
+   Kills all real-time apps.
+5. **Unbounded fan-out over per-request streams with synthetic 502-on-error.**
+   The fragility on asset-heavy pages.
+6. **No dmsg TLS-MITM analog; the `https` scheme is cosmetic** for dmsg sites.
+
+Divergences #1–#2 cannot be fixed by patching the transcoder — they are the
+transcoder.
+
+## 2. The reference is already in the tree: `pkg/dmsgweb`
+
+`dmsgweb` is a **transparent SOCKS5 splice**, not a transcoder (`runtime.go`
+package doc: "raw TCP forwards bytes transparently and works for HTTP,
+WebSockets, server-sent events, chunked transfers, and any other protocol").
+A real browser pointed at it "just works" because:
+
+- it **resolves `.dmsg`/`.skynet` to `127.0.0.1`** so the browser issues normal
+  requests (and non-mesh TLDs also map to loopback to prevent DNS leaks);
+- `Dial` returns a **raw dmsg stream** as the SOCKS tunnel — the browser's own
+  HTTP/1.1 bytes (its cookies, redirects, keep-alive, range, `Upgrade`) flow
+  through untouched;
+- name-based backends get a **`Host` rewrite on the real byte stream**;
+- **`CONNECT` on :443 is TLS-MITM'd** with a locally-trusted leaf cert, so
+  `https://…dmsg` is a real secure context.
+
+The browser stays the browser; skywire only moves the transport. That is the
+behaviour we want inside the WinBox app too.
+
+## 3. Design principle
+
+> **Proxy the transport; don't re-implement the browser.**
+> The iframe must load from a **real origin** served by a transparent proxy that
+> streams responses **verbatim** (status + all headers + body, redirects,
+> chunked/streaming, content-types). Subresource loading, redirects, cookies,
+> WASM, streaming, and relative-URL resolution become the **browser's** job —
+> correct by construction — and skywire supplies only the mesh transport.
+
+An in-page iframe can't be given a SOCKS proxy (that's browser-global — which is
+exactly what Waterfox does and what we just proved works). So we give it a real
+origin backed by a transparent proxy, per surface:
+
+## 4. Proposed architecture
+
+### 4a. Native visor (:8000): local reverse-proxy origin
+
+Expose a reverse proxy that is an **origin the iframe points at**, reusing
+`dmsgweb`'s resolver + dialer + TLS-MITM rather than duplicating them:
+
+- Per-site origin via **`*.localhost` subdomains**:
+  `http://<pkslug>.mesh.localhost:<proxyport>/<path>` (browsers resolve any
+  `*.localhost` to loopback **and** treat each subdomain as a **distinct
+  origin**). This restores per-site cookie/storage/CORS isolation that the
+  current single-opaque-origin model destroys.
+- The iframe's `src` is that real URL. The browser fetches **every** subresource
+  itself; those requests hit the same reverse-proxy origin and are forwarded
+  over dmsg/skysocks. **Zero DOM/URL rewriting.**
+- Response is streamed **verbatim** — status, all headers, body — so redirects,
+  `Set-Cookie`, content-types (incl. `application/wasm`), chunked/SSE all pass
+  through. `Location` on a same-mesh redirect is rewritten host→`*.localhost`
+  subdomain (or the resolver maps it) so the browser follows it back through the
+  proxy.
+- HTTPS mesh sites: the reverse proxy does the **TLS-MITM upstream** (reusing
+  `dmsgweb`'s MITM + the existing `~/.skywire/resolver` CA) and serves the
+  iframe locally; the site is a real secure context.
+
+Net: cookies, storage, service workers, history, WASM, streaming, WebSockets,
+forms (incl. file upload) all work, because the browser is doing them.
+
+### 4b. Wasm visor (:8443 / standalone): service worker as the network layer
+
+The wasm visor's dmsg client lives **in the browser** (Go/wasm in the visor
+app), not in a privileged Go process, so the transport must be reached from the
+browser. The isolated origin is achieved with the **same `*.mesh.localhost`
+scheme as the native case** — the difference is only *who fulfils the fetch*:
+
+**Origins (one listener, Host-routed):** `wasmserve` already runs an HTTP(S)
+server for the visor app. Serve two origin classes off the same listener:
+
+- `localhost:<port>` (+ the real host) = the **visor app origin `V`** — holds the
+  wasm dmsg client and the identity key.
+- `<pkslug>.mesh.localhost:<port>` = the **browse-frame origin(s) `B`** — one
+  distinct origin per mesh site. `wasmserve` serves only a tiny bootstrap page +
+  the Service Worker for these; the SW answers everything after install.
+
+`B ≠ V` (different host) makes them **cross-origin**, so a mesh site can never
+reach the visor's origin, storage, or key. Per-site `<pkslug>` subdomains also
+isolate sites **from each other** (separate cookies/storage). Both are served on
+the *same TCP port* — the browser sends distinct `Host` headers and the browser
+treats each as a distinct origin; no second listener needed.
+
+**The SW as the transport:** the SW scoped to `B` intercepts the top navigation
+**and every subresource** and fulfils each via the in-wasm dmsg/clearnet fetch,
+returning a `Response` streamed **verbatim** (status + headers + body,
+`Content-Type` preserved, `redirect:"manual"` followed by re-issuing through the
+proxy). The browse iframe's `src` is a real URL
+(`https://<pkslug>.mesh.localhost:<port>/<path>`); the browser does native
+subresource loading, and the site gets real cookies/storage/history/WASM/
+streaming — isolated from `V` and from other sites.
+
+**Wiring the SW → in-wasm fetch (the crux):** a SW on origin `B` cannot postMessage
+across to origin `V`. So establish the channel **out-of-band, once per `B`
+origin**, without involving any untrusted site document:
+
+1. The visor app `V` opens a **hidden helper iframe** on origin `B` (a page we
+   control, served by `wasmserve`).
+2. `V` ↔ helper(`B`) do a `postMessage` handshake over a `MessageChannel`; the
+   helper **transfers one `MessagePort` to `B`'s Service Worker**
+   (`navigator.serviceWorker.controller.postMessage(port, [port])`).
+3. The SW now holds a private port to `V`'s wasm. For each intercepted request it
+   sends `{method, url, headers, body}` over the port; `V`'s wasm runs the
+   existing `fetchDmsg`/`fetchClearnet` and returns
+   `{status, headers, body}` (transferred `ArrayBuffer`); the SW builds the
+   `Response`.
+4. The port carries **only the transport capability**, never the identity key,
+   and is held by the SW — not exposed to any site document. The untrusted site
+   (later loaded as the top document of `B`) shares origin `B` with the SW but
+   has no handle to the helper or the port; it can only *cause* fetches, which is
+   the intended behaviour.
+
+**Secure context / mixed content:** Service Workers require a secure context.
+`*.localhost` is treated as potentially-trustworthy (secure) by Chromium and
+Firefox, so `http://<pkslug>.mesh.localhost` alone is SW-eligible. But when the
+visor app `V` is served over **HTTPS** (`hv serve --tls`), an `http://` `B`
+iframe is mixed-content-blocked — so `B` must also be HTTPS. Extend
+`wasmLocalhostTLSCert` to add a `*.mesh.localhost` SAN (and `mesh.localhost`) so
+the one self-signed cert covers both `V` and every `B`. When `V` is plain HTTP
+(no `--tls`), `B` is plain HTTP too and no cert work is needed.
+
+**Hosting modes — the `B`-origin suffix is a DEPLOYMENT PARAMETER, not `.localhost`.**
+`*.localhost` resolves to loopback with no DNS, so `<pkslug>.mesh.localhost` only
+reaches a server running on the *user's own machine*. That holds for a local
+`wasmserve` (`hv serve` / `wasm_serve` on `:8443`) and for the native visor
+(always local), but NOT when the wasm visor is fetched from a remote host (e.g.
+`theskywirenetwork.net`) — there is no co-located listener. The SW + helper-iframe
+`MessagePort` bridge is identical in every case (cross-origin `postMessage`/port
+transfer works regardless of where the origins live); only where `B` is served
+changes, so the suffix is configured per deployment:
+
+- **Local** (`wasmserve` on the machine, or native visor): `B = <pkslug>.mesh.localhost`
+  → loopback → the co-located listener.
+- **Remote, wildcard subdomain (443-friendly, preferred):**
+  `B = <pkslug>.mesh.<publichost>`, needing wildcard DNS `*.mesh.<publichost>` +
+  a wildcard TLS cert; the server serves only the SW bootstrap there (it does NOT
+  proxy dmsg — the SW relays to `V`'s in-tab wasm). Keeps per-site isolation, works
+  over 443 (CDN-compatible).
+- **Remote, second port on the same host:** `B = <publichost>:<port2>` — cross-origin
+  from `V` (port is part of origin), and the existing host cert already covers it
+  (certs are host-scoped, not port-scoped), so no wildcard DNS. Cheaper, but loses
+  *inter-site* isolation (all sites share one `B`) and needs a non-443 port (not
+  CDN-friendly).
+- **Shared browse origin (alternative):** one skywire-operated `*.mesh.<shared>`
+  used by any deployment; removes per-deploy wildcard setup at the cost of
+  centralizing (and having to trust/pin) the host serving the SW code.
+
+The native reverse-proxy (§4a) is unaffected — the native visor is always the
+local daemon, so loopback is always correct there; this only concerns the wasm
+surface's hosted mode.
+
+**Residual limitations (documented, far smaller than today's):** the site's *own*
+service worker can't nest under ours; and environments with no `B`-origin at all
+(`file://` single-file HV, or a static host with neither a wildcard subdomain nor
+a spare port) fall back to the transcoder (§6). Per-site subdomain isolation can
+ship in a second step (v1 may share one `B` origin for simplicity, still
+protecting `V`).
+
+## 5. Security / isolation trade-off
+
+- **Today:** opaque `srcdoc` = strong isolation, broken platform. The site can't
+  persist anything or reach the visor — but also can't function.
+- **Proposed:** a **real, per-site, isolated origin** = correct platform + real
+  origin isolation *between mesh sites*. The site gains real cookies/storage
+  (which is the point — logins work), so the design must guarantee the site's
+  origin can **never** reach the visor's origin or secret key: separate origin
+  (distinct `*.localhost` subdomain / distinct SW origin), no shared storage,
+  `frame-ancestors`/`X-Frame-Options` on the visor origin, and the reverse proxy
+  refusing to proxy the visor's own control endpoints.
+
+## 6. What we keep
+
+The current transcoder is retained as an explicit **fallback** for environments
+with no proxy origin available — the `file://` single-file hypervisor, or a
+browser where SW/`*.localhost` isn't usable. Feature-detect and prefer the
+real-origin path; fall back to transcoding with a visible "compatibility mode"
+indicator.
+
+## 7. Divergence inventory → how the new model resolves it
+
+| Current mechanism (approximation) | Real-origin model |
+|---|---|
+| Opaque `srcdoc`, no origin | Real per-site origin (`*.localhost` / isolated SW origin) |
+| `window.fetch`/XHR monkeypatch | Native fetch/XHR through the proxy origin |
+| `<script>`/`<link>`/`<img>` pre-inline as `data:` | Native subresource loading (streamed) |
+| `srcset` dropped, images lazy-swapped | Native responsive images |
+| ES-module `import()` uninterceptable | Works (native) |
+| Form serialize→re-fetch, no file upload | Native form submit incl. multipart |
+| History as parent-side stack; `pushState` swallowed | Native history / SPA routing |
+| storage/cookie/serviceWorker stubs | Real storage/cookies; SW is *ours* (transport) |
+| MIME guessed from extension | Upstream `Content-Type` preserved verbatim |
+| No redirect follow → blank pages | Browser follows redirects natively |
+| `connect-src 'none'`, no WS/SSE | Native WS/SSE/streaming through the tunnel |
+| Unbounded fan-out → 502 bursts | Browser's own connection management + a bounded transport pool |
+| base64 body, 16 MiB cap | Streamed bytes, no cap |
+
+## 8. Migration path
+
+1. **Native, behind a flag:** implement the reverse-proxy origin
+   (`dmsgweb`-derived) + `*.localhost` per-site origins; point the WinBox iframe
+   at real URLs; keep the transcoder as fallback. Validate against the
+   Waterfox+resolving-proxy reference (`cmd/wfdrive`).
+2. **Wasm:** SW network layer on an isolated origin; same validation.
+3. **Flip the default** to the real-origin path; transcoder only as fallback.
+4. **Delete** the redundant approximation code paths once parity holds.
+
+Throughout: **reuse `pkg/dmsgweb`** (resolver, dialer, TLS-MITM, host rewrite) —
+the reverse proxy is a thin re-framing of the forward proxy, not a re-write.
+
+## 9. Open questions / risks
+
+- `*.localhost` origin behaviour across OSes/browsers (Chromium + Firefox both
+  map `*.localhost`→loopback and isolate origins; confirm on the target set).
+- Per-site local TLS: wildcard/on-the-fly leaf issuance from the local CA for
+  `https://<pkslug>.mesh.localhost`.
+- Wasm isolated-origin problem — **resolved in §4b** via `*.mesh.localhost`
+  Host-routed origins + a SW whose transport port is wired from `V` through a
+  hidden helper iframe. Residual risks: robustness of the SW↔`V` port handshake
+  across reload/SW-restart (re-wire on `controllerchange`); per-origin SW
+  registration cost if per-site subdomains are used from v1; `*.mesh.localhost`
+  SAN on the self-signed cert when `V` is HTTPS.
+- Keeping the visor identity/control surface unreachable from the site origin.
+- Performance: streaming vs. today's base64 (strictly better), and a **bounded**
+  transport pool to replace unbounded fan-out.
+- The `cmd/wfdrive` (Waterfox/BiDi) + `cmd/hvinspect` (Brave/CDP) rigs give us a
+  real-browser oracle to diff the WinBox browser against during migration.

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -302,6 +302,36 @@
     var log = opts.log || function () {};
     var currentSitePK = "";
 
+    // --- real-origin mode (RFC §4a/§4b) -------------------------------------
+    // When the host injected __SKYWIRE_BROWSE_ORIGIN__, a dmsg/skynet site loads
+    // from a REAL, isolated origin "<label>[.<net>]<suffix>:<port>" instead of the
+    // sandboxed-srcdoc transcoder — so the BROWSER does native subresource
+    // loading, cookies, redirects, WASM and streaming, and the visor only proxies
+    // the transport (native = local reverse-proxy origin on that port; wasm = the
+    // origin's Service Worker → this tab's visor). Transcoder stays as fallback.
+    var realOriginCfg = (typeof globalThis !== "undefined" && globalThis.__SKYWIRE_BROWSE_ORIGIN__) || null;
+    var B32 = "abcdefghijklmnopqrstuvwxyz234567"; // RFC4648 base32 lowercase (= cipher.DNSLabel)
+    function pkDNSLabel(hexPK) {
+      var bytes = [];
+      for (var i = 0; i + 1 < hexPK.length; i += 2) { bytes.push(parseInt(hexPK.substr(i, 2), 16)); }
+      var out = "", bits = 0, val = 0;
+      for (var j = 0; j < bytes.length; j++) {
+        val = (val << 8) | bytes[j]; bits += 8;
+        while (bits >= 5) { out += B32[(val >>> (bits - 5)) & 31]; bits -= 5; }
+      }
+      if (bits > 0) { out += B32[(val << (5 - bits)) & 31]; }
+      return out;
+    }
+    // labelFor: a 66-hex PK → 53-char base32 DNS label (hex is too long for a DNS
+    // label); an alias / already-base32 label passes through unchanged.
+    function labelFor(pk) { return /^[0-9a-fA-F]{66}$/.test(pk) ? pkDNSLabel(pk) : pk; }
+    function buildRealOrigin(pk, path, scheme) {
+      var c = realOriginCfg;
+      var net = (scheme === "skynet") ? "skynet" : (scheme === "dmsg") ? "dmsg" : ""; // "" = auto
+      var host = labelFor(pk) + (net ? ("." + net) : "") + (c.suffix || ".mesh.localhost");
+      return (c.scheme || "https") + "://" + host + (c.port ? (":" + c.port) : "") + (path || "/");
+    }
+
     // 1x1 transparent GIF — placeholder src for a deferred (lazy) image so it
     // occupies layout without a broken-image flash until the real bytes arrive.
     var BLANK_IMG = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
@@ -465,7 +495,18 @@
     // dmsg_sessions}). Returns {} if the core isn't booted yet (status() throws).
     function dmsgStatus() {
       return Promise.resolve().then(function () {
-        return (globalThis.skywireVisor && globalThis.skywireVisor.status && globalThis.skywireVisor.status()) || {};
+        var v = globalThis.skywireVisor;
+        if (v && v.status) { return v.status() || {}; }
+        // Native / hosted HV UI (directViaBackend, no in-tab wasm core to
+        // introspect): the BACKEND visor owns the dmsg connection and fetchDmsg
+        // is proxied to it over /api/browse/*, so the page can't read a session
+        // count. Report "connected" — otherwise waitForDmsg spins the full
+        // connect-overlay timeout on EVERY dmsg navigation even though the visor
+        // is connected (the bug that made every .dmsg site show "Connecting to
+        // the mesh…"). A genuinely-disconnected visor still surfaces as a real
+        // fetchDmsg error, not an endless spinner.
+        if (opts.directViaBackend) { return { dmsg_connected: true }; }
+        return {};
       }).catch(function () { return {}; });
     }
     // dmsg is "up" when there's a live session. Prefer the explicit fields
@@ -569,6 +610,27 @@
       resetFavicon(); // default icon now; the site's own favicon replaces it once fetched
       setLoading(true);
       try {
+        // Real-origin: hand the whole load to the browser via an isolated origin.
+        if (realOriginCfg && entry.kind === "dmsg") {
+          var rurl = buildRealOrigin(entry.pk, entry.path, entry.scheme);
+          frame.removeAttribute("srcdoc");
+          frame.src = rurl;
+          currentSitePK = entry.pk;
+          try { if (typeof hideConnecting === "function") { hideConnecting(); } } catch (e) {}
+          if (opts.setAddr) {
+            // Show a readable, re-typable address WITH a protocol, e.g.
+            // "http://<pk>.dmsg/path" (or https://, or .skynet). A host already
+            // carrying a dot (name-vhost / alias.dmsg) keeps it. The scheme is the
+            // HTTP scheme carried over the mesh transport (http unless TLS/https).
+            var disp = entry.pk;
+            if (disp.indexOf(".") < 0) { disp += (entry.scheme === "skynet" ? ".skynet" : ".dmsg"); }
+            if (entry.path && entry.path !== "/") { disp += entry.path; }
+            opts.setAddr((entry.scheme === "https" ? "https" : "http") + "://" + disp);
+          }
+          log("real-origin " + rurl);
+          setLoading(false);
+          return { status: 0, realOrigin: true };
+        }
         if (entry.kind === "clearnet") {
           var rc = await fetchClearnetEntry(entry.url, gen);
           return rc;
@@ -1076,14 +1138,27 @@
       // per-site-origin design that would lift the storage limit.
       '<div id="sb-info-panel" style="display:none;flex-direction:column;gap:.5em;padding:.7em .8em;background:#1a1726;border-bottom:1px solid #2a2342;font:12px/1.5 monospace;color:#cdd2da;max-height:40%;overflow:auto">' +
       '<div style="display:flex;align-items:center;gap:.5em"><b style="color:#9d7cff;font-size:13px">about the skynet browser</b><span style="flex:1"></span><button id="sb-info-x" style="cursor:pointer">×</button></div>' +
-      '<div>Fetches sites over <b>dmsg</b> (skynet) — no DNS, no certificate authorities, IP-anonymous. Address bar accepts a visor <b>PK</b>, <b>pk.dmsg</b>, an <b>alias.dmsg</b> (e.g. <b>home.dmsg</b>), or an <b>https://</b> clearnet site (routed through a skysocks exit — set in ⚙).</div>' +
-      '<div style="border-top:1px solid #2a2342;padding-top:.5em"><b style="color:#e0af68">Limitations (by design):</b></div>' +
-      '<ul style="margin:.1em 0 0;padding-left:1.2em;display:flex;flex-direction:column;gap:.25em">' +
-      '<li><b>No persistent storage.</b> Every page runs in a sandboxed frame with an opaque origin — <b>cookies, localStorage and logins do not persist</b>, even across a reload. Each visit is effectively fresh/incognito.</li>' +
-      '<li><b>Isolated.</b> Sites cannot read each other\'s data, and cannot read this visor\'s keys/storage.</li>' +
-      '<li><b>Scripts limited</b> (sandbox: allow-scripts allow-forms); no plugins, popups, or top-level navigation. Some clearnet sites that require cookies/service-workers may misbehave.</li>' +
-      '<li>Per-site persistent storage like a normal browser would need the <b>native desktop</b> app (each site on its own local origin) — not possible in a keyless browser tab.</li>' +
-      '</ul>' +
+      (globalThis.__SKYWIRE_BROWSE_ORIGIN__ ?
+        // Real-origin mode (RFC §4a/§4b): each site is its own genuine origin.
+        '<div>Each mesh site loads from its <b>own real, isolated origin</b> (<code>&lt;pk&gt;.mesh.localhost</code>), fetched over <b>this visor\'s own dmsg / skynet transports</b> — no DNS, no certificate authorities, IP-anonymous. Clearnet sites route through a skysocks exit (set in ⚙).</div>' +
+        '<div style="border-top:1px solid #2a2342;padding-top:.5em"><b style="color:#9ece6a">Works like a normal browser:</b></div>' +
+        '<ul style="margin:.1em 0 0;padding-left:1.2em;display:flex;flex-direction:column;gap:.25em">' +
+        '<li><b>Persistent storage.</b> Cookies, localStorage, logins and service workers <b>persist</b> across reloads — each site in its own real origin.</li>' +
+        '<li><b>Isolated per-site.</b> A real cross-origin boundary keeps sites from reading each other\'s data, and none can reach this visor\'s keys.</li>' +
+        '<li><b>Full scripts</b>, subresources, redirects, WASM and streaming — the browser renders the page natively; the visor only proxies the transport.</li>' +
+        '<li>Address bar: a visor <b>PK</b>, <b>pk.dmsg</b>, <b>alias.dmsg</b>, <b>dmsg://</b>/<b>skynet://</b>, or an <b>https://</b> clearnet site.</li>' +
+        '</ul>'
+      :
+        // Transcoder fallback: sandboxed opaque-origin srcdoc (the old limits).
+        '<div>Fetches sites over <b>dmsg</b> (skynet) — no DNS, no certificate authorities, IP-anonymous. Address bar accepts a visor <b>PK</b>, <b>pk.dmsg</b>, an <b>alias.dmsg</b> (e.g. <b>home.dmsg</b>), or an <b>https://</b> clearnet site (routed through a skysocks exit — set in ⚙).</div>' +
+        '<div style="border-top:1px solid #2a2342;padding-top:.5em"><b style="color:#e0af68">Limitations (by design):</b></div>' +
+        '<ul style="margin:.1em 0 0;padding-left:1.2em;display:flex;flex-direction:column;gap:.25em">' +
+        '<li><b>No persistent storage.</b> Every page runs in a sandboxed frame with an opaque origin — <b>cookies, localStorage and logins do not persist</b>, even across a reload. Each visit is effectively fresh/incognito.</li>' +
+        '<li><b>Isolated.</b> Sites cannot read each other\'s data, and cannot read this visor\'s keys/storage.</li>' +
+        '<li><b>Scripts limited</b> (sandbox: allow-scripts allow-forms); no plugins, popups, or top-level navigation. Some clearnet sites that require cookies/service-workers may misbehave.</li>' +
+        '<li>Per-site persistent storage like a normal browser would need the <b>native desktop</b> app (each site on its own local origin) — not possible in a keyless browser tab.</li>' +
+        '</ul>'
+      ) +
       '</div>' +
       // The page iframe + a DOM overlay (sb-connect) for the connecting/journey
       // state. The overlay is rendered/updated in the PARENT dom — NOT via the
@@ -1091,7 +1166,11 @@
       // (re-setting srcdoc every tick flashed the iframe's background = strobe).
       // iframe background is dark (not #fff) so any transition is not a white flash.
       '<div id="sb-frame-wrap" style="position:relative;flex:1;display:flex;min-height:0">' +
-      '<iframe id="sb-frame" sandbox="allow-scripts allow-forms" style="flex:1;width:100%;border:0;background:#0e0c14"></iframe>' +
+      // Real-origin mode (RFC): NO sandbox — B is a genuine isolated origin that
+      // must have its own storage/cookies/service-worker/secure-context. The old
+      // transcoder keeps the opaque-origin sandbox. Cross-origin isolation between
+      // sites is by ORIGIN (<pk>.mesh.localhost), not the sandbox attribute.
+      '<iframe id="sb-frame" ' + (globalThis.__SKYWIRE_BROWSE_ORIGIN__ ? '' : 'sandbox="allow-scripts allow-forms" ') + 'style="flex:1;width:100%;border:0;background:#0e0c14"></iframe>' +
       '<div id="sb-connect" style="position:absolute;inset:0;display:none;background:#0e0c14;color:#cdd2da;font:14px/1.6 system-ui,-apple-system,sans-serif;overflow:auto"></div>' +
       '</div>';
 

--- a/pkg/wasmhv/embed.go
+++ b/pkg/wasmhv/embed.go
@@ -85,6 +85,30 @@ var PWAManifest []byte
 //go:embed sw.js
 var ServiceWorkerJS []byte
 
+// Real-origin mesh browser (RFC §4b) served on the isolated browse origin B
+// (<pkslug>.mesh.localhost) and the visor origin V:
+//
+//	BrowseSWJS         — transport Service Worker on B: intercepts subresource
+//	                     fetches and relays them through the in-tab visor.
+//	BrowseBootstrapHTML— B navigation shell: registers the SW, stands up the V
+//	                     helper bridge, injects the real mesh HTML into B.
+//
+// (Distinct from ServiceWorkerJS/sw.js, which is the PWA app-shell cache for V.)
+//
+//go:embed browse-sw.js
+var BrowseSWJS []byte
+
+//go:embed browse-bootstrap.html
+var BrowseBootstrapHTML []byte
+
+// BrowseResponderJS is injected into the visor app origin V: it answers
+// {type:'mesh-hello'} from embedded browse-origin (B) iframes with a MessagePort
+// and services their fetches via V's first-party skywireVisor (the trust
+// boundary). Replaces the partitioned cross-origin helper iframe.
+//
+//go:embed browse-responder.js
+var BrowseResponderJS []byte
+
 // PWAIcon192 / PWAIcon512 are the maskable install icons referenced by the
 // manifest, served at /icon-192.png and /icon-512.png.
 //


### PR DESCRIPTION
Opens any `.dmsg` / `.skynet` site in the in-visor iframe browser as a **normal, isolated, secure web page** — the browser gets a genuine per-site origin, so it does native subresource loading, cookies, `localStorage`, service workers, redirects, WASM and streaming, while skywire only proxies the **transport** over the visor's own routes (never a shared/central relay). The old sandboxed-srcdoc transcoder stays as the fallback.

Same behavior on **both** surfaces:

## Native HV UI — `pkg/visor/meshproxy.go`
A loopback reverse-proxy origin (default `127.0.0.1:8461`), enabled via `browse_origin` config. Two isolation modes:
- **subdomain** (default): one listener; each site is the origin `<vhost>.<base32pk><suffix>`, routed by Host header. `*.mesh.localhost` resolves to loopback in every target browser (no DNS setup); point `suffix` at a wildcard domain you control for a hosted origin behind real TLS.
- **port**: each site gets its own `127.0.0.1:<port>` from a small LRU pool — no DNS/wildcard dependency at all.

dmsg + skynet transports (auto = skynet-first, dmsg fallback; forced by a `.dmsg`/`.skynet` label). Optional TLS (a real cert, or a locally-trusted mkcert cert) for https parity with a hosted origin. `mesh_proxy` is a router-gated init module.

## Wasm visor — Service-Worker origin + parent-relay bridge
The in-tab wasm visor serves the identical browser from its own `:8443`; **the static host serves only the bootstrap**, all content flows through the in-tab visor's transports:
- `ServeWasm` host-routes `*.mesh.localhost` requests to a bootstrap shell (`browse-bootstrap.html`, per-request `__V_ORIGIN__`/`__SUFFIX__` substitution).
- `browse-sw.js` — the transport Service Worker on origin B — intercepts subresource fetches and relays them through the bootstrap → the V-origin responder → V's first-party `skywireVisor`.
- `browse-responder.js` (injected into the visor origin V) is the trust boundary: it answers `mesh-hello` from embedded B iframes with a private `MessagePort` and services their fetches, so B (untrusted mesh content) never reaches V's key. This replaces the storage-partitioned cross-origin helper iframe.
- The self-signed localhost cert now carries `mesh.localhost` + `*.mesh.localhost` SANs (one cert for V and every B); `wasm_serve.tls_cert`/`tls_key` (+ `hv serve --tls-cert/--tls-key`) serve a locally-trusted `*.mesh.localhost` cert so B iframes load with no per-host accept.

Design: `pkg/wasmhv/browseui/RFC-real-origin-browser.md`.

## Notes
- Stacks on #3803 (wasm-serve from the visor process), now in develop.
- Fully backward-compatible: `browse_origin` disabled and `wasm_serve.tls_cert` empty → identical to today (transcoder + self-signed localhost cert).
- ws/wss over the bridge is a separate follow-up (needs a new duplex dial primitive; `dialRoute` today is a one-shot probe).
- `go build .`, `go vet ./pkg/visor/ ./pkg/wasmhv/... ./cmd/skywire-cli/...`, `gofmt` all clean.