### PR TITLE
feat(transport): visor-as-relay over skynet (signed PK-addressed VStream forwarding)

### DIFF
--- a/pkg/transport/vstream.go
+++ b/pkg/transport/vstream.go
@@ -6,6 +6,23 @@
 //
 // Wire format per packet: [streamID:8][senderPK:33][flags:1][data...]
 // Flags: 0x00=data, 0x01=SYN (new stream), 0x02=FIN (close)
+//
+// A visor also acts as a dmsg-server-style RELAY over its skynet transports:
+// a SYN carrying the Relay flag names a third-party destination PK and is
+// signed by the originator. If the destination is not this visor and a direct
+// transport to it exists, the SYN is forwarded (byte-spliced) to that peer —
+// PK-addressed forwarding with no route, mirroring the dmsg server's
+// forwardViaPeer/bridgeStream. Relaying is always on and bounded (1-hop guard
+// via the Relayed flag + a concurrent-relay cap); it is not configurable off.
+// See pkg/transport/vstream_relay.go and docs/design/dmsg-bootstrap-floor.md.
+//
+// Relay SYN wire format:
+//
+//	[streamID:8][senderPK:33][flags:1][dstPK:33][originID:8][sig:65]
+//
+// where sig = sign_senderSK(originID || senderPK || dstPK). originID is the
+// originator's own stream id, preserved end-to-end (the relay remaps streamID
+// but not originID) so the signature verifies at the destination.
 package transport
 
 import (
@@ -26,9 +43,23 @@ import (
 // VStream header constants.
 const (
 	VStreamHeaderSize = 8 + 33 + 1 // streamID + senderPK + flags
-	VStreamFlagData   = 0x00
-	VStreamFlagSyn    = 0x01
-	VStreamFlagFin    = 0x02
+	// vstreamRelaySynHeaderSize is the header of a relay SYN, which appends
+	// [dstPK:33][originID:8][sig:65] after the base header.
+	vstreamRelaySynHeaderSize = VStreamHeaderSize + 33 + 8 + 65
+
+	VStreamFlagData = 0x00
+	VStreamFlagSyn  = 0x01
+	VStreamFlagFin  = 0x02
+	// VStreamFlagRelay marks a SYN destined for a third-party PK carried in
+	// the extended relay header; the relay forwards it PK-addressed.
+	VStreamFlagRelay = 0x04
+	// VStreamFlagRelayed is set by a relay on the leg it emits, so the next
+	// hop refuses to forward again (1-hop guard, mirrors dmsg's ss.isPeer).
+	VStreamFlagRelayed = 0x08
+
+	// DefaultMaxRelayedVStreams bounds concurrent relayed streams a visor
+	// carries on behalf of others, so an always-on relay can't be amplified.
+	DefaultMaxRelayedVStreams = 4096
 )
 
 // VStreamMux multiplexes virtual streams over route ID 0 packets.
@@ -42,6 +73,16 @@ type VStreamMux struct {
 	streams   map[uint64]*VStream
 	streamsMu sync.Mutex
 	streamID  uint64
+
+	// relays holds active relay legs keyed by (inbound transport, wire
+	// streamID). Each direction of a bridged stream is registered pointing
+	// at its peer leg, so a DATA/FIN frame arriving on either transport is
+	// spliced to the other. relayCount is the live count (atomic), bounded
+	// by maxRelays.
+	relays     map[relayKey]relayKey
+	relaysMu   sync.Mutex
+	relayCount int64
+	maxRelays  int
 
 	incoming chan *VStream
 	done     chan struct{}
@@ -62,6 +103,8 @@ func NewVStreamMux(tm *Manager, packetType routing.PacketType, log *logging.Logg
 		tm:         tm,
 		packetType: packetType,
 		streams:    make(map[uint64]*VStream),
+		relays:     make(map[relayKey]relayKey),
+		maxRelays:  DefaultMaxRelayedVStreams,
 		incoming:   make(chan *VStream, 32),
 		done:       make(chan struct{}),
 	}
@@ -217,8 +260,29 @@ func (m *VStreamMux) HandlePacket(p routing.Packet, mt *ManagedTransport) {
 	flags := payload[41]
 	data := payload[VStreamHeaderSize:]
 
-	switch flags {
-	case VStreamFlagSyn:
+	// Established relay leg? Splice DATA/FIN straight through to the paired
+	// leg on the other transport. Checked before local handling; a relayed
+	// stream is never a local endpoint on this node.
+	inKey := relayKey{tp: mt.Entry.ID, streamID: streamID}
+	if peer, ok := m.lookupRelayLeg(inKey); ok {
+		if flags&VStreamFlagFin != 0 {
+			m.forwardRelayFrame(peer, VStreamFlagFin, nil)
+			m.teardownRelayLeg(inKey, peer)
+			return
+		}
+		m.forwardRelayFrame(peer, VStreamFlagData, data)
+		return
+	}
+
+	// Relay SYN: a new stream addressed to a third-party PK. Verify, then
+	// either terminate locally (we are the destination) or forward.
+	if flags&VStreamFlagSyn != 0 && flags&VStreamFlagRelay != 0 {
+		m.handleRelaySyn(mt, streamID, remotePK, flags, payload)
+		return
+	}
+
+	switch {
+	case flags&VStreamFlagSyn != 0:
 		stream := &VStream{
 			id:       streamID,
 			remotePK: remotePK,
@@ -238,7 +302,18 @@ func (m *VStreamMux) HandlePacket(p routing.Packet, mt *ManagedTransport) {
 			stream.Close() //nolint:errcheck,gosec
 		}
 
-	case VStreamFlagData:
+	case flags&VStreamFlagFin != 0:
+		m.streamsMu.Lock()
+		stream, ok := m.streams[streamID]
+		if ok {
+			delete(m.streams, streamID)
+		}
+		m.streamsMu.Unlock()
+		if ok {
+			stream.Close() //nolint:errcheck,gosec
+		}
+
+	default: // DATA
 		m.streamsMu.Lock()
 		stream, ok := m.streams[streamID]
 		m.streamsMu.Unlock()
@@ -252,17 +327,6 @@ func (m *VStreamMux) HandlePacket(p routing.Packet, mt *ManagedTransport) {
 		case <-stream.closed:
 		default:
 			m.log.Warn("vstream: read buffer full, dropping data")
-		}
-
-	case VStreamFlagFin:
-		m.streamsMu.Lock()
-		stream, ok := m.streams[streamID]
-		if ok {
-			delete(m.streams, streamID)
-		}
-		m.streamsMu.Unlock()
-		if ok {
-			stream.Close() //nolint:errcheck,gosec
 		}
 	}
 }

--- a/pkg/transport/vstream_relay.go
+++ b/pkg/transport/vstream_relay.go
@@ -1,0 +1,247 @@
+// Package transport pkg/transport/vstream_relay.go c2-net-transport
+//
+// Visor-as-relay for VStreamMux: a visor forwards a signed, PK-addressed
+// SYN to a third party it has a direct (non-dmsg) transport to, then
+// byte-splices the two legs — the skynet analog of the dmsg server's
+// forwardViaPeer/bridgeStream. Always on, bounded, not configurable off.
+package transport
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// relayKey identifies one leg of a bridged stream: the wire streamID on a
+// specific transport. Both directions are registered in VStreamMux.relays,
+// each pointing at its peer leg.
+type relayKey struct {
+	tp       uuid.UUID
+	streamID uint64
+}
+
+func (m *VStreamMux) lookupRelayLeg(k relayKey) (relayKey, bool) {
+	m.relaysMu.Lock()
+	peer, ok := m.relays[k]
+	m.relaysMu.Unlock()
+	return peer, ok
+}
+
+func (m *VStreamMux) registerRelayLeg(in, out relayKey) {
+	m.relaysMu.Lock()
+	m.relays[in] = out
+	m.relays[out] = in
+	m.relaysMu.Unlock()
+	atomic.AddInt64(&m.relayCount, 1)
+}
+
+// teardownRelayLeg removes both directions of a bridged stream and drops the
+// live-relay count once. Safe to call from either leg's FIN.
+func (m *VStreamMux) teardownRelayLeg(a, b relayKey) {
+	m.relaysMu.Lock()
+	_, ok := m.relays[a]
+	if ok {
+		delete(m.relays, a)
+		delete(m.relays, b)
+	}
+	m.relaysMu.Unlock()
+	if ok {
+		atomic.AddInt64(&m.relayCount, -1)
+	}
+}
+
+// forwardRelayFrame emits a base-format DATA/FIN frame to the peer leg. The
+// senderPK field is set to this relay's local PK (it is ignored by the
+// receiver for DATA/FIN, which key on streamID alone).
+func (m *VStreamMux) forwardRelayFrame(peer relayKey, flags byte, data []byte) {
+	tp, err := m.tm.GetTransportByID(peer.tp)
+	if err != nil {
+		m.log.WithError(err).Debug("vstream relay: peer transport gone; dropping frame")
+		return
+	}
+	localPK := m.localPK()
+	payload := make([]byte, VStreamHeaderSize+len(data))
+	binary.BigEndian.PutUint64(payload[:8], peer.streamID)
+	copy(payload[8:41], localPK[:])
+	payload[41] = flags
+	copy(payload[VStreamHeaderSize:], data)
+	if err := m.writePayload(tp, payload); err != nil {
+		m.log.WithError(err).Debug("vstream relay: forward frame failed")
+	}
+}
+
+// handleRelaySyn processes an inbound SYN carrying the Relay flag: it verifies
+// the originator's signature, then either terminates locally (this visor is
+// the destination) or forwards to a directly-connected destination peer.
+func (m *VStreamMux) handleRelaySyn(mt *ManagedTransport, wireID uint64, senderPK cipher.PubKey, flags byte, payload []byte) {
+	if len(payload) < vstreamRelaySynHeaderSize {
+		m.log.Warn("vstream relay: short relay SYN; dropping")
+		return
+	}
+	var dstPK cipher.PubKey
+	copy(dstPK[:], payload[42:75])
+	originID := binary.BigEndian.Uint64(payload[75:83])
+	var sig cipher.Sig
+	copy(sig[:], payload[83:vstreamRelaySynHeaderSize])
+
+	// The originator (senderPK) must have signed (originID||senderPK||dstPK),
+	// so a relay can't be tricked into forwarding a spoofed source and the
+	// destination can attribute the stream to the real origin.
+	if err := cipher.VerifyPubKeySignedPayload(senderPK, sig, relaySigPayload(originID, senderPK, dstPK)); err != nil {
+		m.log.WithError(err).Warn("vstream relay: bad SYN signature; dropping")
+		return
+	}
+
+	// Destination is this visor — terminate locally, attributing the stream
+	// to the true origin (senderPK), not the relay we received it from.
+	if dstPK == m.localPK() {
+		stream := &VStream{
+			id:       wireID,
+			remotePK: senderPK,
+			tpID:     mt.Entry.ID,
+			readBuf:  make(chan []byte, 64),
+			closed:   make(chan struct{}),
+			mux:      m,
+		}
+		m.streamsMu.Lock()
+		m.streams[wireID] = stream
+		m.streamsMu.Unlock()
+		select {
+		case m.incoming <- stream:
+		default:
+			m.log.Warn("vstream relay: incoming (relayed) stream dropped (buffer full)")
+			stream.Close() //nolint:errcheck,gosec
+		}
+		return
+	}
+
+	// 1-hop guard: never re-forward an already-relayed SYN (mirrors dmsg's
+	// ss.isPeer). Combined with "forward only to a directly-connected dst",
+	// this bounds a relayed stream to a single relay hop.
+	if flags&VStreamFlagRelayed != 0 {
+		m.log.Warn("vstream relay: refusing to re-forward already-relayed SYN (1-hop)")
+		return
+	}
+	if atomic.LoadInt64(&m.relayCount) >= int64(m.maxRelays) {
+		m.log.Warn("vstream relay: at relay-stream capacity; dropping")
+		return
+	}
+	outTp := m.findDirectTransport(dstPK)
+	if outTp == nil {
+		m.log.WithField("dst", dstPK.String()).Debug("vstream relay: no direct transport to dst; dropping")
+		return
+	}
+
+	outID := m.nextID()
+	inKey := relayKey{tp: mt.Entry.ID, streamID: wireID}
+	outKey := relayKey{tp: outTp.Entry.ID, streamID: outID}
+	m.registerRelayLeg(inKey, outKey)
+
+	// Forward the SYN with the origin's PK + signature preserved and the
+	// Relayed flag set; streamID is remapped to a fresh local id (outID) so
+	// ids from different inbound transports can't collide on the outbound.
+	if err := m.sendRelaySyn(outTp, outID, senderPK, dstPK, originID, sig, true); err != nil {
+		m.log.WithError(err).Warn("vstream relay: forward SYN failed")
+		m.teardownRelayLeg(inKey, outKey)
+		return
+	}
+	m.log.WithField("origin", senderPK.String()).
+		WithField("dst", dstPK.String()).
+		Debug("vstream relay: bridging stream")
+}
+
+// DialThroughRelay opens a virtual stream to dstPK via a relay visor
+// (relayPK) that this node has a direct transport to. The SYN is signed so
+// the relay and the destination can verify the origin. Reads/writes on the
+// returned stream are spliced through the relay to dstPK.
+func (m *VStreamMux) DialThroughRelay(relayPK, dstPK cipher.PubKey, appName string) (*VStream, error) {
+	relayTp := m.findDirectTransport(relayPK)
+	if relayTp == nil {
+		return nil, fmt.Errorf("vstream: no non-DMSG transport to relay %s", relayPK.String())
+	}
+	if hook := m.loadDirectDialHook(); hook != nil {
+		if err := hook(relayPK, string(relayTp.Type()), appName); err != nil {
+			return nil, err
+		}
+	}
+
+	id := m.nextID()
+	sig, err := cipher.SignPayload(relaySigPayload(id, m.localPK(), dstPK), m.tm.Conf.SecKey)
+	if err != nil {
+		return nil, fmt.Errorf("vstream: sign relay SYN: %w", err)
+	}
+
+	stream := &VStream{
+		id:       id,
+		remotePK: dstPK,
+		tpID:     relayTp.Entry.ID,
+		readBuf:  make(chan []byte, 64),
+		closed:   make(chan struct{}),
+		mux:      m,
+	}
+	m.streamsMu.Lock()
+	m.streams[id] = stream
+	m.streamsMu.Unlock()
+
+	// originID == id: the origin's own stream id, preserved end-to-end so the
+	// destination verifies the signature after the relay remaps streamID.
+	if err := m.sendRelaySyn(relayTp, id, m.localPK(), dstPK, id, sig, false); err != nil {
+		stream.Close() //nolint:errcheck,gosec
+		return nil, fmt.Errorf("vstream: send relay SYN: %w", err)
+	}
+	return stream, nil
+}
+
+// sendRelaySyn writes an extended relay SYN on the given transport.
+func (m *VStreamMux) sendRelaySyn(tp *ManagedTransport, wireID uint64, senderPK, dstPK cipher.PubKey, originID uint64, sig cipher.Sig, relayed bool) error {
+	flags := byte(VStreamFlagSyn | VStreamFlagRelay)
+	if relayed {
+		flags |= VStreamFlagRelayed
+	}
+	payload := make([]byte, vstreamRelaySynHeaderSize)
+	binary.BigEndian.PutUint64(payload[:8], wireID)
+	copy(payload[8:41], senderPK[:])
+	payload[41] = flags
+	copy(payload[42:75], dstPK[:])
+	binary.BigEndian.PutUint64(payload[75:83], originID)
+	copy(payload[83:vstreamRelaySynHeaderSize], sig[:])
+	return m.writePayload(tp, payload)
+}
+
+// writePayload frames payload as a route-ID-0 packet of this mux's type and
+// writes it on tp.
+func (m *VStreamMux) writePayload(tp *ManagedTransport, payload []byte) error {
+	pkt := make(routing.Packet, routing.PacketHeaderSize+len(payload))
+	pkt[routing.PacketTypeOffset] = byte(m.packetType)
+	binary.BigEndian.PutUint16(pkt[routing.PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec
+	copy(pkt[routing.PacketPayloadOffset:], payload)
+	return tp.WriteRawPacket(pkt)
+}
+
+// findDirectTransport returns a live non-dmsg transport to pk, or nil.
+func (m *VStreamMux) findDirectTransport(pk cipher.PubKey) *ManagedTransport {
+	var target *ManagedTransport
+	m.tm.WalkTransports(func(tp *ManagedTransport) bool {
+		if tp.Remote() == pk && !tp.IsClosed() && tp.Type() != "dmsg" {
+			target = tp
+			return false
+		}
+		return true
+	})
+	return target
+}
+
+// relaySigPayload builds the signed message for a relay SYN:
+// originID || senderPK || dstPK.
+func relaySigPayload(originID uint64, sender, dst cipher.PubKey) []byte {
+	buf := make([]byte, 8+33+33)
+	binary.BigEndian.PutUint64(buf[:8], originID)
+	copy(buf[8:41], sender[:])
+	copy(buf[41:74], dst[:])
+	return buf
+}

--- a/pkg/transport/vstream_relay_test.go
+++ b/pkg/transport/vstream_relay_test.go
@@ -1,0 +1,194 @@
+package transport
+
+import (
+	"encoding/binary"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/routing"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// parsedVStream holds the decoded fields of a VStream frame written to a
+// memTransport (mem.written is exactly the routing.Packet bytes).
+type parsedVStream struct {
+	streamID uint64
+	senderPK cipher.PubKey
+	flags    byte
+	dstPK    cipher.PubKey
+	originID uint64
+	sig      cipher.Sig
+	data     []byte
+}
+
+func parseVStream(t *testing.T, written []byte) parsedVStream {
+	t.Helper()
+	require.NotEmpty(t, written, "expected a written packet")
+	payload := routing.Packet(written).Payload()
+	require.GreaterOrEqual(t, len(payload), VStreamHeaderSize)
+	var p parsedVStream
+	p.streamID = binary.BigEndian.Uint64(payload[:8])
+	copy(p.senderPK[:], payload[8:41])
+	p.flags = payload[41]
+	if p.flags&VStreamFlagSyn != 0 && p.flags&VStreamFlagRelay != 0 {
+		require.GreaterOrEqual(t, len(payload), vstreamRelaySynHeaderSize)
+		copy(p.dstPK[:], payload[42:75])
+		p.originID = binary.BigEndian.Uint64(payload[75:83])
+		copy(p.sig[:], payload[83:vstreamRelaySynHeaderSize])
+		p.data = payload[vstreamRelaySynHeaderSize:]
+	} else {
+		p.data = payload[VStreamHeaderSize:]
+	}
+	return p
+}
+
+// buildRelaySyn builds a signed relay-SYN packet as an originator would.
+func buildRelaySyn(t *testing.T, streamID uint64, senderPK cipher.PubKey, senderSK cipher.SecKey, dstPK cipher.PubKey, originID uint64, relayed bool) routing.Packet {
+	t.Helper()
+	sig, err := cipher.SignPayload(relaySigPayload(originID, senderPK, dstPK), senderSK)
+	require.NoError(t, err)
+	return buildRelaySynWithSig(streamID, senderPK, dstPK, originID, sig, relayed)
+}
+
+func buildRelaySynWithSig(streamID uint64, senderPK, dstPK cipher.PubKey, originID uint64, sig cipher.Sig, relayed bool) routing.Packet {
+	flags := byte(VStreamFlagSyn | VStreamFlagRelay)
+	if relayed {
+		flags |= VStreamFlagRelayed
+	}
+	payload := make([]byte, vstreamRelaySynHeaderSize)
+	binary.BigEndian.PutUint64(payload[:8], streamID)
+	copy(payload[8:41], senderPK[:])
+	payload[41] = flags
+	copy(payload[42:75], dstPK[:])
+	binary.BigEndian.PutUint64(payload[75:83], originID)
+	copy(payload[83:vstreamRelaySynHeaderSize], sig[:])
+
+	pkt := make(routing.Packet, routing.PacketHeaderSize+len(payload))
+	pkt[routing.PacketTypeOffset] = byte(routing.SkynetForwardPacket)
+	binary.BigEndian.PutUint16(pkt[routing.PacketPayloadSizeOffset:], uint16(len(payload))) //nolint:gosec
+	copy(pkt[routing.PacketPayloadOffset:], payload)
+	return pkt
+}
+
+// TestVStreamRelayForward covers the relay's forward path: a signed relay SYN
+// from A destined for B is bridged to B (origin PK + signature preserved,
+// Relayed flag set, streamID remapped), DATA is spliced in both directions
+// with correct id remapping, and FIN tears the leg down.
+func TestVStreamRelayForward(t *testing.T) {
+	tmR := newTestManager(t)
+	apk, ask := cipher.GenerateKeyPair()
+	bpk := mustPK(t)
+
+	mtRA, memRA := servingTransport(t, tmR, apk, types.STCPR) // R <-> A
+	mtRB, memRB := servingTransport(t, tmR, bpk, types.SUDPH) // R <-> B (mixed transport type)
+	muxR := NewVStreamMux(tmR, routing.SkynetForwardPacket, logging.MustGetLogger("relay-test"))
+
+	const inID = uint64(100)
+	syn := buildRelaySyn(t, inID, apk, ask, bpk, inID, false)
+	memRB.written = nil
+	muxR.HandlePacket(syn, mtRA)
+
+	fwd := parseVStream(t, memRB.written)
+	require.NotZero(t, fwd.flags&VStreamFlagSyn, "forwarded frame is a SYN")
+	require.NotZero(t, fwd.flags&VStreamFlagRelay, "forwarded frame keeps Relay flag")
+	require.NotZero(t, fwd.flags&VStreamFlagRelayed, "forwarded leg marked Relayed (1-hop)")
+	require.Equal(t, apk, fwd.senderPK, "origin PK preserved end-to-end")
+	require.Equal(t, bpk, fwd.dstPK)
+	require.Equal(t, inID, fwd.originID, "originID preserved so sig still verifies")
+	require.NoError(t, cipher.VerifyPubKeySignedPayload(apk, fwd.sig, relaySigPayload(fwd.originID, apk, bpk)),
+		"forwarded signature must still verify under the origin PK")
+	outID := fwd.streamID
+	require.NotEqual(t, inID, outID, "streamID must be remapped on the outbound leg")
+	require.Equal(t, int64(1), atomic.LoadInt64(&muxR.relayCount))
+
+	// DATA A->B: forwarded on the outbound id.
+	memRB.written = nil
+	muxR.HandlePacket(buildVStreamPacket(routing.SkynetForwardPacket, inID, apk, VStreamFlagData, []byte("ping")), mtRA)
+	d := parseVStream(t, memRB.written)
+	require.Equal(t, outID, d.streamID)
+	require.Equal(t, "ping", string(d.data))
+
+	// DATA B->A (reverse): arrives on outID from B's transport, forwarded back
+	// on the original inbound id.
+	memRA.written = nil
+	muxR.HandlePacket(buildVStreamPacket(routing.SkynetForwardPacket, outID, bpk, VStreamFlagData, []byte("pong")), mtRB)
+	r := parseVStream(t, memRA.written)
+	require.Equal(t, inID, r.streamID)
+	require.Equal(t, "pong", string(r.data))
+
+	// FIN A->B tears the leg down.
+	muxR.HandlePacket(buildVStreamPacket(routing.SkynetForwardPacket, inID, apk, VStreamFlagFin, nil), mtRA)
+	require.Equal(t, int64(0), atomic.LoadInt64(&muxR.relayCount), "relay count drops to 0 on FIN")
+}
+
+// TestVStreamRelayRejects covers the relay's refusal paths.
+func TestVStreamRelayRejects(t *testing.T) {
+	tmR := newTestManager(t)
+	apk, ask := cipher.GenerateKeyPair()
+	bpk := mustPK(t)
+	mtRA, _ := servingTransport(t, tmR, apk, types.STCPR)
+	_, memRB := servingTransport(t, tmR, bpk, types.SUDPH)
+	muxR := NewVStreamMux(tmR, routing.SkynetForwardPacket, logging.MustGetLogger("relay-test"))
+
+	// Bad signature (signed by a different key than the claimed sender).
+	_, otherSK := cipher.GenerateKeyPair()
+	badSig, err := cipher.SignPayload(relaySigPayload(1, apk, bpk), otherSK)
+	require.NoError(t, err)
+	memRB.written = nil
+	muxR.HandlePacket(buildRelaySynWithSig(1, apk, bpk, 1, badSig, false), mtRA)
+	require.Empty(t, memRB.written, "relay must not forward a bad-signature SYN")
+	require.Equal(t, int64(0), atomic.LoadInt64(&muxR.relayCount))
+
+	// Already-relayed SYN (1-hop guard).
+	memRB.written = nil
+	muxR.HandlePacket(buildRelaySyn(t, 2, apk, ask, bpk, 2, true), mtRA)
+	require.Empty(t, memRB.written, "relay must not re-forward an already-relayed SYN")
+	require.Equal(t, int64(0), atomic.LoadInt64(&muxR.relayCount))
+
+	// No transport to the destination.
+	noTpDst := mustPK(t)
+	muxR.HandlePacket(buildRelaySyn(t, 3, apk, ask, noTpDst, 3, false), mtRA)
+	require.Equal(t, int64(0), atomic.LoadInt64(&muxR.relayCount), "no dst transport → no relay leg")
+}
+
+// TestVStreamRelayTerminatesLocally covers a relay SYN whose destination is
+// this visor: it terminates locally, attributed to the true origin.
+func TestVStreamRelayTerminatesLocally(t *testing.T) {
+	tmR := newTestManager(t)
+	apk, ask := cipher.GenerateKeyPair()
+	mtRA, _ := servingTransport(t, tmR, apk, types.STCPR)
+	muxR := NewVStreamMux(tmR, routing.SkynetForwardPacket, logging.MustGetLogger("relay-test"))
+
+	dst := tmR.Conf.PubKey // destination is this visor
+	muxR.HandlePacket(buildRelaySyn(t, 5, apk, ask, dst, 5, false), mtRA)
+
+	s, err := muxR.Accept()
+	require.NoError(t, err)
+	require.Equal(t, apk, s.RemotePK(), "locally-terminated relayed stream is attributed to the origin")
+	require.Equal(t, int64(0), atomic.LoadInt64(&muxR.relayCount), "local termination is not a relay leg")
+}
+
+// TestVStreamDialThroughRelay covers the originator side: it emits a valid
+// signed relay SYN (Relay set, Relayed unset) over the relay transport.
+func TestVStreamDialThroughRelay(t *testing.T) {
+	tmA := newTestManager(t)
+	rpk := mustPK(t)
+	_, memAR := servingTransport(t, tmA, rpk, types.STCPR)
+	muxA := NewVStreamMux(tmA, routing.SkynetForwardPacket, logging.MustGetLogger("relay-test"))
+	bpk := mustPK(t)
+
+	s, err := muxA.DialThroughRelay(rpk, bpk, "app")
+	require.NoError(t, err)
+	require.Equal(t, bpk, s.RemotePK())
+
+	syn := parseVStream(t, memAR.written)
+	require.NotZero(t, syn.flags&VStreamFlagRelay)
+	require.Zero(t, syn.flags&VStreamFlagRelayed, "originator's SYN is not yet relayed")
+	require.Equal(t, tmA.Conf.PubKey, syn.senderPK)
+	require.Equal(t, bpk, syn.dstPK)
+	require.NoError(t, cipher.VerifyPubKeySignedPayload(tmA.Conf.PubKey, syn.sig, relaySigPayload(syn.originID, tmA.Conf.PubKey, bpk)))
+}


### PR DESCRIPTION
Component 2 of the [dmsg-bootstrap-floor RFC](https://github.com/skycoin/skywire/blob/develop/docs/design/dmsg-bootstrap-floor.md) — the "real prize": generalize the dmsg server's `forwardViaPeer`/`bridgeStream` to **any visor**, carried over its **skynet transports**. A visor now forwards a stream to a third party it has a direct (non-dmsg) transport to, **PK-addressed with no route**. Always on and bounded — **not configurable off** (same policy as the server↔server relay in #3812).

## The five gaps closed (in `pkg/transport/vstream.go` + new `vstream_relay.go`)

1. **Forward branch** — `HandlePacket` bridges a relayed SYN to the destination transport and byte-splices DATA/FIN both ways, keyed by `(transport, streamID)`.
2. **Destination PK in the frame** — a new **Relay SYN** appends `[dstPK:33][originID:8][sig:65]` after the base header. Non-relay frames are unchanged on the wire (**backward compatible**).
3. **Peer discovery** — `WalkTransports` finds a live non-dmsg transport to the destination.
4. **Loop guard** — the `Relayed` flag + "forward only to a directly-connected dst" bound a relayed stream to a **single relay hop** (mirrors dmsg's `ss.isPeer`).
5. **Stream-id remap** — the relay allocates a fresh outbound id per leg + a translation table, so ids from different inbound transports can't collide.

## Security (per the "sign the SYN" decision)

The SYN is **signed by the originator**: `sig` over `originID || senderPK || dstPK`.
- The **relay verifies before forwarding** — no open, spoofable amplifier.
- The **destination attributes** the stream to the true origin (not the relay).
- `originID` is **preserved end-to-end**, so the signature still verifies after the relay remaps `streamID`.
- Concurrent relayed streams are **capped** (`DefaultMaxRelayedVStreams` = 4096); the existing 1-hop guard prevents chains.

`DialThroughRelay(relayPK, dstPK, appName)` is the originator entry point.

## Tests — `vstream_relay_test.go` (uses the existing `servingTransport`/`memTransport` harness)

- **Forward**: origin PK + signature preserved, `Relayed` set, `streamID` remapped; DATA spliced both directions with correct id remap; FIN tears the leg down (relay count → 0).
- **Rejects**: bad signature, already-relayed (1-hop), no transport to dst — none forwarded, no leg created.
- **Local termination**: a relay SYN addressed to this visor terminates locally, attributed to the origin.
- **Originator**: `DialThroughRelay` emits a valid signed SYN (Relay set, Relayed unset).

Full `pkg/transport` suite green; `go build .` + `golangci-lint` clean.

## Not in this PR

Wiring an app/consumer to *use* `DialThroughRelay` for reaching deployment services, and live-fleet validation, are follow-ups — this lands the relay primitive itself, tested in isolation.