### PR TITLE
feat(dmsg): idle-session reaper — settle session count toward MinSessions

### DIFF
--- a/pkg/dmsg/dmsg/client.go
+++ b/pkg/dmsg/dmsg/client.go
@@ -348,6 +348,7 @@ func (ce *Client) Serve(ctx context.Context) {
 	pingLoopOnce := new(sync.Once)
 	reconnectLoopOnce := new(sync.Once)
 	porterReapLoopOnce := new(sync.Once)
+	reapLoopOnce := new(sync.Once)
 
 	needInitialPost := true
 
@@ -601,6 +602,7 @@ func (ce *Client) Serve(ctx context.Context) {
 				updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done, ce.conf.ClientType) })
 				pingLoopOnce.Do(func() { go ce.pingSessionsLoop(cancellabelCtx) })
 				porterReapLoopOnce.Do(func() { go ce.porterReapLoop(cancellabelCtx) })
+				reapLoopOnce.Do(func() { go ce.reapIdleSessionsLoop(cancellabelCtx) })
 				if ce.conf.MinSessions == 0 {
 					reconnectLoopOnce.Do(func() { go ce.reconnectLoop(cancellabelCtx) })
 				}
@@ -614,6 +616,7 @@ func (ce *Client) Serve(ctx context.Context) {
 		updateEntryLoopOnce.Do(func() { go ce.updateClientEntryLoop(cancellabelCtx, ce.done, ce.conf.ClientType) })
 		pingLoopOnce.Do(func() { go ce.pingSessionsLoop(cancellabelCtx) })
 		porterReapLoopOnce.Do(func() { go ce.porterReapLoop(cancellabelCtx) })
+		reapLoopOnce.Do(func() { go ce.reapIdleSessionsLoop(cancellabelCtx) })
 		// When MinSessions is 0 (connect to all), start a reconnect loop that
 		// aggressively retries connecting to servers we failed to reach on the first pass.
 		if ce.conf.MinSessions == 0 {
@@ -1209,6 +1212,99 @@ func (ce *Client) porterReapLoop(ctx context.Context) {
 			ce.reapOrphanPorts()
 		}
 	}
+}
+
+// reapIdleSessionsLoop periodically closes sessions that are streamless and
+// beyond MinSessions, so on-demand rendezvous sessions (opened by the dial path
+// to reach a peer delegated to a server this client wasn't connected to, then
+// kept alive forever by pingSessionsLoop) don't accumulate — the session count
+// settles toward the configured minimum instead of drifting toward "all servers".
+// Disabled when MinSessions == 0 (connect-to-all), where every session is
+// intentional and reconnectLoop actively re-dials.
+func (ce *Client) reapIdleSessionsLoop(ctx context.Context) {
+	if ce.MinSessions() <= 0 {
+		return
+	}
+	const interval = 60 * time.Second
+	// A session must read as streamless for this many consecutive checks before
+	// it's reaped, so a brief gap between requests (or a transient ping stream)
+	// doesn't cull an in-use session.
+	const idleChecksToReap = 2
+	idleStreak := make(map[cipher.PubKey]int)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ce.done:
+			return
+		case <-ticker.C:
+			ce.reapExcessIdleSessions(idleStreak, idleChecksToReap)
+		}
+	}
+}
+
+// reapExcessIdleSessions snapshots the live sessions and their stream counts,
+// asks pickIdleSessionsToReap which to close, and closes them. Closing a session
+// unwinds its serve goroutine, which calls delSession to drop it from the map.
+func (ce *Client) reapExcessIdleSessions(idleStreak map[cipher.PubKey]int, idleChecksToReap int) {
+	min := ce.MinSessions()
+	if min <= 0 {
+		return
+	}
+	ce.sessionsMx.Lock()
+	sessions := make(map[cipher.PubKey]*SessionCommon, len(ce.sessions))
+	streams := make(map[cipher.PubKey]int, len(ce.sessions))
+	for pk, ses := range ce.sessions {
+		sessions[pk] = ses
+		streams[pk] = ses.NumStreams()
+	}
+	ce.sessionsMx.Unlock()
+
+	for _, pk := range pickIdleSessionsToReap(streams, idleStreak, min, idleChecksToReap) {
+		if ses := sessions[pk]; ses != nil {
+			ce.log.WithField("remote_pk", pk.String()).
+				Debug("reaping idle dmsg session (streamless, over min_sessions)")
+			_ = ses.Close() //nolint:errcheck
+		}
+	}
+}
+
+// pickIdleSessionsToReap decides which sessions to close given each session's
+// open-stream count (0 = idle; a negative "unknown" count — e.g. quic — is
+// treated as busy). It advances the per-session idle streak, prunes streaks for
+// sessions that have vanished, and returns up to (total - min) sessions that have
+// read as streamless for at least idleChecksToReap consecutive calls — so it
+// never takes the count below the MinSessions floor and never reaps an in-use
+// session. Pure over its inputs (it mutates idleStreak) so the policy is unit
+// testable without real sessions.
+func pickIdleSessionsToReap(streams, idleStreak map[cipher.PubKey]int, min, idleChecksToReap int) []cipher.PubKey {
+	total := len(streams)
+	var reap []cipher.PubKey
+	for pk, n := range streams {
+		if n == 0 {
+			idleStreak[pk]++
+			if idleStreak[pk] >= idleChecksToReap {
+				reap = append(reap, pk)
+			}
+		} else {
+			idleStreak[pk] = 0
+		}
+	}
+	for pk := range idleStreak {
+		if _, ok := streams[pk]; !ok {
+			delete(idleStreak, pk)
+		}
+	}
+	surplus := total - min
+	if surplus <= 0 {
+		return nil
+	}
+	if len(reap) > surplus {
+		reap = reap[:surplus]
+	}
+	return reap
 }
 
 // reapOrphanPorts walks the porter and calls the close function for any

--- a/pkg/dmsg/dmsg/client_reaper_test.go
+++ b/pkg/dmsg/dmsg/client_reaper_test.go
@@ -1,0 +1,69 @@
+package dmsg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func mkPK(t *testing.T) cipher.PubKey {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return pk
+}
+
+// TestPickIdleSessionsToReap covers the idle-session reaper's decision policy:
+// only streamless sessions that stayed idle for >= idleChecksToReap consecutive
+// checks are reaped, never below the MinSessions floor, and busy/unknown sessions
+// are kept. The idleStreak map is advanced across calls.
+func TestPickIdleSessionsToReap(t *testing.T) {
+	const min = 2
+	const thresh = 2
+
+	// Two idle + one busy, floor 2. Surplus = 1. First call: streaks reach 1
+	// (< thresh) → nothing yet.
+	a, b, c := mkPK(t), mkPK(t), mkPK(t)
+	streams := map[cipher.PubKey]int{a: 0, b: 0, c: 3}
+	streak := map[cipher.PubKey]int{}
+
+	require.Empty(t, pickIdleSessionsToReap(streams, streak, min, thresh), "first check: below streak threshold")
+	require.Equal(t, 1, streak[a])
+	require.Equal(t, 1, streak[b])
+	require.Equal(t, 0, streak[c], "busy session streak stays 0")
+
+	// Second call: idle streaks reach 2 (== thresh). 3 sessions, floor 2 →
+	// surplus 1 → exactly ONE idle session reaped (the busy one is never a
+	// candidate, and the floor is respected).
+	reap := pickIdleSessionsToReap(streams, streak, min, thresh)
+	require.Len(t, reap, 1, "reap only the surplus above MinSessions")
+	require.NotEqual(t, c, reap[0], "never reap a busy session")
+
+	// A busy session resets its streak.
+	streams2 := map[cipher.PubKey]int{a: 0, b: 5}
+	streak2 := map[cipher.PubKey]int{a: 1, b: 3}
+	pickIdleSessionsToReap(streams2, streak2, min, thresh)
+	require.Equal(t, 0, streak2[b], "streak reset when the session has streams")
+
+	// Never reap below the floor: total == min → nothing, even if all idle.
+	streams3 := map[cipher.PubKey]int{a: 0, b: 0}
+	streak3 := map[cipher.PubKey]int{a: 9, b: 9}
+	require.Empty(t, pickIdleSessionsToReap(streams3, streak3, min, thresh), "at the floor, keep all")
+
+	// Unknown stream count (-1, e.g. quic) is treated as busy → never reaped,
+	// and doesn't accrue an idle streak.
+	streams4 := map[cipher.PubKey]int{a: -1, b: -1, c: -1}
+	streak4 := map[cipher.PubKey]int{}
+	require.Empty(t, pickIdleSessionsToReap(streams4, streak4, 1, 1), "unknown counts are busy")
+	for _, v := range streak4 {
+		require.Equal(t, 0, v, "unknown/busy sessions never accrue an idle streak")
+	}
+
+	// Vanished sessions are pruned from the streak map.
+	gone := mkPK(t)
+	streak5 := map[cipher.PubKey]int{gone: 5, a: 1}
+	pickIdleSessionsToReap(map[cipher.PubKey]int{a: 0}, streak5, 1, 5)
+	_, stillThere := streak5[gone]
+	require.False(t, stillThere, "streak pruned for a session no longer present")
+}

--- a/pkg/dmsg/dmsg/session_common.go
+++ b/pkg/dmsg/dmsg/session_common.go
@@ -77,6 +77,27 @@ type SessionManager struct {
 	addr  net.Addr
 }
 
+// NumStreams reports the number of open mux streams on this session. Returns -1
+// when the count is unavailable — a quic session's native streams aren't cheaply
+// countable, and a not-yet-established manager has no mux — which the idle-session
+// reaper treats as "busy" so it never reaps a session it can't measure.
+func (sm *SessionManager) NumStreams() int {
+	sm.mutx.RLock()
+	defer sm.mutx.RUnlock()
+	switch {
+	case sm.yamux != nil:
+		return sm.yamux.NumStreams()
+	case sm.smux != nil:
+		return sm.smux.NumStreams()
+	default:
+		return -1
+	}
+}
+
+// NumStreams reports the number of open mux streams on this session (0 = idle;
+// -1 = unmeasurable, treated as busy). Used by the idle-session reaper.
+func (sc *SessionCommon) NumStreams() int { return sc.sm.NumStreams() }
+
 // GetConn returns underlying TCP `net.Conn`.
 func (sc *SessionCommon) GetConn() net.Conn {
 	return sc.netConn


### PR DESCRIPTION
First step of the "dmsg as a bootstrap-only floor" transition: stop the on-demand session accumulation that has visors connected to far more dmsg servers than their `sessions_count`.

## Problem
A dmsg client's *initial* connect stops at `MinSessions`, but the **dial path** opens on-demand rendezvous sessions to reach a peer delegated to a server the client wasn't connected to — and `pingSessionsLoop` then keeps those alive forever. With no reaper, the session count drifts up toward "all servers" over the process lifetime (observed: visors on 7 servers with `sessions_count=2`). That's real, recurring fleet bandwidth.

## Change
`reapIdleSessionsLoop` (started next to `pingSessionsLoop`/`porterReapLoop`): every 60s, close sessions that have read as **streamless** (`NumStreams()==0`) for **≥2 consecutive checks** and are **beyond `MinSessions`** — never below the floor.

- In-use sessions (open mux streams) are never reaped; the 2-check grace tolerates the brief per-ping stream and gaps between requests.
- quic sessions have no cheap stream count → `NumStreams()` returns `-1` (unknown) which is treated as **busy** (never reaped on a guess).
- Disabled entirely when `MinSessions==0` (connect-to-all / dev), where every session is intentional and `reconnectLoop` re-dials.
- A reaped session is simply re-dialed on demand if traffic to that peer resumes.

The decision is factored into a pure `pickIdleSessionsToReap` (mutates the idle-streak map) so the policy is unit-tested without real sessions (`client_reaper_test.go`). Adds `SessionManager`/`SessionCommon.NumStreams()`.

## Testing
- `pickIdleSessionsToReap` table test (floor respected, streak threshold, busy/unknown kept, streak-prune of vanished sessions).
- Full `pkg/dmsg/dmsg` suite green; `go build ./...`, vet, golangci-lint clean.
- Live fleet validation to follow (session counts settling toward `sessions_count`).