### PR TITLE
feat(dmsg): always-on server↔server relay (remove peer toggles, add caps)

### DIFF
--- a/docs/design/dmsg-bootstrap-floor.md
+++ b/docs/design/dmsg-bootstrap-floor.md
@@ -41,13 +41,23 @@ Two premises make this a *bounded* change rather than a rewrite:
 
 ### 1. Server↔server relay, always on
 
-`forwardViaPeer` / `PeerAnnounce` exist but ship opt-in
+`forwardViaPeer` / `PeerAnnounce` shipped opt-in
 (`AnnounceAsPeer` / `AcceptPeerAnnouncements` default off). A relay capability
 that fragments the network into "relays" and "non-relays" for no reason should
 just be how a dmsg server behaves — so the on/off toggles are **removed** (not
 merely defaulted on), with internal caps (max accepted peer links, max relayed
 streams, the existing loop/hop guard) so an always-open relay can't become an
 amplifier. "Implicitly enabled, bounded — not configurable off."
+
+*(Shipped.)* Every server now announces itself as a forwardable peer over
+its outbound links and honors inbound announcements unconditionally. The
+`AnnounceAsPeer` / `AcceptPeerAnnouncements` config fields are gone; the
+optional `accepted_peer_pks` allowlist remains (empty = accept any), joined by
+`max_peer_links` (`DefaultMaxPeerLinks`) and `max_relayed_streams`
+(`DefaultMaxRelayedStreams`) as the bounds. A bridge is counted against the
+relay-stream cap only when one side is a peer session — plain local
+client↔client bridging is never gated. Peer-originated frames are still refused
+re-forwarding (`ss.isPeer` 1-hop guard).
 
 ### 2. Visor as a dmsg relay (the `VStreamMux` bridge)
 

--- a/pkg/dmsg/dmsg/const.go
+++ b/pkg/dmsg/dmsg/const.go
@@ -22,6 +22,14 @@ const (
 
 	DefaultMaxSessions = 2048
 
+	// DefaultMaxPeerLinks bounds concurrent peer sessions (inbound
+	// announced + configured outbound) on an always-on relay server.
+	DefaultMaxPeerLinks = 512
+
+	// DefaultMaxRelayedStreams bounds concurrent streams a server relays
+	// on behalf of a peer, so an always-open relay can't be amplified.
+	DefaultMaxRelayedStreams = 4096
+
 	DefaultDmsgHTTPPort = uint16(80)
 
 	DefaultOfficialDmsgServerType = "official"

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -108,15 +108,22 @@ type EntityCommon struct {
 	peerSessionsFunc func() []*SessionCommon
 
 	// acceptPeerAnnouncements, peerAnnounceAllowedFunc and
-	// promoteToPeerFunc support inbound peer announcements: a non-public
-	// server (not in discovery, never dialed by anyone) announcing itself
-	// as a forwardable peer over the link it dials out. Only set on
-	// Server entities that opt in. promoteToPeerFunc files the announced
-	// inbound session in the server's peer set so the reverse path can
-	// forward client streams to it.
+	// promoteToPeerFunc support inbound peer announcements: a server
+	// announcing itself as a forwardable peer over the link it dials out.
+	// Set to true on all Server entities (peer relaying is always on).
+	// peerAnnounceAllowedFunc bounds/allowlists who may be filed;
+	// promoteToPeerFunc files the announced inbound session in the
+	// server's peer set so the reverse path can forward client streams.
 	acceptPeerAnnouncements bool
 	peerAnnounceAllowedFunc func(remotePK cipher.PubKey) bool
 	promoteToPeerFunc       func(remotePK cipher.PubKey, ses *SessionCommon)
+
+	// maxRelayedStreams bounds concurrent streams this server relays on
+	// behalf of a peer (a peer bridge, either direction); relayedStreams
+	// is the live count (accessed atomically). Local client↔client
+	// bridging on the same server is not counted. Set on Server entities.
+	maxRelayedStreams int
+	relayedStreams    int64
 
 	// lastPushedSrvPKs is the set of delegated server PKs most recently
 	// pushed to the dmsg discovery. It is used by updateClientEntry to
@@ -305,6 +312,27 @@ func (c *EntityCommon) peerAnnounceAllowed(remotePK cipher.PubKey) bool {
 		return false
 	}
 	return c.peerAnnounceAllowedFunc(remotePK)
+}
+
+// tryAcquireRelaySlot reserves capacity for one peer-relayed stream,
+// reporting false when the server is already at maxRelayedStreams. A
+// zero/unset cap means relaying is not configured (client entities) —
+// reject rather than relay unbounded. Pair every true return with a
+// releaseRelaySlot.
+func (c *EntityCommon) tryAcquireRelaySlot() bool {
+	if c.maxRelayedStreams <= 0 {
+		return false
+	}
+	if atomic.AddInt64(&c.relayedStreams, 1) > int64(c.maxRelayedStreams) {
+		atomic.AddInt64(&c.relayedStreams, -1)
+		return false
+	}
+	return true
+}
+
+// releaseRelaySlot returns a slot reserved by tryAcquireRelaySlot.
+func (c *EntityCommon) releaseRelaySlot() {
+	atomic.AddInt64(&c.relayedStreams, -1)
 }
 
 // promoteToPeer files an announced inbound session in the server's peer

--- a/pkg/dmsg/dmsg/errors.go
+++ b/pkg/dmsg/dmsg/errors.go
@@ -24,14 +24,15 @@ var (
 
 // Errors for dial request/response (3xx).
 var (
-	ErrReqInvalidSig       = registerErr(Error{code: 300, msg: "request has invalid signature"})
-	ErrReqInvalidTimestamp = registerErr(Error{code: 301, msg: "request timestamp should be higher than last"})
-	ErrReqInvalidSrcPK     = registerErr(Error{code: 302, msg: "request has invalid source public key"})
-	ErrReqInvalidDstPK     = registerErr(Error{code: 303, msg: "request has invalid destination public key"})
-	ErrReqInvalidSrcPort   = registerErr(Error{code: 304, msg: "request has invalid source port"})
-	ErrReqInvalidDstPort   = registerErr(Error{code: 305, msg: "request has invalid destination port"})
-	ErrReqNoListener       = registerErr(Error{code: 306, msg: "request has no associated listener", temp: true})
-	ErrReqNoNextSession    = registerErr(Error{code: 307, msg: "request cannot be forwarded because the next session is non-existent"})
+	ErrReqInvalidSig        = registerErr(Error{code: 300, msg: "request has invalid signature"})
+	ErrReqInvalidTimestamp  = registerErr(Error{code: 301, msg: "request timestamp should be higher than last"})
+	ErrReqInvalidSrcPK      = registerErr(Error{code: 302, msg: "request has invalid source public key"})
+	ErrReqInvalidDstPK      = registerErr(Error{code: 303, msg: "request has invalid destination public key"})
+	ErrReqInvalidSrcPort    = registerErr(Error{code: 304, msg: "request has invalid source port"})
+	ErrReqInvalidDstPort    = registerErr(Error{code: 305, msg: "request has invalid destination port"})
+	ErrReqNoListener        = registerErr(Error{code: 306, msg: "request has no associated listener", temp: true})
+	ErrReqNoNextSession     = registerErr(Error{code: 307, msg: "request cannot be forwarded because the next session is non-existent"})
+	ErrRelayCapacityReached = registerErr(Error{code: 308, msg: "server is at its peer-relay stream capacity", temp: true})
 
 	ErrDialRespInvalidSig  = registerErr(Error{code: 350, msg: "response has invalid signature"})
 	ErrDialRespInvalidHash = registerErr(Error{code: 351, msg: "response has invalid hash of associated request"})

--- a/pkg/dmsg/dmsg/relay_cap_test.go
+++ b/pkg/dmsg/dmsg/relay_cap_test.go
@@ -1,0 +1,51 @@
+package dmsg
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestRelaySlotCap covers the always-on relay's stream-capacity bound:
+// tryAcquireRelaySlot admits up to maxRelayedStreams concurrent slots and
+// refuses beyond that, releaseRelaySlot frees a slot for reuse, and an
+// unconfigured cap (client entities) refuses to relay at all.
+func TestRelaySlotCap(t *testing.T) {
+	// Unconfigured cap: never relay.
+	var client EntityCommon
+	require.False(t, client.tryAcquireRelaySlot(), "unset cap must not relay")
+
+	c := EntityCommon{maxRelayedStreams: 3}
+
+	// Fill to capacity.
+	require.True(t, c.tryAcquireRelaySlot())
+	require.True(t, c.tryAcquireRelaySlot())
+	require.True(t, c.tryAcquireRelaySlot())
+	require.False(t, c.tryAcquireRelaySlot(), "at capacity, further acquires fail")
+
+	// Releasing one slot admits exactly one more.
+	c.releaseRelaySlot()
+	require.True(t, c.tryAcquireRelaySlot(), "a freed slot is reusable")
+	require.False(t, c.tryAcquireRelaySlot(), "back at capacity")
+
+	// The live count never overshoots the cap under concurrency.
+	c2 := EntityCommon{maxRelayedStreams: 8}
+	var granted int64
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if c2.tryAcquireRelaySlot() {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int64(8), granted, "exactly cap slots granted, no overshoot")
+	require.Equal(t, int64(8), c2.relayedStreams, "live count equals granted slots")
+}

--- a/pkg/dmsg/dmsg/server.go
+++ b/pkg/dmsg/dmsg/server.go
@@ -44,26 +44,32 @@ type ServerConfig struct {
 	// pkg/dmsg decoupled from skywire's buildinfo. Empty preserves "0.0.1".
 	Version string
 
-	// AnnounceAsPeer makes this server send a signed PeerAnnounce on
-	// every outbound peer link it dials, asking the remote to treat
-	// this server as a forwardable peer. Used by a non-public server
-	// (not registered in discovery) so its clients become reachable
-	// inbound via the link it dialed out.
-	AnnounceAsPeer bool
-	// AcceptPeerAnnouncements lets this server honor inbound PeerAnnounce
-	// frames, filing the announcing session in its peer set so it
-	// forwards client streams back down that link. When AcceptedPeerPKs
-	// is non-empty it acts as an allowlist; empty means accept any
-	// announcer (an open relay surface — set deliberately).
-	AcceptPeerAnnouncements bool
-	AcceptedPeerPKs         []cipher.PubKey
+	// AcceptedPeerPKs optionally restricts which servers may announce
+	// themselves as forwardable peers over an inbound link. Empty (the
+	// default) accepts any announcer — every dmsg server is a relay
+	// surface. Peer relaying is always on and cannot be disabled; this
+	// allowlist only narrows *who* may be filed as a peer.
+	AcceptedPeerPKs []cipher.PubKey
+
+	// MaxPeerLinks bounds the number of concurrent peer sessions (inbound
+	// announced + configured outbound) so an always-open relay surface
+	// can't accumulate unbounded peer links. Zero uses DefaultMaxPeerLinks.
+	MaxPeerLinks int
+	// MaxRelayedStreams bounds the number of concurrent streams this
+	// server relays on behalf of a peer (either direction of a peer
+	// bridge), so relaying for others can't be turned into an amplifier.
+	// Zero uses DefaultMaxRelayedStreams. Local client↔client bridging on
+	// this same server is unaffected — only peer-relayed streams count.
+	MaxRelayedStreams int
 }
 
 // DefaultServerConfig returns the default server config.
 func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
-		MaxSessions:    DefaultMaxSessions,
-		UpdateInterval: DefaultUpdateInterval,
+		MaxSessions:       DefaultMaxSessions,
+		UpdateInterval:    DefaultUpdateInterval,
+		MaxPeerLinks:      DefaultMaxPeerLinks,
+		MaxRelayedStreams: DefaultMaxRelayedStreams,
 	}
 }
 
@@ -103,10 +109,12 @@ type Server struct {
 	peerSessions   map[cipher.PubKey]*SessionCommon
 	peerSessionsMx sync.Mutex
 
-	// Inbound peer-announcement support (non-public servers).
-	announceAsPeer          bool
-	acceptPeerAnnouncements bool
-	acceptedPeerPKs         map[cipher.PubKey]struct{} // allowlist; empty = accept any
+	// Inbound peer-announcement support. Peer relaying is always on; a
+	// server always announces on its outbound peer links and always
+	// honors inbound announcements, bounded by maxPeerLinks and the
+	// optional acceptedPeerPKs allowlist.
+	acceptedPeerPKs map[cipher.PubKey]struct{} // allowlist; empty = accept any
+	maxPeerLinks    int
 }
 
 // GeoLookupFunc returns geolocation data for the given IP. Returns
@@ -171,22 +179,32 @@ func NewServer(pk cipher.PubKey, sk cipher.SecKey, dc disc.APIClient, conf *Serv
 		return sessions
 	}
 
-	// Inbound peer-announcement support: a non-public server announces
-	// itself as a forwardable peer over its outbound links; an accepting
-	// server promotes the announced inbound session into peerSessions.
-	s.announceAsPeer = conf.AnnounceAsPeer
-	s.acceptPeerAnnouncements = conf.AcceptPeerAnnouncements
+	// Peer relaying is always on: a server always announces itself as a
+	// forwardable peer over its outbound links, and always promotes an
+	// accepted inbound announcement into peerSessions. Bounded by
+	// maxPeerLinks (link count) and the optional acceptedPeerPKs
+	// allowlist; there is no on/off toggle.
+	s.maxPeerLinks = conf.MaxPeerLinks
+	if s.maxPeerLinks <= 0 {
+		s.maxPeerLinks = DefaultMaxPeerLinks
+	}
 	s.acceptedPeerPKs = make(map[cipher.PubKey]struct{}, len(conf.AcceptedPeerPKs))
 	for _, pk := range conf.AcceptedPeerPKs {
 		s.acceptedPeerPKs[pk] = struct{}{}
 	}
-	s.EntityCommon.acceptPeerAnnouncements = conf.AcceptPeerAnnouncements
+	s.EntityCommon.acceptPeerAnnouncements = true
+	s.EntityCommon.maxRelayedStreams = conf.MaxRelayedStreams
+	if s.EntityCommon.maxRelayedStreams <= 0 {
+		s.EntityCommon.maxRelayedStreams = DefaultMaxRelayedStreams
+	}
 	s.EntityCommon.peerAnnounceAllowedFunc = func(remotePK cipher.PubKey) bool {
-		if !s.acceptPeerAnnouncements {
-			return false
-		}
 		s.peerSessionsMx.Lock()
 		defer s.peerSessionsMx.Unlock()
+		// Bound the number of peer links so an always-open relay surface
+		// can't accumulate unbounded inbound peers.
+		if len(s.peerSessions) >= s.maxPeerLinks {
+			return false
+		}
 		if len(s.acceptedPeerPKs) == 0 {
 			return true // empty allowlist = accept any announcer
 		}
@@ -581,15 +599,13 @@ func (s *Server) maintainPeerConnection(ctx context.Context, peer PeerEntry) {
 		bo = 5 * time.Second // reset backoff on success
 
 		// Announce ourselves as a forwardable peer over this outbound
-		// link so a non-public server (not in discovery) becomes
+		// link so we (and, for a non-public server, our clients) become
 		// reachable inbound: the remote files this session in its peer
-		// set and forwards client streams back down it.
-		if s.announceAsPeer {
-			if aErr := s.sendPeerAnnounce(ses); aErr != nil {
-				log.WithError(aErr).Warn("Failed to announce as peer.")
-			} else {
-				log.Info("Announced as forwardable peer.")
-			}
+		// set and forwards client streams back down it. Always on.
+		if aErr := s.sendPeerAnnounce(ses); aErr != nil {
+			log.WithError(aErr).Warn("Failed to announce as peer.")
+		} else {
+			log.Info("Announced as forwardable peer.")
 		}
 
 		// Serve the outbound peer session so forwarded streams arriving
@@ -637,9 +653,9 @@ func (s *Server) isPeerPK(pk cipher.PubKey) bool {
 }
 
 // sendPeerAnnounce opens a stream on the given (outbound) peer session,
-// sends a signed PeerAnnounce, and waits for the remote's ack. Used on
-// outbound peer links when AnnounceAsPeer is set, so a non-public server
-// becomes reachable inbound.
+// sends a signed PeerAnnounce, and waits for the remote's ack. Sent on
+// every outbound peer link (peer relaying is always on), so the server —
+// and a non-public server's clients — become reachable inbound.
 func (s *Server) sendPeerAnnounce(ses *SessionCommon) error {
 	ann := &PeerAnnounce{Timestamp: time.Now().UnixNano(), SrcPK: s.pk}
 	obj, err := MakeSignedPeerAnnounce(ann, s.sk)

--- a/pkg/dmsg/dmsg/server_session.go
+++ b/pkg/dmsg/dmsg/server_session.go
@@ -317,6 +317,19 @@ func (ss *ServerSession) serveStream(log logrus.FieldLogger, yStr io.ReadWriteCl
 
 // bridgeStream forwards a request to a destination session and bridges the two streams.
 func (ss *ServerSession) bridgeStream(log logrus.FieldLogger, yStr io.ReadWriteCloser, dst ServerSession, req StreamRequest) error {
+	// A bridge where either side is a peer session is a *relayed* stream —
+	// this server carrying traffic on behalf of another server. Bound the
+	// concurrent count so an always-open relay can't be amplified. A plain
+	// local client↔client bridge (neither side a peer) is normal operation
+	// and is never gated.
+	if ss.isPeer || dst.isPeer {
+		if !ss.entity.tryAcquireRelaySlot() {
+			ss.m.RecordStream(metrics.DeltaFailed)
+			return ErrRelayCapacityReached
+		}
+		defer ss.entity.releaseRelaySlot()
+	}
+
 	yStr2, resp, err := dst.forwardRequest(req)
 	if err != nil {
 		ss.m.RecordStream(metrics.DeltaFailed)

--- a/pkg/dmsg/dmsgserver/config.go
+++ b/pkg/dmsg/dmsgserver/config.go
@@ -183,16 +183,15 @@ type Config struct {
 	Peers            []PeerConfig  `json:"peers,omitempty"`
 	EnableRouteSetup bool          `json:"enable_route_setup,omitempty"`
 
-	// AnnounceAsPeer makes this (typically non-public) server announce
-	// itself as a forwardable peer over every outbound peer link it
-	// dials, so its clients become reachable inbound without it being
-	// registered in the discovery. AcceptPeerAnnouncements lets a
-	// (typically public) server honor such announcements, filing the
-	// announcing session in its peer set; AcceptedPeerPKs, when non-empty,
-	// restricts which announcers are honored (allowlist).
-	AnnounceAsPeer          bool            `json:"announce_as_peer,omitempty"`
-	AcceptPeerAnnouncements bool            `json:"accept_peer_announcements,omitempty"`
-	AcceptedPeerPKs         []cipher.PubKey `json:"accepted_peer_pks,omitempty"`
+	// Peer relaying is always on: every server announces itself as a
+	// forwardable peer over the links it dials and honors inbound
+	// announcements. AcceptedPeerPKs, when non-empty, restricts which
+	// announcers are honored (allowlist); empty accepts any. MaxPeerLinks
+	// and MaxRelayedStreams bound the relay surface (0 = built-in
+	// defaults). There is no toggle to disable relaying.
+	AcceptedPeerPKs   []cipher.PubKey `json:"accepted_peer_pks,omitempty"`
+	MaxPeerLinks      int             `json:"max_peer_links,omitempty"`
+	MaxRelayedStreams int             `json:"max_relayed_streams,omitempty"`
 }
 
 // GenerateDefaultConfig generate default config for dmsg-server

--- a/pkg/dmsg/dmsgtest/mesh_test.go
+++ b/pkg/dmsg/dmsgtest/mesh_test.go
@@ -199,14 +199,17 @@ func TestServerMesh_CrossServerDial(t *testing.T) {
 	srvWg.Wait()
 }
 
-// nonPublicReverseSetup stands up a public server S_pub (AcceptPeerAnnouncements
-// = accept) and a non-public server S_priv that dials S_pub and announces
-// itself as a forwardable peer; S_priv is NOT registered in the public
-// discovery. It then connects client A (reachable only via S_priv) and client B
-// (on S_pub), and attempts B's dial of A. The dial can only succeed via the
-// announced reverse-forward path. Returns B's dial result so callers can assert
-// both the gate-on (success) and gate-off (failure) behavior.
-func nonPublicReverseSetup(t *testing.T, ctx context.Context, accept bool) (streamB *dmsg.Stream, accA func() (*dmsg.Stream, error), cleanup func(), dialErr error) {
+// nonPublicReverseSetup stands up a public server S_pub and a non-public
+// server S_priv that dials S_pub and announces itself as a forwardable peer;
+// S_priv is NOT registered in the public discovery. Peer relaying is always
+// on, so reachability is instead governed by S_pub's AcceptedPeerPKs
+// allowlist: when allow is true the allowlist admits S_priv; when false it
+// lists a foreign PK, so S_priv's announcement is rejected. It then connects
+// client A (reachable only via S_priv) and client B (on S_pub) and attempts
+// B's dial of A — which can only succeed via the announced reverse-forward
+// path. Returns B's dial result so callers can assert both the allow (success)
+// and reject (failure) behavior.
+func nonPublicReverseSetup(t *testing.T, ctx context.Context, allow bool) (streamB *dmsg.Stream, accA func() (*dmsg.Stream, error), cleanup func(), dialErr error) {
 	t.Helper()
 
 	// Public discovery — only S_pub registers here.
@@ -217,11 +220,17 @@ func nonPublicReverseSetup(t *testing.T, ctx context.Context, accept bool) (stre
 	require.NoError(t, err)
 	pkPriv, skPriv := cipher.GenerateKeyPair()
 
+	// Peer relaying is always on; the allowlist is what gates S_priv. Admit
+	// pkPriv to allow the reverse path, or list a foreign PK to reject it.
+	allowlist := []cipher.PubKey{pkPriv}
+	if !allow {
+		foreign, _ := cipher.GenerateKeyPair()
+		allowlist = []cipher.PubKey{foreign}
+	}
 	confPub := &dmsg.ServerConfig{
-		MaxSessions:             10,
-		UpdateInterval:          dmsg.DefaultUpdateInterval,
-		AcceptPeerAnnouncements: accept,
-		AcceptedPeerPKs:         []cipher.PubKey{pkPriv},
+		MaxSessions:     10,
+		UpdateInterval:  dmsg.DefaultUpdateInterval,
+		AcceptedPeerPKs: allowlist,
 	}
 
 	lisPriv, err := nettest.NewLocalListener("tcp")
@@ -230,7 +239,6 @@ func nonPublicReverseSetup(t *testing.T, ctx context.Context, accept bool) (stre
 	confPriv := &dmsg.ServerConfig{
 		MaxSessions:    10,
 		UpdateInterval: dmsg.DefaultUpdateInterval,
-		AnnounceAsPeer: true,
 		Peers:          []dmsg.PeerEntry{{PK: pkPub, Addr: lisPub.Addr().String()}},
 	}
 
@@ -390,10 +398,10 @@ func TestNonPublicServer_ReverseDial(t *testing.T) {
 	t.Log("Non-public-server reverse-dial test passed.")
 }
 
-// TestNonPublicServer_ReverseDial_GateOff is the negative control: with
-// AcceptPeerAnnouncements disabled on the public server, the same reverse dial
-// must FAIL — proving it is the announcement gate (not the static-peer path)
-// that makes the non-public server's clients reachable inbound.
+// TestNonPublicServer_ReverseDial_GateOff is the negative control: with an
+// AcceptedPeerPKs allowlist that does NOT include S_priv, the same reverse
+// dial must FAIL — proving it is the (always-on) announcement path, gated by
+// the allowlist, that makes the non-public server's clients reachable inbound.
 func TestNonPublicServer_ReverseDial_GateOff(t *testing.T) {
 	const timeout = 40 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/services/dmsgsrv/dmsgsrv.go
+++ b/pkg/services/dmsgsrv/dmsgsrv.go
@@ -210,12 +210,12 @@ func (s *service) Run(ctx context.Context) error {
 		// (disc.Entry.Version) instead of the vestigial "0.0.1" protocol
 		// constant, so `mdisc servers` / discovery consumers see it. Empty
 		// (unknown build) preserves "0.0.1".
-		Version:                 dmsgEntryVersion(),
-		AuthPassphrase:          s.cfg.AuthPassphrase,
-		Peers:                   peers,
-		AnnounceAsPeer:          cfg.AnnounceAsPeer,
-		AcceptPeerAnnouncements: cfg.AcceptPeerAnnouncements,
-		AcceptedPeerPKs:         cfg.AcceptedPeerPKs,
+		Version:           dmsgEntryVersion(),
+		AuthPassphrase:    s.cfg.AuthPassphrase,
+		Peers:             peers,
+		AcceptedPeerPKs:   cfg.AcceptedPeerPKs,
+		MaxPeerLinks:      cfg.MaxPeerLinks,
+		MaxRelayedStreams: cfg.MaxRelayedStreams,
 	}
 
 	deployments := cfg.NormalizedDeployments()


### PR DESCRIPTION
## What

Makes dmsg **server↔server peer relaying always on**, bounded, and no longer configurable off — component 1 of the [dmsg-bootstrap-floor RFC](https://github.com/skycoin/skywire/blob/develop/docs/design/dmsg-bootstrap-floor.md).

A dmsg server already forwards between clients on *different* servers via `forwardViaPeer` / `PeerAnnounce` (no routing needed — the destination PK is the address, resolved by one map lookup + byte-splice). That capability shipped opt-in behind `AnnounceAsPeer` / `AcceptPeerAnnouncements`, both **default off**, which fragmented the fleet into "relays" and "non-relays" for no good reason. This makes it simply how a dmsg server behaves.

## Changes

- **Remove** `AnnounceAsPeer` / `AcceptPeerAnnouncements` from `dmsg.ServerConfig` and the `dmsgserver` JSON config. Every server now announces itself as a forwardable peer over its outbound links and honors inbound announcements unconditionally.
- **Keep** `accepted_peer_pks` as an optional allowlist (empty = accept any announcer). This only narrows *who* may be filed as a peer — there is no toggle to disable relaying.
- **Add bounds** so an always-open relay surface can't be turned into an amplifier:
  - `max_peer_links` (`DefaultMaxPeerLinks` = 512) — caps concurrent peer sessions (inbound announced + configured outbound).
  - `max_relayed_streams` (`DefaultMaxRelayedStreams` = 4096) — caps concurrent streams bridged **on behalf of a peer**. A bridge is counted only when one side is a peer session; plain local client↔client bridging on the same server is never gated.
  - The existing `ss.isPeer` **1-hop loop guard** (a peer-originated stream is never re-forwarded) is unchanged.
- `tryAcquireRelaySlot` / `releaseRelaySlot` on `EntityCommon` (atomic counter); `ErrRelayCapacityReached` (temp error) returned at capacity.

## Tests

- `relay_cap_test.go` — slot cap, concurrency (no overshoot past the cap), and unset-cap = never-relay (client entities).
- `mesh_test.go` reverse-dial: the non-public-server reverse path now asserts **always-on** behavior; the former "gate off" negative control is repurposed to prove the **allowlist** still rejects a non-listed announcer.
- Full `pkg/dmsg/dmsg` + `pkg/dmsg/dmsgtest` suites green; `go build .` + `golangci-lint` clean.

## Why now

Reduces continuous fan-out to public dmsg **servers**: once relaying is universal, the fleet can reach each other through any server-to-server hop, and (with the follow-on visor-relay + idle-session reaper, already merged in #3810) drift toward using dmsg servers as a bootstrap/fallback floor rather than a permanent star.