### PR TITLE
feat(wasm-visor): configurable browse-origin suffix + two-port hosted mode

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -10,14 +10,17 @@ import (
 )
 
 var (
-	serveAddr     string
-	serveHarness  bool
-	serveTLS      bool
-	serveTLSCert  string
-	serveTLSKey   string
-	servePassword string
-	serveVariant  string
-	serveWallet   bool
+	serveAddr         string
+	serveHarness      bool
+	serveTLS          bool
+	serveTLSCert      string
+	serveTLSKey       string
+	servePassword     string
+	serveVariant      string
+	serveWallet       bool
+	serveBrowseSuffix string
+	serveBrowseOrigin string
+	serveVOrigin      string
 )
 
 func init() {
@@ -29,6 +32,9 @@ func init() {
 	serveCmd.Flags().StringVar(&servePassword, "password", "", "gate the served PWA behind an access password (cookie login). Empty = open. Use over --tls / behind TLS so the password isn't sent in clear")
 	serveCmd.Flags().StringVarP(&serveVariant, "variant", "W", "", "which embedded wasm-visor to serve: 'go' (larger, full crypto/tls+net/http) or 'tinygo' (~4x smaller — better for the PWA, with the documented TinyGo feature gaps). Empty = the build default. A standard-Go build embeds both; a TinyGo build has only 'tinygo'")
 	serveCmd.Flags().BoolVar(&serveWallet, "wallet", true, "serve the bundled skycoin-web wallet at /wallet/ (custody stays browser-side — the host never sees keys). --wallet=false serves a wallet-less PWA")
+	serveCmd.Flags().StringVar(&serveBrowseSuffix, "browse-suffix", "", "browse-origin domain suffix for the real-origin browser (leading dot). Empty = .mesh.localhost (local). Set e.g. .haltingstate.net for a hosted deploy")
+	serveCmd.Flags().StringVar(&serveBrowseOrigin, "browse-origin", "", "ALSO serve the browse-origin SW bootstrap on this second addr (e.g. 127.0.0.1:7998), for the hosted real-origin browser's B origins. Caddy routes *.<browse-suffix> here; this same process serves V on --addr and B here. Empty = off (V host-routes B on --addr, local mode)")
+	serveCmd.Flags().StringVar(&serveVOrigin, "v-origin", "", "the PUBLIC origin of the visor app V that B's bootstrap postMessages to, e.g. https://theskywirenetwork.net. Only needed with --browse-origin behind a proxy; empty = derive from --addr (local)")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -54,14 +60,17 @@ ephemeral key (localStorage). That is what makes serving from a domain safe — 
 page never asks anyone to type a secret key.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if err := visor.ServeWasm(cmd.Context(), visor.WasmServeConfig{
-			Addr:     serveAddr,
-			TLS:      serveTLS,
-			TLSCert:  serveTLSCert,
-			TLSKey:   serveTLSKey,
-			Harness:  serveHarness,
-			Wallet:   serveWallet,
-			Variant:  serveVariant,
-			Password: servePassword,
+			Addr:             serveAddr,
+			TLS:              serveTLS,
+			TLSCert:          serveTLSCert,
+			TLSKey:           serveTLSKey,
+			Harness:          serveHarness,
+			Wallet:           serveWallet,
+			Variant:          serveVariant,
+			Password:         servePassword,
+			BrowseSuffix:     serveBrowseSuffix,
+			BrowseOriginAddr: serveBrowseOrigin,
+			VOrigin:          serveVOrigin,
 		}); err != nil {
 			cmd.PrintErrln("serve:", err)
 			os.Exit(1)

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -549,14 +549,17 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 		ws := conf.Hypervisor.WasmServe
 		go func() {
 			if err := ServeWasm(parentCtx, WasmServeConfig{
-				Addr:     ws.Addr,
-				TLS:      ws.TLS,
-				TLSCert:  ws.TLSCert,
-				TLSKey:   ws.TLSKey,
-				Harness:  ws.Harness,
-				Wallet:   !ws.NoWallet,
-				Variant:  ws.Variant,
-				Password: ws.Password,
+				Addr:             ws.Addr,
+				TLS:              ws.TLS,
+				TLSCert:          ws.TLSCert,
+				TLSKey:           ws.TLSKey,
+				Harness:          ws.Harness,
+				Wallet:           !ws.NoWallet,
+				Variant:          ws.Variant,
+				Password:         ws.Password,
+				BrowseSuffix:     ws.BrowseSuffix,
+				BrowseOriginAddr: ws.BrowseOriginAddr,
+				VOrigin:          ws.VOrigin,
 			}); err != nil {
 				mLog.WithError(err).Error("wasm-serve failed")
 			}

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -126,6 +126,16 @@ type WasmServeConf struct {
 	NoWallet bool   `json:"no_wallet,omitempty"` // default serves the bundled skycoin-web wallet; set true to omit it
 	Variant  string `json:"variant,omitempty"`   // "" = build default; "go" | "tinygo"
 	Password string `json:"password,omitempty"`  // optional access-password gate (use with TLS)
+	// BrowseSuffix is the real-origin browser's browse-origin domain suffix
+	// (leading dot); empty = ".mesh.localhost".
+	BrowseSuffix string `json:"browse_suffix,omitempty"`
+	// BrowseOriginAddr, when set, ALSO serves the browse-origin SW bootstrap on
+	// this second address (Caddy fronts it on *.<browse_suffix>). Empty = off.
+	BrowseOriginAddr string `json:"browse_origin_addr,omitempty"`
+	// VOrigin is the public origin of the visor app V (e.g.
+	// "https://theskywirenetwork.net") that B's bootstrap postMessages to — used
+	// only with BrowseOriginAddr behind a proxy. Empty = derive from Addr.
+	VOrigin string `json:"browse_v_origin,omitempty"`
 }
 
 // DefaultHypervisorConfig returns a HypervisorConfig with sensible defaults.

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -50,15 +50,28 @@ import (
 
 // WasmServeConfig configures ServeWasm. Mirrors the `hv serve` flags.
 type WasmServeConfig struct {
-	Addr     string          // HTTP listen address (e.g. ":8443")
-	TLS      bool            // serve HTTPS (self-signed localhost cert, or TLSCert/TLSKey if set)
-	TLSCert  string          // optional cert file (PEM) — a locally-trusted *.mesh.localhost cert (mkcert) so B-origin iframes load without a per-host accept; empty = built-in self-signed
-	TLSKey   string          // optional key file (PEM), paired with TLSCert
-	Harness  bool            // mount the /ctl/* operator control bridge (DEV ONLY)
-	Wallet   bool            // serve the bundled skycoin-web wallet at /wallet/
-	Variant  string          // "" = build default; "go" | "tinygo"
-	Password string          // optional access-password gate
-	Log      *logging.Logger // nil → package default
+	Addr     string // HTTP listen address (e.g. ":8443")
+	TLS      bool   // serve HTTPS (self-signed localhost cert, or TLSCert/TLSKey if set)
+	TLSCert  string // optional cert file (PEM) — a locally-trusted *.mesh.localhost cert (mkcert) so B-origin iframes load without a per-host accept; empty = built-in self-signed
+	TLSKey   string // optional key file (PEM), paired with TLSCert
+	Harness  bool   // mount the /ctl/* operator control bridge (DEV ONLY)
+	Wallet   bool   // serve the bundled skycoin-web wallet at /wallet/
+	Variant  string // "" = build default; "go" | "tinygo"
+	Password string // optional access-password gate
+	// BrowseSuffix is the browse-origin domain suffix (leading dot), e.g.
+	// ".mesh.localhost" (local) or ".haltingstate.net" (hosted). Empty →
+	// ".mesh.localhost".
+	BrowseSuffix string
+	// BrowseOriginAddr, when set, ALSO serves the browse-origin SW bootstrap on a
+	// SECOND listener at this address (the same process serves V on Addr and the
+	// isolated browse origins B here). A hosted deploy fronts this with Caddy on
+	// *.<BrowseSuffix>. Empty = off (local mode host-routes B on the V listener).
+	BrowseOriginAddr string
+	// VOrigin is the PUBLIC origin of the visor app V (e.g.
+	// "https://theskywirenetwork.net") that B's bootstrap postMessages to — used
+	// only with BrowseOriginAddr behind a proxy. Empty = derive from Addr (local).
+	VOrigin string
+	Log     *logging.Logger // nil → package default
 }
 
 // ServeWasm builds the standalone wasm-visor handler and serves it on
@@ -134,13 +147,51 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	if bport != "" {
 		vHostPort = "localhost:" + bport
 	}
-	// Injected so browse.js enters real-origin mode and builds <pk>.mesh.localhost
-	// :<port> origins for the WinBox browser iframe.
-	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:\".mesh.localhost\",scheme:" + strconv.Quote(browseScheme) + ",port:" + strconv.Quote(bport) + "};"
+	// Browse-origin domain suffix. Empty = local single-listener default.
+	suffix := cfg.BrowseSuffix
+	if suffix == "" {
+		suffix = ".mesh.localhost"
+	}
+	// B-origin scheme+port. B may live elsewhere than V: for the *.localhost local
+	// model B and V share THIS listener + cert, so B inherits browseScheme/bport;
+	// for a hosted suffix B is fronted by Caddy TLS on 443 (a separate process /
+	// host — see ServeBrowseOrigin), so it's plain https with no explicit port.
+	bScheme, bPort := browseScheme, bport
+	if !strings.HasSuffix(suffix, ".localhost") {
+		bScheme, bPort = "https", ""
+	}
+	// Injected so browse.js enters real-origin mode and builds <pk><suffix>[:<port>]
+	// origins for the WinBox browser iframe.
+	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:" + strconv.Quote(suffix) + ",scheme:" + strconv.Quote(bScheme) + ",port:" + strconv.Quote(bPort) + "};"
 	index := injectWasmBoot(indexB, wasmVer, cfg.Harness, browseOriginJS)
 
 	browseBootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__V_ORIGIN__"), []byte(browseScheme+"://"+vHostPort))
-	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(".mesh.localhost"))
+	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(suffix))
+
+	// Hosted two-port mode: when BrowseOriginAddr is set, this SAME process ALSO
+	// runs the browse-origin bootstrap server on that second listener (Caddy fronts
+	// it on *.<suffix>). V (this listener) and B (that one) are separate origins;
+	// co-locating them in one process keeps the deploy to a single unit. Best-effort
+	// — a bind failure is logged, not fatal to serving V.
+	if cfg.BrowseOriginAddr != "" {
+		vOrigin := cfg.VOrigin
+		if vOrigin == "" {
+			vOrigin = browseScheme + "://" + vHostPort
+		}
+		go func() {
+			if err := ServeBrowseOrigin(ctx, BrowseOriginConfig{
+				Addr:    cfg.BrowseOriginAddr,
+				VOrigin: vOrigin,
+				Suffix:  suffix,
+				TLS:     cfg.TLS,
+				TLSCert: cfg.TLSCert,
+				TLSKey:  cfg.TLSKey,
+				Log:     log,
+			}); err != nil {
+				log.WithError(err).Error("browse-origin bootstrap server failed")
+			}
+		}()
+	}
 
 	mux := http.NewServeMux()
 	serveBytes := func(path, ct string, body []byte) {
@@ -318,7 +369,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// subresources. Non-B hosts (the visor origin V = localhost) are untouched.
 	base := handler
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isMeshBrowseHost(r.Host) && r.URL.Path != "/browse-sw.js" {
+		if isMeshBrowseHost(r.Host, suffix) && r.URL.Path != "/browse-sw.js" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Header().Set("Cache-Control", "no-store")
 			_, _ = w.Write(browseBootstrap) //nolint:errcheck
@@ -359,6 +410,95 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		return nil
 	}
 	log.Infof("serving standalone wasm-visor (ui + %d-byte wasm + hv-boot) on %s", len(wasm), cfg.Addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
+}
+
+// BrowseOriginConfig configures ServeBrowseOrigin — the browse-origin bootstrap
+// server for the hosted two-server model. It serves ONLY the embedded SW bootstrap
+// (and browse-sw.js) for the isolated browse origins B (<pk><Suffix>); it is NEVER
+// in the content path (the registered SW relays every fetch to the visitor's in-tab
+// visor at VOrigin). Front it with Caddy on *.<Suffix>.
+type BrowseOriginConfig struct {
+	Addr    string          // HTTP listen address (loopback; Caddy fronts it)
+	VOrigin string          // the visor app origin V, e.g. "https://theskywirenetwork.net"
+	Suffix  string          // browse-origin domain suffix (leading dot), e.g. ".haltingstate.net"
+	TLS     bool            // usually false — Caddy terminates TLS
+	TLSCert string          // optional PEM cert (paired with TLSKey)
+	TLSKey  string          // optional PEM key
+	Log     *logging.Logger // nil → package default
+}
+
+// ServeBrowseOrigin runs the browse-origin bootstrap server (RFC §4b, hosted mode):
+// for any Host under Suffix it returns the SW bootstrap shell with __V_ORIGIN__ and
+// __SUFFIX__ substituted; /browse-sw.js returns the transport SW. Blocking until ctx
+// is canceled.
+func ServeBrowseOrigin(ctx context.Context, cfg BrowseOriginConfig) error {
+	log := cfg.Log
+	if log == nil {
+		log = logging.MustGetLogger("browse-origin")
+	}
+	if strings.TrimSpace(cfg.VOrigin) == "" {
+		return fmt.Errorf("browse-origin: VOrigin is required")
+	}
+	suffix := strings.TrimSpace(cfg.Suffix)
+	if suffix == "" {
+		return fmt.Errorf("browse-origin: Suffix is required")
+	}
+	if !strings.HasPrefix(suffix, ".") {
+		suffix = "." + suffix
+	}
+
+	// Precompute the bootstrap shell: the SW bootstrap that every browse origin B
+	// serves. It registers browse-sw.js and points the SW at the visitor's in-tab
+	// visor at VOrigin; the transcode substitutions match ServeWasm.
+	bootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__V_ORIGIN__"), []byte(cfg.VOrigin))
+	bootstrap = bytes.ReplaceAll(bootstrap, []byte("__SUFFIX__"), []byte(suffix))
+
+	// Caddy only routes *.Suffix here, so no host check is needed: /browse-sw.js is
+	// the transport SW, every other path is the bootstrap shell.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/browse-sw.js" {
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(wasmhv.BrowseSWJS) //nolint:errcheck
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write(bootstrap) //nolint:errcheck
+	})
+
+	srv := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close() //nolint:errcheck
+	}()
+
+	log.Infof("serving browse-origin bootstrap on %s (V-origin %s, suffix %s)", cfg.Addr, cfg.VOrigin, suffix)
+	if cfg.TLS {
+		var cert tls.Certificate
+		var err error
+		if cfg.TLSCert != "" && cfg.TLSKey != "" {
+			cert, err = tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+		} else {
+			cert, err = wasmLocalhostTLSCert()
+		}
+		if err != nil {
+			return fmt.Errorf("tls cert: %w", err)
+		}
+		srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+		if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("serve: %w", err)
+		}
+		return nil
+	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("serve: %w", err)
 	}
@@ -462,15 +602,16 @@ func injectWasmBoot(index []byte, wasmVer string, harness bool, browseOriginJS s
 }
 
 // isMeshBrowseHost reports whether an HTTP Host header targets an isolated
-// real-origin browse origin B (<...>.mesh.localhost[:port]) rather than the visor
-// origin V (localhost). Browsers resolve *.localhost to loopback, so these hit
-// the same wasm-serve listener and are distinguished only by Host.
-func isMeshBrowseHost(h string) bool {
+// real-origin browse origin B (<...><suffix>[:port]) rather than the visor
+// origin V. For the *.mesh.localhost local model browsers resolve *.localhost to
+// loopback, so these hit the same wasm-serve listener and are distinguished only
+// by Host.
+func isMeshBrowseHost(h, suffix string) bool {
 	host := h
 	if i := strings.IndexByte(host, ':'); i >= 0 {
 		host = host[:i]
 	}
-	return strings.HasSuffix(host, ".mesh.localhost")
+	return strings.HasSuffix(host, suffix)
 }
 
 // wasmLocalhostTLSCert returns a self-signed localhost cert for

--- a/pkg/wasmhv/browse-responder.js
+++ b/pkg/wasmhv/browse-responder.js
@@ -20,8 +20,8 @@
   // isMeshBrowseHost / the configured browse suffix).
   function isBrowseOrigin(origin) {
     try {
-      var h = new URL(origin).hostname;
-      return /\.mesh\.localhost$/.test(h);
+      var suffix = (globalThis.__SKYWIRE_BROWSE_ORIGIN__ && globalThis.__SKYWIRE_BROWSE_ORIGIN__.suffix) || '.mesh.localhost';
+      return new URL(origin).hostname.endsWith(suffix);
     } catch (e) { return false; }
   }
 


### PR DESCRIPTION
Follow-up to #3807. Makes the real-origin browser's **wasm surface deployable on a real host** (not just loopback), so it can run on theskywirenetwork.net.

## Problem
#3807's `ServeWasm` hardcoded `.mesh.localhost` (and `localhost`) for the browse origin B. That's fine locally (`*.localhost` resolves to loopback and hits the same listener), but on a real domain `<pk>.mesh.localhost` is the *visitor's* loopback — dead. And B must be a **separate registrable domain** from the visor app V anyway (untrusted mesh content must be cross-site from V — cookie/storage isolation; same reason `*.googleusercontent.com` exists).

## Change — one process, two ports
- `WasmServeConf`/`WasmServeConfig`: `browse_suffix` (browse-origin domain, default `.mesh.localhost`), `browse_origin_addr` (a **second** listener serving the browse-origin bootstrap), `browse_v_origin` (V's public origin). `hv serve` gains `--browse-suffix`, `--browse-origin`, `--v-origin`.
- `ServeBrowseOrigin`: the **browse-origin bootstrap server** — for any Host under the suffix it serves only the embedded SW bootstrap (V-origin + suffix substituted) and `browse-sw.js`; never content. When `browse_origin_addr` is set, `ServeWasm` runs it in the **same process** on that second listener.
- `ServeWasm` injects `__SKYWIRE_BROWSE_ORIGIN__` with the configured suffix (https/no-port for a hosted suffix).
- `browse-responder.js`: `isBrowseOrigin` now trusts the configured suffix (from the injected config) instead of hardcoding `.mesh.localhost`.

## Hosted deploy (both domains co-located on one host)
```
Caddy:  theskywirenetwork.net  → 127.0.0.1:7999   (V, the PWA)
        *.haltingstate.net     → 127.0.0.1:7998   (B, the bootstrap)
hv serve --addr 127.0.0.1:7999 --browse-origin 127.0.0.1:7998 \
         --browse-suffix .haltingstate.net --v-origin https://theskywirenetwork.net
```
V = `theskywirenetwork.net`; each mesh site = `<base32pk>.haltingstate.net` (cross-site, its own cookies/storage), whose SW relays every fetch to the visitor's in-tab wasm visor. The host serves **only the bootstrap** — never content.

## Validation
Local two-port run: V injects `suffix ".haltingstate.net"`; B host-routes `<pk>.haltingstate.net` → the bootstrap (`__V_ORIGIN__=https://theskywirenetwork.net`) and serves `/browse-sw.js` (200). Backward-compatible: no config → identical to today (`.mesh.localhost`, single listener). `go build`, `golangci-lint`, `gofmt` clean.