### PR TITLE
feat(wasm-visor): clearnet-over-skysocks real-origin + content-addressed browse origins

### DIFF
--- a/cmd/skywire-cli/commands/hv/serve.go
+++ b/cmd/skywire-cli/commands/hv/serve.go
@@ -10,14 +10,17 @@ import (
 )
 
 var (
-	serveAddr     string
-	serveHarness  bool
-	serveTLS      bool
-	serveTLSCert  string
-	serveTLSKey   string
-	servePassword string
-	serveVariant  string
-	serveWallet   bool
+	serveAddr         string
+	serveHarness      bool
+	serveTLS          bool
+	serveTLSCert      string
+	serveTLSKey       string
+	servePassword     string
+	serveVariant      string
+	serveWallet       bool
+	serveBrowseSuffix string
+	serveBrowseOrigin string
+	serveVOrigin      string
 )
 
 func init() {
@@ -29,6 +32,9 @@ func init() {
 	serveCmd.Flags().StringVar(&servePassword, "password", "", "gate the served PWA behind an access password (cookie login). Empty = open. Use over --tls / behind TLS so the password isn't sent in clear")
 	serveCmd.Flags().StringVarP(&serveVariant, "variant", "W", "", "which embedded wasm-visor to serve: 'go' (larger, full crypto/tls+net/http) or 'tinygo' (~4x smaller — better for the PWA, with the documented TinyGo feature gaps). Empty = the build default. A standard-Go build embeds both; a TinyGo build has only 'tinygo'")
 	serveCmd.Flags().BoolVar(&serveWallet, "wallet", true, "serve the bundled skycoin-web wallet at /wallet/ (custody stays browser-side — the host never sees keys). --wallet=false serves a wallet-less PWA")
+	serveCmd.Flags().StringVar(&serveBrowseSuffix, "browse-suffix", "", "browse-origin domain suffix for the real-origin browser (leading dot). Empty = .mesh.localhost (local). Set e.g. .haltingstate.net for a hosted deploy")
+	serveCmd.Flags().StringVar(&serveBrowseOrigin, "browse-origin", "", "ALSO serve the browse-origin SW bootstrap on this second addr (e.g. 127.0.0.1:7998), for the hosted real-origin browser's B origins. Caddy routes *.<browse-suffix> here; this same process serves V on --addr and B here. Empty = off (V host-routes B on --addr, local mode)")
+	serveCmd.Flags().StringVar(&serveVOrigin, "v-origin", "", "the PUBLIC origin of the visor app V that B's bootstrap postMessages to, e.g. https://theskywirenetwork.net. Only needed with --browse-origin behind a proxy; empty = derive from --addr (local)")
 	RootCmd.AddCommand(serveCmd)
 }
 
@@ -54,14 +60,17 @@ ephemeral key (localStorage). That is what makes serving from a domain safe — 
 page never asks anyone to type a secret key.`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if err := visor.ServeWasm(cmd.Context(), visor.WasmServeConfig{
-			Addr:     serveAddr,
-			TLS:      serveTLS,
-			TLSCert:  serveTLSCert,
-			TLSKey:   serveTLSKey,
-			Harness:  serveHarness,
-			Wallet:   serveWallet,
-			Variant:  serveVariant,
-			Password: servePassword,
+			Addr:             serveAddr,
+			TLS:              serveTLS,
+			TLSCert:          serveTLSCert,
+			TLSKey:           serveTLSKey,
+			Harness:          serveHarness,
+			Wallet:           serveWallet,
+			Variant:          serveVariant,
+			Password:         servePassword,
+			BrowseSuffix:     serveBrowseSuffix,
+			BrowseOriginAddr: serveBrowseOrigin,
+			VOrigin:          serveVOrigin,
 		}); err != nil {
 			cmd.PrintErrln("serve:", err)
 			os.Exit(1)

--- a/docs/deploy/standalone-wasm-visor/README.md
+++ b/docs/deploy/standalone-wasm-visor/README.md
@@ -44,6 +44,36 @@ sudoedit /etc/caddy/Caddyfile
 sudo systemctl reload caddy
 ```
 
+## Optional: the real-origin browser (open mesh sites as real web pages)
+
+The served page includes an in-app browser that can open `.dmsg`/`.skynet` (and
+clearnet over skysocks) sites as **real, isolated browser origins** — persistent
+cookies/storage/service-workers — instead of opaque sandboxed frames. That needs
+a second, wildcard-fronted origin for the isolated per-site pages. Add a second
+listener + a wildcard subdomain:
+
+```
+# hv serve on two ports: the PWA on :7999, the browse-origin bootstrap on :7998
+skywire cli hv serve --addr 127.0.0.1:7999 \
+  --browse-origin 127.0.0.1:7998 \
+  --browse-suffix .<browse-domain> \
+  --v-origin https://<this-subdomain>
+
+# Caddy: the app subdomain to :7999, the wildcard browse domain to :7998
+<this-subdomain>   { reverse_proxy 127.0.0.1:7999 }
+*.<browse-domain>  {
+    tls { dns cloudflare {env.CF_API_TOKEN} }   # wildcard needs DNS-01
+    reverse_proxy 127.0.0.1:7998
+}
+```
+
+Use a **separate registrable domain** for `<browse-domain>` (not a subdomain of
+the app domain) so untrusted mesh content is fully cross-site from the visor app.
+A single wildcard cert covers every site — the per-site origins are short content
+hashes, not the target encoded into the name. See
+[`docs/real-origin-browser.md`](../../real-origin-browser.md) for the full design
+and the reasoning behind the content-addressed origins.
+
 ## Keeping it current on auto-update
 
 The page is built at process start, so restart the serve service after skywire updates:

--- a/docs/real-origin-browser.md
+++ b/docs/real-origin-browser.md
@@ -1,0 +1,199 @@
+# The real-origin mesh browser
+
+The visor's in-app browser (both the native hypervisor UI and the in-browser
+WASM visor) can open a `.dmsg` / `.skynet` site — or a clearnet site over
+skysocks — as a **normal, isolated, secure web page**: its own origin, its own
+cookies / `localStorage` / service worker / secure context, native subresource
+loading, redirects, streaming and WASM. The visor only proxies the *transport*;
+the browser does everything else, exactly as it would for any website.
+
+This document explains what "real origin" means here, the two different ways a
+mesh site can become a real browser origin, how the zero-config in-app browser
+achieves it, and — because it was not obvious — how the origin **naming** scheme
+evolved from encoding the target into the hostname to hashing it.
+
+## Two ways to get a real origin (they are not the same thing)
+
+There are two distinct mechanisms, and it is easy to conflate them:
+
+### 1. The SOCKS5 resolving proxy (`dmsgweb`) — needs browser configuration
+
+If you point your browser's SOCKS5 proxy at the visor's resolving proxy, the
+**browser itself** resolves `http://<pk>.dmsg` (and `<pk>.skynet`, aliases,
+name-vhosts, clearnet-over-skysocks) through the proxy → the visor → the mesh.
+In this mode `<pk>.dmsg` *is* a genuine, distinct browser origin with real
+cookies/storage — no extra machinery required.
+
+The cost: every user must configure their browser's proxy settings. That is fine
+for an operator, but not for someone who just opens a hosted page.
+
+### 2. The in-app iframe browser — zero configuration
+
+The visor's built-in browser (the WinBox "browser" window) is for users who have
+**not** configured a proxy — most importantly, a visitor who just opens a hosted
+wasm visor like `theskywirenetwork.net`. That browser cannot point an iframe at
+`http://<pk>.dmsg`, because the visitor's browser has no way to resolve `.dmsg`.
+
+Historically it worked around this by fetching the page with the visor and
+injecting the HTML into a **sandboxed `srcdoc` iframe** — which has an **opaque**
+origin: no persistent cookies/storage, no service workers, logins do not survive
+a reload. Correct isolation, broken platform.
+
+The **real-origin** browser replaces that: it gives the iframe a genuine,
+per-site origin **without** any proxy configuration, so the browser does native
+cookie/storage/SW/subresource handling. The rest of this document is about that
+mechanism.
+
+> TL;DR — if you have the SOCKS proxy configured, `.dmsg`/`.skynet` already work
+> as real origins and none of this is needed. The real-origin browser exists for
+> the **zero-config, in-page** case (the hosted PWA).
+
+## How the zero-config real origin works
+
+Each mesh site is served from its own isolated **browse origin** `B`
+(`<id>.<browse-domain>`), separate from the **visor app origin** `V` (the page
+that holds the in-tab visor and its key). Because `B ≠ V` (different host), the
+browser treats them as cross-origin: a mesh site can never read the visor's
+storage or key.
+
+- **Native HV UI**: `B` is a loopback reverse-proxy origin on the operator's own
+  machine (`pkg/visor/meshproxy.go`) — content flows through *their* transports.
+- **WASM visor (hosted)**: `B` is served by a tiny bootstrap. The server hands
+  the browser only a **static Service-Worker bootstrap** (`browse-bootstrap.html`
+  + `browse-sw.js`). The SW then becomes `B`'s network layer: it relays every
+  fetch through a `postMessage` bridge to `V`'s **first-party** in-tab visor,
+  which fetches over dmsg/skynet/skysocks. **The host never serves content** —
+  only the bootstrap. `V` holds the key; `B` may only ask "fetch this URL".
+
+The trust boundary is `browse-responder.js`, injected into `V`: it validates the
+`B` origin, hands `B` a private `MessagePort`, and services fetches via `V`'s own
+visor. `B` never touches the key.
+
+### Networks
+
+The target network is explicit in the address you type, and the visor fetches
+accordingly:
+
+| You type | Network | How it's fetched |
+|---|---|---|
+| `<pk>.dmsg`, `home.dmsg`, `<vhost>.<pk>.dmsg` | dmsg | `fetchDmsg` (resolving proxy) |
+| `<pk>.skynet` | skynet | `fetchDmsg` (skynet route) |
+| `https://skycoin.com` | clearnet | `fetchClearnet` via skysocks-lite (anonymous exit) |
+
+A public key may be given in the 66-char **hex** or the 53-char **base32** form;
+both resolve to the same site.
+
+## Origin naming — why it ends in a hash, and the road not taken
+
+Giving `B` a real origin over HTTPS requires a TLS certificate for `B`'s
+hostname. Issuing a cert per site does not scale (CA rate limits), so we want a
+**single wildcard** cert to cover every site. Getting there took a wrong turn
+worth recording.
+
+### First attempt: encode the target into the hostname
+
+The obvious scheme was to put the target *in* the name:
+
+```
+<base32pk>.dmsg.<browse-domain>
+<clearnethost>.skysocks.<browse-domain>
+```
+
+This works for a bare public key. But it runs straight into how TLS wildcards
+are defined:
+
+- A wildcard certificate matches **exactly one label**, and only as the
+  **left-most** label (RFC 6125 §6.4.3; CA/Browser Forum Baseline Requirements).
+- `*.*.<domain>` is **not** a valid certificate — no CA issues it and no browser
+  accepts it. A `*` never spans a dot.
+
+So any **multi-label** target has no cert:
+
+- a clearnet **subdomain** — `explorer.skycoin.com` → `explorer.skycoin.com.skysocks.<domain>`;
+- a dmsg **name-vhost** — `magnetosphere.net.<base32pk>.dmsg`, where the 53-char
+  base32 PK already nearly fills the 63-char DNS-label limit, so `vhost + PK`
+  cannot even be collapsed into a single label.
+
+Dead ends we considered and rejected:
+
+- **Per-depth wildcards** (`*.dmsg`, `*.skysocks`, `*.com.skysocks`, …): unbounded
+  for clearnet — you would need one wildcard per distinct prefix path, forever.
+- **On-demand per-host TLS**: readable, but issues a new certificate per site on
+  first visit → Let's Encrypt rate limits (~50/week per registered domain) break
+  under normal browsing.
+- **Hyphen-escaping the dots** into one label (`skycoin-com`, real `-` → `--`):
+  reversible and readable, but a `vhost + 53-char base32 PK` still blows past the
+  63-char label cap. Handles clearnet, not name-vhosts.
+
+### The fix: content-addressed origins
+
+Stop encoding the target in the name at all. Make `B`'s origin a short **stable
+hash** of the target, and keep the map in the visor:
+
+```
+id = base32( sha256(canonical-target) )[:20]      # 20 chars, 80 bits
+B  = https://<id>.<browse-domain>
+```
+
+- The visor keeps `id → target` (`globalThis.__meshOrigins`), populated when the
+  browser navigates. `B`'s bootstrap sends its `id` at handshake; `V`'s responder
+  looks up the target and **binds it to the port** — an untrusted `B` cannot ask
+  for a different site's content.
+- The `id` is a deterministic hash, so the same site always gets the same origin
+  → per-site cookies/storage persist across sessions. Hex and base32 PK inputs
+  canonicalize to the same `id`.
+- **One wildcard** (`*.<browse-domain>`) now covers **every** site — any PK
+  length, any clearnet subdomain depth, any dmsg name-vhost — because the label
+  no longer scales with the target.
+
+The trade-off is that the origin is opaque (`k3f9x2q7m1a8b4c0zzzz.<domain>`), not
+`skycoin.com…`. That is purely cosmetic: the browser's address bar shows the
+**true** URL (`https://skycoin.com`, `https://magnetosphere.net`); the hash is an
+internal handle the user never types or sees.
+
+## Hosted deployment
+
+`V` (the wasm-visor PWA) and `B` (the browse origins) must be **different
+registrable domains** so untrusted mesh content is fully cross-site from the
+visor app (no shared cookies/storage). For example `V = theskywirenetwork.net`,
+`B = *.<browse-domain>` on a separate eTLD+1.
+
+A single process serves both, on two ports, behind one reverse proxy:
+
+```
+Caddy:  V-domain           → 127.0.0.1:7999     # the visor PWA + browse-responder.js
+        *.<browse-domain>  → 127.0.0.1:7998     # the browse-origin bootstrap (static)
+
+skywire cli hv serve \
+  --addr 127.0.0.1:7999 \
+  --browse-origin 127.0.0.1:7998 \
+  --browse-suffix .<browse-domain> \
+  --v-origin https://<V-domain>
+```
+
+or via the visor config (`hypervisor.wasm_serve`):
+
+```json
+"wasm_serve": {
+  "addr": ":7999",
+  "browse_origin_addr": "127.0.0.1:7998",
+  "browse_suffix": ".<browse-domain>",
+  "browse_v_origin": "https://<V-domain>"
+}
+```
+
+The `*.<browse-domain>` wildcard needs a wildcard TLS cert, which requires the
+**DNS-01** ACME challenge (HTTP-01 cannot issue wildcards). With Caddy and the
+`caddy-dns/cloudflare` provider that is a few lines; one wildcard covers every
+content-addressed origin.
+
+The bootstrap server never proxies content — it serves only the embedded
+`browse-bootstrap.html` + `browse-sw.js`; the SW relays all fetches to the
+visitor's own in-tab visor.
+
+## See also
+
+- `pkg/wasmhv/browseui/RFC-real-origin-browser.md` — the design RFC.
+- `pkg/visor/meshproxy.go` — the native reverse-proxy origin.
+- `pkg/wasmhv/browse-{bootstrap.html,sw.js,responder.js}` — the hosted bridge.
+- `docs/deploy/standalone-wasm-visor/` — deploy recipe.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -549,14 +549,17 @@ func run(parentCtx context.Context, conf *visorconfig.V1) error {
 		ws := conf.Hypervisor.WasmServe
 		go func() {
 			if err := ServeWasm(parentCtx, WasmServeConfig{
-				Addr:     ws.Addr,
-				TLS:      ws.TLS,
-				TLSCert:  ws.TLSCert,
-				TLSKey:   ws.TLSKey,
-				Harness:  ws.Harness,
-				Wallet:   !ws.NoWallet,
-				Variant:  ws.Variant,
-				Password: ws.Password,
+				Addr:             ws.Addr,
+				TLS:              ws.TLS,
+				TLSCert:          ws.TLSCert,
+				TLSKey:           ws.TLSKey,
+				Harness:          ws.Harness,
+				Wallet:           !ws.NoWallet,
+				Variant:          ws.Variant,
+				Password:         ws.Password,
+				BrowseSuffix:     ws.BrowseSuffix,
+				BrowseOriginAddr: ws.BrowseOriginAddr,
+				VOrigin:          ws.VOrigin,
 			}); err != nil {
 				mLog.WithError(err).Error("wasm-serve failed")
 			}

--- a/pkg/visor/visorconfig/hypervisorconfig.go
+++ b/pkg/visor/visorconfig/hypervisorconfig.go
@@ -126,6 +126,16 @@ type WasmServeConf struct {
 	NoWallet bool   `json:"no_wallet,omitempty"` // default serves the bundled skycoin-web wallet; set true to omit it
 	Variant  string `json:"variant,omitempty"`   // "" = build default; "go" | "tinygo"
 	Password string `json:"password,omitempty"`  // optional access-password gate (use with TLS)
+	// BrowseSuffix is the real-origin browser's browse-origin domain suffix
+	// (leading dot); empty = ".mesh.localhost".
+	BrowseSuffix string `json:"browse_suffix,omitempty"`
+	// BrowseOriginAddr, when set, ALSO serves the browse-origin SW bootstrap on
+	// this second address (Caddy fronts it on *.<browse_suffix>). Empty = off.
+	BrowseOriginAddr string `json:"browse_origin_addr,omitempty"`
+	// VOrigin is the public origin of the visor app V (e.g.
+	// "https://theskywirenetwork.net") that B's bootstrap postMessages to — used
+	// only with BrowseOriginAddr behind a proxy. Empty = derive from Addr.
+	VOrigin string `json:"browse_v_origin,omitempty"`
 }
 
 // DefaultHypervisorConfig returns a HypervisorConfig with sensible defaults.

--- a/pkg/visor/wasmserve.go
+++ b/pkg/visor/wasmserve.go
@@ -50,15 +50,28 @@ import (
 
 // WasmServeConfig configures ServeWasm. Mirrors the `hv serve` flags.
 type WasmServeConfig struct {
-	Addr     string          // HTTP listen address (e.g. ":8443")
-	TLS      bool            // serve HTTPS (self-signed localhost cert, or TLSCert/TLSKey if set)
-	TLSCert  string          // optional cert file (PEM) — a locally-trusted *.mesh.localhost cert (mkcert) so B-origin iframes load without a per-host accept; empty = built-in self-signed
-	TLSKey   string          // optional key file (PEM), paired with TLSCert
-	Harness  bool            // mount the /ctl/* operator control bridge (DEV ONLY)
-	Wallet   bool            // serve the bundled skycoin-web wallet at /wallet/
-	Variant  string          // "" = build default; "go" | "tinygo"
-	Password string          // optional access-password gate
-	Log      *logging.Logger // nil → package default
+	Addr     string // HTTP listen address (e.g. ":8443")
+	TLS      bool   // serve HTTPS (self-signed localhost cert, or TLSCert/TLSKey if set)
+	TLSCert  string // optional cert file (PEM) — a locally-trusted *.mesh.localhost cert (mkcert) so B-origin iframes load without a per-host accept; empty = built-in self-signed
+	TLSKey   string // optional key file (PEM), paired with TLSCert
+	Harness  bool   // mount the /ctl/* operator control bridge (DEV ONLY)
+	Wallet   bool   // serve the bundled skycoin-web wallet at /wallet/
+	Variant  string // "" = build default; "go" | "tinygo"
+	Password string // optional access-password gate
+	// BrowseSuffix is the browse-origin domain suffix (leading dot), e.g.
+	// ".mesh.localhost" (local) or ".haltingstate.net" (hosted). Empty →
+	// ".mesh.localhost".
+	BrowseSuffix string
+	// BrowseOriginAddr, when set, ALSO serves the browse-origin SW bootstrap on a
+	// SECOND listener at this address (the same process serves V on Addr and the
+	// isolated browse origins B here). A hosted deploy fronts this with Caddy on
+	// *.<BrowseSuffix>. Empty = off (local mode host-routes B on the V listener).
+	BrowseOriginAddr string
+	// VOrigin is the PUBLIC origin of the visor app V (e.g.
+	// "https://theskywirenetwork.net") that B's bootstrap postMessages to — used
+	// only with BrowseOriginAddr behind a proxy. Empty = derive from Addr (local).
+	VOrigin string
+	Log     *logging.Logger // nil → package default
 }
 
 // ServeWasm builds the standalone wasm-visor handler and serves it on
@@ -134,13 +147,51 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	if bport != "" {
 		vHostPort = "localhost:" + bport
 	}
-	// Injected so browse.js enters real-origin mode and builds <pk>.mesh.localhost
-	// :<port> origins for the WinBox browser iframe.
-	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:\".mesh.localhost\",scheme:" + strconv.Quote(browseScheme) + ",port:" + strconv.Quote(bport) + "};"
+	// Browse-origin domain suffix. Empty = local single-listener default.
+	suffix := cfg.BrowseSuffix
+	if suffix == "" {
+		suffix = ".mesh.localhost"
+	}
+	// B-origin scheme+port. B may live elsewhere than V: for the *.localhost local
+	// model B and V share THIS listener + cert, so B inherits browseScheme/bport;
+	// for a hosted suffix B is fronted by Caddy TLS on 443 (a separate process /
+	// host — see ServeBrowseOrigin), so it's plain https with no explicit port.
+	bScheme, bPort := browseScheme, bport
+	if !strings.HasSuffix(suffix, ".localhost") {
+		bScheme, bPort = "https", ""
+	}
+	// Injected so browse.js enters real-origin mode and builds <pk><suffix>[:<port>]
+	// origins for the WinBox browser iframe.
+	browseOriginJS := "window.__SKYWIRE_BROWSE_ORIGIN__={suffix:" + strconv.Quote(suffix) + ",scheme:" + strconv.Quote(bScheme) + ",port:" + strconv.Quote(bPort) + "};"
 	index := injectWasmBoot(indexB, wasmVer, cfg.Harness, browseOriginJS)
 
 	browseBootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__V_ORIGIN__"), []byte(browseScheme+"://"+vHostPort))
-	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(".mesh.localhost"))
+	browseBootstrap = bytes.ReplaceAll(browseBootstrap, []byte("__SUFFIX__"), []byte(suffix))
+
+	// Hosted two-port mode: when BrowseOriginAddr is set, this SAME process ALSO
+	// runs the browse-origin bootstrap server on that second listener (Caddy fronts
+	// it on *.<suffix>). V (this listener) and B (that one) are separate origins;
+	// co-locating them in one process keeps the deploy to a single unit. Best-effort
+	// — a bind failure is logged, not fatal to serving V.
+	if cfg.BrowseOriginAddr != "" {
+		vOrigin := cfg.VOrigin
+		if vOrigin == "" {
+			vOrigin = browseScheme + "://" + vHostPort
+		}
+		go func() {
+			if err := ServeBrowseOrigin(ctx, BrowseOriginConfig{
+				Addr:    cfg.BrowseOriginAddr,
+				VOrigin: vOrigin,
+				Suffix:  suffix,
+				TLS:     cfg.TLS,
+				TLSCert: cfg.TLSCert,
+				TLSKey:  cfg.TLSKey,
+				Log:     log,
+			}); err != nil {
+				log.WithError(err).Error("browse-origin bootstrap server failed")
+			}
+		}()
+	}
 
 	mux := http.NewServeMux()
 	serveBytes := func(path, ct string, body []byte) {
@@ -318,7 +369,7 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 	// subresources. Non-B hosts (the visor origin V = localhost) are untouched.
 	base := handler
 	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isMeshBrowseHost(r.Host) && r.URL.Path != "/browse-sw.js" {
+		if isMeshBrowseHost(r.Host, suffix) && r.URL.Path != "/browse-sw.js" {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.Header().Set("Cache-Control", "no-store")
 			_, _ = w.Write(browseBootstrap) //nolint:errcheck
@@ -359,6 +410,95 @@ func ServeWasm(ctx context.Context, cfg WasmServeConfig) error {
 		return nil
 	}
 	log.Infof("serving standalone wasm-visor (ui + %d-byte wasm + hv-boot) on %s", len(wasm), cfg.Addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
+}
+
+// BrowseOriginConfig configures ServeBrowseOrigin — the browse-origin bootstrap
+// server for the hosted two-server model. It serves ONLY the embedded SW bootstrap
+// (and browse-sw.js) for the isolated browse origins B (<pk><Suffix>); it is NEVER
+// in the content path (the registered SW relays every fetch to the visitor's in-tab
+// visor at VOrigin). Front it with Caddy on *.<Suffix>.
+type BrowseOriginConfig struct {
+	Addr    string          // HTTP listen address (loopback; Caddy fronts it)
+	VOrigin string          // the visor app origin V, e.g. "https://theskywirenetwork.net"
+	Suffix  string          // browse-origin domain suffix (leading dot), e.g. ".haltingstate.net"
+	TLS     bool            // usually false — Caddy terminates TLS
+	TLSCert string          // optional PEM cert (paired with TLSKey)
+	TLSKey  string          // optional PEM key
+	Log     *logging.Logger // nil → package default
+}
+
+// ServeBrowseOrigin runs the browse-origin bootstrap server (RFC §4b, hosted mode):
+// for any Host under Suffix it returns the SW bootstrap shell with __V_ORIGIN__ and
+// __SUFFIX__ substituted; /browse-sw.js returns the transport SW. Blocking until ctx
+// is canceled.
+func ServeBrowseOrigin(ctx context.Context, cfg BrowseOriginConfig) error {
+	log := cfg.Log
+	if log == nil {
+		log = logging.MustGetLogger("browse-origin")
+	}
+	if strings.TrimSpace(cfg.VOrigin) == "" {
+		return fmt.Errorf("browse-origin: VOrigin is required")
+	}
+	suffix := strings.TrimSpace(cfg.Suffix)
+	if suffix == "" {
+		return fmt.Errorf("browse-origin: Suffix is required")
+	}
+	if !strings.HasPrefix(suffix, ".") {
+		suffix = "." + suffix
+	}
+
+	// Precompute the bootstrap shell: the SW bootstrap that every browse origin B
+	// serves. It registers browse-sw.js and points the SW at the visitor's in-tab
+	// visor at VOrigin; the transcode substitutions match ServeWasm.
+	bootstrap := bytes.ReplaceAll(wasmhv.BrowseBootstrapHTML, []byte("__V_ORIGIN__"), []byte(cfg.VOrigin))
+	bootstrap = bytes.ReplaceAll(bootstrap, []byte("__SUFFIX__"), []byte(suffix))
+
+	// Caddy only routes *.Suffix here, so no host check is needed: /browse-sw.js is
+	// the transport SW, every other path is the bootstrap shell.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/browse-sw.js" {
+			w.Header().Set("Content-Type", "text/javascript")
+			w.Header().Set("Cache-Control", "no-cache")
+			_, _ = w.Write(wasmhv.BrowseSWJS) //nolint:errcheck
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		_, _ = w.Write(bootstrap) //nolint:errcheck
+	})
+
+	srv := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	go func() {
+		<-ctx.Done()
+		_ = srv.Close() //nolint:errcheck
+	}()
+
+	log.Infof("serving browse-origin bootstrap on %s (V-origin %s, suffix %s)", cfg.Addr, cfg.VOrigin, suffix)
+	if cfg.TLS {
+		var cert tls.Certificate
+		var err error
+		if cfg.TLSCert != "" && cfg.TLSKey != "" {
+			cert, err = tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+		} else {
+			cert, err = wasmLocalhostTLSCert()
+		}
+		if err != nil {
+			return fmt.Errorf("tls cert: %w", err)
+		}
+		srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12}
+		if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			return fmt.Errorf("serve: %w", err)
+		}
+		return nil
+	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("serve: %w", err)
 	}
@@ -462,15 +602,16 @@ func injectWasmBoot(index []byte, wasmVer string, harness bool, browseOriginJS s
 }
 
 // isMeshBrowseHost reports whether an HTTP Host header targets an isolated
-// real-origin browse origin B (<...>.mesh.localhost[:port]) rather than the visor
-// origin V (localhost). Browsers resolve *.localhost to loopback, so these hit
-// the same wasm-serve listener and are distinguished only by Host.
-func isMeshBrowseHost(h string) bool {
+// real-origin browse origin B (<...><suffix>[:port]) rather than the visor
+// origin V. For the *.mesh.localhost local model browsers resolve *.localhost to
+// loopback, so these hit the same wasm-serve listener and are distinguished only
+// by Host.
+func isMeshBrowseHost(h, suffix string) bool {
 	host := h
 	if i := strings.IndexByte(host, ':'); i >= 0 {
 		host = host[:i]
 	}
-	return strings.HasSuffix(host, ".mesh.localhost")
+	return strings.HasSuffix(host, suffix)
 }
 
 // wasmLocalhostTLSCert returns a self-signed localhost cert for

--- a/pkg/wasmhv/browse-bootstrap.html
+++ b/pkg/wasmhv/browse-bootstrap.html
@@ -45,7 +45,25 @@
     var net = 'dmsg';
     if (/\.skynet$/.test(host)) { net = 'skynet'; host = host.replace(/\.skynet$/, ''); }
     else if (/\.dmsg$/.test(host)) { net = 'dmsg'; host = host.replace(/\.dmsg$/, ''); }
+    else if (/\.skysocks$/.test(host)) { net = 'skysocks'; host = host.replace(/\.skysocks$/, ''); }
+    // For skysocks the host IS the clearnet hostname (no ".<net>" mesh suffix).
+    if (net === 'skysocks') return { host: host, net: net };
     return { host: host + '.' + net, net: net };
+  }
+
+  // For skysocks, a request to origin B (<clearnethost>.skysocks<SUFFIX>) maps to
+  // the real clearnet URL https://<clearnethost><path>; an absolute cross-origin
+  // request is already a real clearnet URL and passes through unchanged.
+  function realFetchUrl(net, reqUrl) {
+    if (net !== 'skysocks') return reqUrl;
+    try {
+      var u = new URL(reqUrl, location.href);
+      var suf = '.skysocks' + SUFFIX;
+      if (u.hostname.slice(-suf.length) === suf) {
+        return 'https://' + u.hostname.slice(0, -suf.length) + u.pathname + u.search;
+      }
+      return u.href;
+    } catch (e) { return reqUrl; }
   }
 
   var tgt = meshTarget();
@@ -119,7 +137,7 @@
       var replyPort = e.ports[0];
       var r = d.req || {};
       var transfer = r.body ? [r.body] : [];
-      helperFetch({ host: tgt.host, net: tgt.net, url: r.url, method: r.method, headers: r.headers, body: r.body }, transfer)
+      helperFetch({ host: tgt.host, net: tgt.net, url: realFetchUrl(tgt.net, r.url), method: r.method, headers: r.headers, body: r.body }, transfer)
         .then(function (res) {
           var t = res.body ? [res.body] : [];
           replyPort.postMessage(res, t);
@@ -145,7 +163,7 @@
   ]).then(function () {
     window.__mb.step = 'fetching-top';
     var path = location.pathname + location.search;
-    return helperFetch({ host: tgt.host, net: tgt.net, url: location.href, method: 'GET', headers: {}, body: null, path: path });
+    return helperFetch({ host: tgt.host, net: tgt.net, url: realFetchUrl(tgt.net, location.href), method: 'GET', headers: {}, body: null, path: path });
   }).then(function (res) {
     window.__mb.step = 'top-returned';
     window.__mb.topStatus = res && res.status;

--- a/pkg/wasmhv/browse-bootstrap.html
+++ b/pkg/wasmhv/browse-bootstrap.html
@@ -29,45 +29,17 @@
   'use strict';
   var V_ORIGIN = "__V_ORIGIN__";      // visor origin (holds the SharedWorker visor + key)
   var SUFFIX   = "__SUFFIX__" || ".mesh.localhost";
+  // Content-addressed browse origin: the hostname is a short stable hash of the
+  // target (the shortid). V holds shortid -> descriptor and resolves the target;
+  // we just tell V which shortid we are, then send RAW request URLs (V maps them).
+  var SHORTID = location.hostname.slice(0, Math.max(0, location.hostname.length - SUFFIX.length));
 
   function fail(msg) {
     var m = document.getElementById('mesh-msg'); if (m) { m.textContent = msg; }
     var b = document.getElementById('mesh-boot'); if (b) { b.querySelector('.sp').style.display = 'none'; }
   }
 
-  // meshTarget derives the resolving-proxy host (for skywireVisor.fetchDmsg) from
-  // this origin's hostname: "<vhost>.<base32pk>[.<net>].mesh.localhost" →
-  // "<vhost>.<base32pk>.dmsg" (or ".skynet"). fetchDmsg resolves base32/hex PKs,
-  // aliases and name-vhost forms Go-side.
-  function meshTarget() {
-    var host = location.hostname;
-    if (host.slice(-SUFFIX.length) === SUFFIX) host = host.slice(0, -SUFFIX.length);
-    var net = 'dmsg';
-    if (/\.skynet$/.test(host)) { net = 'skynet'; host = host.replace(/\.skynet$/, ''); }
-    else if (/\.dmsg$/.test(host)) { net = 'dmsg'; host = host.replace(/\.dmsg$/, ''); }
-    else if (/\.skysocks$/.test(host)) { net = 'skysocks'; host = host.replace(/\.skysocks$/, ''); }
-    // For skysocks the host IS the clearnet hostname (no ".<net>" mesh suffix).
-    if (net === 'skysocks') return { host: host, net: net };
-    return { host: host + '.' + net, net: net };
-  }
-
-  // For skysocks, a request to origin B (<clearnethost>.skysocks<SUFFIX>) maps to
-  // the real clearnet URL https://<clearnethost><path>; an absolute cross-origin
-  // request is already a real clearnet URL and passes through unchanged.
-  function realFetchUrl(net, reqUrl) {
-    if (net !== 'skysocks') return reqUrl;
-    try {
-      var u = new URL(reqUrl, location.href);
-      var suf = '.skysocks' + SUFFIX;
-      if (u.hostname.slice(-suf.length) === suf) {
-        return 'https://' + u.hostname.slice(0, -suf.length) + u.pathname + u.search;
-      }
-      return u.href;
-    } catch (e) { return reqUrl; }
-  }
-
-  var tgt = meshTarget();
-  var hostEl = document.getElementById('mesh-host'); if (hostEl) hostEl.textContent = tgt.host;
+  var hostEl = document.getElementById('mesh-host'); if (hostEl) hostEl.textContent = SHORTID;
 
   // --- bridge to the PARENT visor app (V) ----------------------------------
   // This browse origin B is embedded as an iframe INSIDE the visor app V (the
@@ -90,6 +62,13 @@
       window.addEventListener('message', function onmsg(e) {
         if (e.origin !== V_ORIGIN) return;               // only trust V
         if (!e.data || e.data.type !== 'mesh-helper-ready') return;
+        if (e.data.error) {                              // V rejected our shortid
+          clearTimeout(to);
+          window.removeEventListener('message', onmsg);
+          fail('mesh: ' + e.data.error);
+          reject(new Error(e.data.error));
+          return;
+        }
         if (!e.ports || !e.ports[0]) return;
         clearTimeout(to);
         helperPort = e.ports[0];
@@ -101,7 +80,7 @@
       (function hello() {
         if (helperPort || tries > 30) return;
         tries++;
-        try { window.parent.postMessage({ type: 'mesh-hello' }, V_ORIGIN); } catch (e) {}
+        try { window.parent.postMessage({ type: 'mesh-hello', shortid: SHORTID }, V_ORIGIN); } catch (e) {}
         setTimeout(hello, 300);
       })();
     });
@@ -137,7 +116,7 @@
       var replyPort = e.ports[0];
       var r = d.req || {};
       var transfer = r.body ? [r.body] : [];
-      helperFetch({ host: tgt.host, net: tgt.net, url: realFetchUrl(tgt.net, r.url), method: r.method, headers: r.headers, body: r.body }, transfer)
+      helperFetch({ url: r.url, method: r.method, headers: r.headers, body: r.body }, transfer)
         .then(function (res) {
           var t = res.body ? [res.body] : [];
           replyPort.postMessage(res, t);
@@ -163,7 +142,7 @@
   ]).then(function () {
     window.__mb.step = 'fetching-top';
     var path = location.pathname + location.search;
-    return helperFetch({ host: tgt.host, net: tgt.net, url: realFetchUrl(tgt.net, location.href), method: 'GET', headers: {}, body: null, path: path });
+    return helperFetch({ url: location.href, method: 'GET', headers: {}, body: null, path: path });
   }).then(function (res) {
     window.__mb.step = 'top-returned';
     window.__mb.topStatus = res && res.status;

--- a/pkg/wasmhv/browse-responder.js
+++ b/pkg/wasmhv/browse-responder.js
@@ -20,8 +20,8 @@
   // isMeshBrowseHost / the configured browse suffix).
   function isBrowseOrigin(origin) {
     try {
-      var h = new URL(origin).hostname;
-      return /\.mesh\.localhost$/.test(h);
+      var suffix = (globalThis.__SKYWIRE_BROWSE_ORIGIN__ && globalThis.__SKYWIRE_BROWSE_ORIGIN__.suffix) || '.mesh.localhost';
+      return new URL(origin).hostname.endsWith(suffix);
     } catch (e) { return false; }
   }
 

--- a/pkg/wasmhv/browse-responder.js
+++ b/pkg/wasmhv/browse-responder.js
@@ -36,29 +36,35 @@
     return null;
   }
 
-  function serve(req) {
+  function serve(desc, req) {
     var v = globalThis.skywireVisor;
     if (!v || !v.fetchDmsg) { return Promise.reject(new Error('visor not ready')); }
     var method = req.method || 'GET';
     var headers = req.headers || {};
     var bodyU8 = req.body ? new Uint8Array(req.body) : null;
-    if (req.net === 'skysocks') {
-      // clearnet egress via skysocks-lite (empty exit = auto pool w/ failover)
-      return v.fetchClearnet('', method, req.url, bodyU8, '', headers);
+    if (desc.net === 'skysocks') {
+      // Map a request to origin B back to its real clearnet URL; an absolute
+      // cross-origin request is already a real clearnet URL and passes through.
+      var realUrl = req.url;
+      try {
+        var u = new URL(req.url);
+        if (isBrowseOrigin(u.origin)) { realUrl = desc.base + u.pathname + u.search; }
+      } catch (e) {}
+      return v.fetchClearnet('', method, realUrl, bodyU8, '', headers);
     }
-    // mesh over dmsg (wasm has no separate skynet round-tripper today → dmsg
-    // serves dmsg + auto).
-    return v.fetchDmsg(req.host, method, pathOf(req.url, req.path), bodyU8, headers);
+    return v.fetchDmsg(desc.host, method, pathOf(req.url, req.path), bodyU8, headers);
   }
 
   window.addEventListener('message', function (e) {
     var d = e.data || {};
     if (d.type !== 'mesh-hello') { return; }
     if (!isBrowseOrigin(e.origin) || !e.source) { return; }
+    var desc = (globalThis.__meshOrigins || {})[String(d.shortid || '')];
+    if (!desc) { try { e.source.postMessage({ type: 'mesh-helper-ready', error: 'unknown browse origin' }, e.origin); } catch (x) {} return; }
     var mc = new MessageChannel();
     mc.port1.onmessage = function (ev) {
       var q = ev.data || {};
-      serve(q.req || {}).then(function (r) {
+      serve(desc, q.req || {}).then(function (r) {
         r = r || {};
         var ab = toArrayBuffer(r.body);
         mc.port1.postMessage({ id: q.id, status: r.status || 200, headers: r.headers || {}, body: ab }, ab ? [ab] : []);

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -325,11 +325,23 @@
     // labelFor: a 66-hex PK → 53-char base32 DNS label (hex is too long for a DNS
     // label); an alias / already-base32 label passes through unchanged.
     function labelFor(pk) { return /^[0-9a-fA-F]{66}$/.test(pk) ? pkDNSLabel(pk) : pk; }
-    function buildRealOrigin(pk, path, scheme) {
+    // buildRealOrigin takes the FULL resolver host go() produced (e.g. "<hex>.dmsg",
+    // "<vhost>.<hex>.dmsg", "home.dmsg", "<base32>.dmsg") and turns it into a valid
+    // browse origin: it peels a trailing ".dmsg"/".skynet" into net (else uses a
+    // dmsg/skynet scheme), then base32-encodes ANY 66-hex label (a bare hex PK is
+    // too long for a DNS label) while leaving aliases / 53-char base32 / vhost
+    // labels alone. Reassembles "<labels>[.<net>]<suffix>[:<port>]<path>".
+    function buildRealOrigin(host, path, scheme) {
       var c = realOriginCfg;
-      var net = (scheme === "skynet") ? "skynet" : (scheme === "dmsg") ? "dmsg" : ""; // "" = auto
-      var host = labelFor(pk) + (net ? ("." + net) : "") + (c.suffix || ".mesh.localhost");
-      return (c.scheme || "https") + "://" + host + (c.port ? (":" + c.port) : "") + (path || "/");
+      var net = "";
+      if (/\.dmsg$/i.test(host)) { net = "dmsg"; host = host.slice(0, -5); }
+      else if (/\.skynet$/i.test(host)) { net = "skynet"; host = host.slice(0, -7); }
+      else if (scheme === "dmsg" || scheme === "skynet") { net = scheme; }
+      var labels = host.split(".").map(function (l) {
+        return /^[0-9a-fA-F]{66}$/.test(l) ? pkDNSLabel(l) : l;
+      }).join(".");
+      var origin = labels + (net ? ("." + net) : "") + (c.suffix || ".mesh.localhost");
+      return (c.scheme || "https") + "://" + origin + (c.port ? (":" + c.port) : "") + (path || "/");
     }
 
     // 1x1 transparent GIF — placeholder src for a deferred (lazy) image so it
@@ -687,6 +699,25 @@
         frame.src = url; // browser/visor loads it directly (non-anonymous, no skysocks hop)
         log("clearnet DIRECT (upstream = local visor): " + url);
         return { status: 0, direct: true };
+      }
+      // Real-origin clearnet: load the site at its own isolated origin
+      // <host>.skysocks.<suffix>; the origin's SW relays every fetch through
+      // this visor's skysocks-lite. (Transcoder below stays as the fallback.)
+      if (realOriginCfg) {
+        var cu; try { cu = new URL(url); } catch (e) { cu = null; }
+        if (cu && (cu.protocol === "http:" || cu.protocol === "https:")) {
+          var corigin = cu.hostname + ".skysocks" + (realOriginCfg.suffix || ".mesh.localhost");
+          var crurl = (realOriginCfg.scheme || "https") + "://" + corigin +
+            (realOriginCfg.port ? (":" + realOriginCfg.port) : "") + (cu.pathname + cu.search);
+          if (gen !== loadGen) return { status: 0, cancelled: true };
+          currentSitePK = "";
+          frame.removeAttribute("srcdoc");
+          frame.src = crurl;
+          if (opts.setAddr) opts.setAddr(url); // show the REAL clearnet URL, not the B origin
+          log("real-origin clearnet " + crurl);
+          setLoading(false);
+          return { status: 0, realOrigin: true };
+        }
       }
       var r = await fetchClearnet(pol.exit, "GET", url, null);
       if (gen !== loadGen) return { status: 0, cancelled: true };

--- a/pkg/wasmhv/browseui/browse.js
+++ b/pkg/wasmhv/browseui/browse.js
@@ -325,23 +325,40 @@
     // labelFor: a 66-hex PK → 53-char base32 DNS label (hex is too long for a DNS
     // label); an alias / already-base32 label passes through unchanged.
     function labelFor(pk) { return /^[0-9a-fA-F]{66}$/.test(pk) ? pkDNSLabel(pk) : pk; }
-    // buildRealOrigin takes the FULL resolver host go() produced (e.g. "<hex>.dmsg",
-    // "<vhost>.<hex>.dmsg", "home.dmsg", "<base32>.dmsg") and turns it into a valid
-    // browse origin: it peels a trailing ".dmsg"/".skynet" into net (else uses a
-    // dmsg/skynet scheme), then base32-encodes ANY 66-hex label (a bare hex PK is
-    // too long for a DNS label) while leaving aliases / 53-char base32 / vhost
-    // labels alone. Reassembles "<labels>[.<net>]<suffix>[:<port>]<path>".
-    function buildRealOrigin(host, path, scheme) {
+    // Content-addressed browse origins: origin B is a short, STABLE hash of the
+    // target — not the target itself — so ONE wildcard cert covers every site
+    // regardless of PK length, clearnet subdomain depth, or dmsg name-vhosts. The
+    // visor keeps shortid -> descriptor; the B bootstrap asks V for its descriptor
+    // by id at handshake (see browse-responder.js / browse-bootstrap.html).
+    var meshOrigins = (globalThis.__meshOrigins = globalThis.__meshOrigins || {});
+    function originIdFor(canon) {
+      return crypto.subtle.digest("SHA-256", new TextEncoder().encode(canon)).then(function (buf) {
+        var b = new Uint8Array(buf), out = "", bits = 0, val = 0;
+        for (var i = 0; i < b.length && out.length < 20; i++) {
+          val = (val << 8) | b[i]; bits += 8;
+          while (bits >= 5 && out.length < 20) { out += B32[(val >>> (bits - 5)) & 31]; bits -= 5; }
+        }
+        return out;
+      });
+    }
+    // normResolverHost canonicalizes a dmsg/skynet resolver host: strips a trailing
+    // .dmsg/.skynet, base32-encodes any 66-hex PK label, re-appends ".<net>". Keeps
+    // aliases / base32 / name-vhost labels intact. So "<hex>.dmsg", "<base32>.dmsg",
+    // "magnetosphere.net.<hex>.dmsg" all normalize to a stable "<...>.<net>".
+    function normResolverHost(pk, net) {
+      var h = String(pk || "").replace(/\.(dmsg|skynet)$/i, "");
+      h = h.split(".").map(function (l) { return /^[0-9a-fA-F]{66}$/.test(l) ? pkDNSLabel(l) : l; }).join(".");
+      return h + "." + net;
+    }
+    // buildRealOrigin(descriptor, path) -> Promise<url>. descriptor is
+    //   {net:'dmsg'|'skynet', host:'<resolverHost>'} or {net:'skysocks', base:'https://<host>'}.
+    function buildRealOrigin(descriptor, path) {
       var c = realOriginCfg;
-      var net = "";
-      if (/\.dmsg$/i.test(host)) { net = "dmsg"; host = host.slice(0, -5); }
-      else if (/\.skynet$/i.test(host)) { net = "skynet"; host = host.slice(0, -7); }
-      else if (scheme === "dmsg" || scheme === "skynet") { net = scheme; }
-      var labels = host.split(".").map(function (l) {
-        return /^[0-9a-fA-F]{66}$/.test(l) ? pkDNSLabel(l) : l;
-      }).join(".");
-      var origin = labels + (net ? ("." + net) : "") + (c.suffix || ".mesh.localhost");
-      return (c.scheme || "https") + "://" + origin + (c.port ? (":" + c.port) : "") + (path || "/");
+      var canon = descriptor.net === "skysocks" ? ("skysocks|" + descriptor.base) : (descriptor.net + "|" + descriptor.host);
+      return originIdFor(canon).then(function (id) {
+        meshOrigins[id] = descriptor;
+        return (c.scheme || "https") + "://" + id + (c.suffix || ".mesh.localhost") + (c.port ? (":" + c.port) : "") + (path || "/");
+      });
     }
 
     // 1x1 transparent GIF — placeholder src for a deferred (lazy) image so it
@@ -624,7 +641,8 @@
       try {
         // Real-origin: hand the whole load to the browser via an isolated origin.
         if (realOriginCfg && entry.kind === "dmsg") {
-          var rurl = buildRealOrigin(entry.pk, entry.path, entry.scheme);
+          var dnet = (entry.scheme === "skynet") ? "skynet" : "dmsg";
+          var rurl = await buildRealOrigin({ net: dnet, host: normResolverHost(entry.pk, dnet) }, entry.path);
           frame.removeAttribute("srcdoc");
           frame.src = rurl;
           currentSitePK = entry.pk;
@@ -706,15 +724,13 @@
       if (realOriginCfg) {
         var cu; try { cu = new URL(url); } catch (e) { cu = null; }
         if (cu && (cu.protocol === "http:" || cu.protocol === "https:")) {
-          var corigin = cu.hostname + ".skysocks" + (realOriginCfg.suffix || ".mesh.localhost");
-          var crurl = (realOriginCfg.scheme || "https") + "://" + corigin +
-            (realOriginCfg.port ? (":" + realOriginCfg.port) : "") + (cu.pathname + cu.search);
           if (gen !== loadGen) return { status: 0, cancelled: true };
+          var crurl = await buildRealOrigin({ net: "skysocks", base: cu.origin }, cu.pathname + cu.search);
           currentSitePK = "";
           frame.removeAttribute("srcdoc");
           frame.src = crurl;
           if (opts.setAddr) opts.setAddr(url); // show the REAL clearnet URL, not the B origin
-          log("real-origin clearnet " + crurl);
+          log("real-origin clearnet " + url);
           setLoading(false);
           return { status: 0, realOrigin: true };
         }


### PR DESCRIPTION
Follow-up to #3807 / #3808. Completes the real-origin browser for the **hosted** wasm surface: clearnet sites over skysocks-lite now get real isolated origins, and every browse origin is content-addressed so a **single** wildcard TLS cert covers all of them.

## What changed
- **Clearnet (skysocks) real-origin** — a clearnet site now loads at its own isolated origin (fetched through the in-tab visor's skysocks-lite) instead of the opaque `srcdoc` transcoder, the same treatment `.dmsg`/`.skynet` already got. The B-origin SW relays the page **and** every subresource; the responder maps B-origin requests back to the real clearnet URL and passes absolute cross-origin URLs through.
- **Content-addressed origins** — origin B is now `base32(sha256(target))[:20]` (80 bits), not the target encoded into the hostname. The visor keeps `shortid → target`; the bootstrap sends its `shortid` at handshake and the responder binds the target to the port (an untrusted B can't redirect the dmsg fetch). Hex and base32 PK inputs canonicalize to the same stable origin, so per-site cookies/storage persist.

## Why content-addressing (the interesting turn)
The first approach encoded the target *into* the hostname — `<base32pk>.dmsg.<domain>`, `<clearnethost>.skysocks.<domain>`. That works for a bare PK, but it collides head-on with how TLS wildcards work:

- A wildcard certificate matches **exactly one label**, and only in the **leftmost** position (RFC 6125 §6.4.3 + CA/Browser Forum BRs). `*.*.<domain>` is not a valid certificate — no CA issues it, no browser accepts it.
- So a multi-label target has no cert: `explorer.skycoin.com` (clearnet subdomain) and especially a dmsg **name-vhost** like `magnetosphere.net.<base32pk>.dmsg` — where the 53-char base32 PK already eats most of the 63-char DNS-label budget, so vhost + PK can't even be collapsed into one label.

We considered per-level wildcards (`*.dmsg`, `*.skysocks`, `*.com.skysocks`…) — unbounded for clearnet — and hyphen-escaping dots into one label (breaks past 63 chars for vhost + base32 PK). The clean fix is to stop encoding the target in the name at all: hash it to a short fixed-length id and keep the map in the visor. Now **one** wildcard (`*.<domain>`) covers every site at any PK length, clearnet subdomain depth, or dmsg name-vhost — and the per-net Caddy blocks go away.

The address bar still shows the true URL (`https://magnetosphere.net`, `https://skycoin.com`); the hash is an internal origin id the user never sees.

## Validated live (theskywirenetwork.net, through the real WinBox browser UI)
- hex-PK `.dmsg` → renders at `<hash>.<domain>` (hex canonicalizes to the same origin as base32)
- `magnetosphere.net.<pk>.dmsg` (89-char name-vhost) → the real magnetosphere.net site
- `https://skycoin.com` via skysocks → full page + 31 subresource images relayed through the SW

All `isSecureContext`, on the one wildcard cert. Clearnet rendering depends on a live skysocks-lite exit (pool availability is intermittent — separate from this change).

`go build`, `node --check` on the three assets, clean.