### PR TITLE
feat(tools): browser-inspection dev tooling — cdpeval, wfdrive, hvinspect hard-reload

### DIFF
--- a/cmd/cdpeval/main.go
+++ b/cmd/cdpeval/main.go
@@ -1,0 +1,56 @@
+// Command cdpeval is a throwaway debug helper: evaluate JS on a SPECIFIC CDP
+// target (by its webSocketDebuggerUrl), so we can inspect OOPIF iframes / workers
+// that hvinspect's URL-matching can't disambiguate. Usage:
+//
+//	cdpeval <webSocketDebuggerUrl> '<js-expression>'
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: cdpeval <wsUrl> <expr>")
+		os.Exit(2)
+	}
+	ws, expr := os.Args[1], os.Args[2]
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, ws, nil)
+	if err != nil {
+		fmt.Println("ERR dial:", err)
+		return
+	}
+	c.SetReadLimit(64 << 20)
+	send := func(id int, method string, params map[string]interface{}) {
+		b, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": params}) //nolint:errcheck
+		_ = c.Write(ctx, websocket.MessageText, b)                                                 //nolint:errcheck
+	}
+	send(1, "Runtime.enable", map[string]interface{}{})
+	send(2, "Runtime.evaluate", map[string]interface{}{
+		"expression": expr, "awaitPromise": true, "returnByValue": true,
+	})
+	for {
+		_, data, err := c.Read(ctx)
+		if err != nil {
+			fmt.Println("ERR read:", err)
+			return
+		}
+		var m map[string]interface{}
+		if json.Unmarshal(data, &m) != nil {
+			continue
+		}
+		if id, ok := m["id"].(float64); ok && int(id) == 2 {
+			b, _ := json.Marshal(m["result"]) //nolint:errcheck
+			fmt.Println(string(b))
+			return
+		}
+	}
+}

--- a/cmd/hvinspect/main.go
+++ b/cmd/hvinspect/main.go
@@ -27,7 +27,10 @@ import (
 
 	cdplog "github.com/chromedp/cdproto/log"
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
+	cdpsecurity "github.com/chromedp/cdproto/security"
+	"github.com/chromedp/cdproto/storage"
 	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
 )
@@ -209,6 +212,10 @@ func main() {
 	evalExpr := os.Getenv("HVINSPECT_EVAL") // optional in-page JS probe (await-able)
 	var evalResult string
 	actions := []chromedp.Action{
+		// Bypass cert errors in ATTACH mode too (the launch path has the
+		// --ignore-certificate-errors flag, but an already-running Brave doesn't):
+		// lets us drive self-signed local origins like https://<pk>.mesh.localhost.
+		cdpsecurity.SetIgnoreCertificateErrors(true),
 		network.Enable(),
 		runtime.Enable(),
 		cdplog.Enable(),
@@ -217,11 +224,30 @@ func main() {
 		// Headless, or attach-with-no-matching-tab: load the URL (headless tab, or
 		// the fresh visor tab we opened in the user's browser).
 		actions = append(actions, chromedp.Navigate(url))
-	} else if os.Getenv("HVINSPECT_RELOAD") != "" {
+	} else if rl := os.Getenv("HVINSPECT_RELOAD"); rl != "" {
 		// Reload the ATTACHED tab (by id, so it stays on the same tab across the
 		// reload — unlike re-matching by URL, which drifts while the page is
 		// momentarily about:blank). Used to pick up new browse.js after a rebuild.
-		actions = append(actions, chromedp.Reload())
+		if rl == "hard" {
+			// Empty-cache-and-hard-reload equivalent: drop the HTTP cache and any
+			// service-worker / CacheStorage for the origin, then reload ignoring
+			// cache — so a rebuilt wasm blob is fetched fresh even while its old
+			// max-age entry is still nominally "fresh" in the HTTP cache.
+			origin := url
+			if i := strings.Index(url, "://"); i >= 0 {
+				if j := strings.IndexAny(url[i+3:], "/#?"); j >= 0 {
+					origin = url[:i+3+j]
+				}
+			}
+			actions = append(actions,
+				network.ClearBrowserCache(),
+				network.SetCacheDisabled(true),
+				storage.ClearDataForOrigin(origin, "service_workers,cache_storage"),
+				page.Reload().WithIgnoreCache(true),
+			)
+		} else {
+			actions = append(actions, chromedp.Reload())
+		}
 	}
 	actions = append(actions, chromedp.Sleep(wait))
 	if evalExpr != "" {

--- a/cmd/wfdrive/main.go
+++ b/cmd/wfdrive/main.go
@@ -1,0 +1,270 @@
+// Package main cmd/wfdrive/main.go c4-vis-cli
+// wfdrive — inspector/driver for Waterfox/Firefox, the BiDi analog of
+// cmd/hvinspect (which drives Brave/Chromium over CDP). Waterfox 6.6 (Firefox
+// ESR 128+) dropped the CDP Remote Agent but still speaks WebDriver BiDi, so this
+// drives it over the BiDi websocket instead — using the main module's already-
+// vendored github.com/coder/websocket (no new dependency, so unlike hvinspect it
+// lives in the main module rather than its own).
+//
+// Firefox BiDi permits ONE active session and does NOT release it when the owning
+// socket drops, so one-shot invocations churn into "Maximum number of active
+// sessions". wfdrive therefore runs as a PERSISTENT driver (like geckodriver):
+// one long-lived session + tab, driven over a tiny local HTTP control port.
+//
+// Attach to a Waterfox started with:
+//
+//	waterfox --remote-debugging-port=9223 --remote-allow-origins=*
+//
+// Serve mode (persistent — run in the background, then curl it):
+//
+//	wfdrive serve 9223 127.0.0.1:9224
+//	curl 'http://127.0.0.1:9224/nav?url=https://magnetosphere.net/&wait=10&out=/tmp/mag'
+//	curl 'http://127.0.0.1:9224/nav?url=...&eval=<js>&out=/tmp/x'
+//	curl  http://127.0.0.1:9224/quit          # session.end + exit
+//
+// /nav writes <out>.png + <out>.console.txt and returns JSON. Testing through
+// Waterfox exercises the REAL client path (dmsg/skynet through the host visor's
+// resolving SOCKS5 proxy), unlike the in-UI iframe browser.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+type bidiMsg struct {
+	ID     int             `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Params json.RawMessage `json:"params,omitempty"`
+	Error  string          `json:"error,omitempty"`
+	Msg    string          `json:"message,omitempty"`
+}
+
+type driver struct {
+	c       *websocket.Conn
+	ctx     context.Context
+	mu      sync.Mutex
+	nextID  int
+	waiters map[int]chan bidiMsg
+	console []string
+}
+
+func (d *driver) pump() {
+	for {
+		_, data, err := d.c.Read(d.ctx)
+		if err != nil {
+			return
+		}
+		var m bidiMsg
+		if json.Unmarshal(data, &m) != nil {
+			continue
+		}
+		if m.ID != 0 {
+			d.mu.Lock()
+			ch := d.waiters[m.ID]
+			delete(d.waiters, m.ID)
+			d.mu.Unlock()
+			if ch != nil {
+				ch <- m
+			}
+			continue
+		}
+		if m.Method == "log.entryAdded" {
+			var p struct{ Level, Text string }
+			_ = json.Unmarshal(m.Params, &p) //nolint:errcheck
+			d.mu.Lock()
+			d.console = append(d.console, fmt.Sprintf("[%s] %s", p.Level, p.Text))
+			d.mu.Unlock()
+		}
+	}
+}
+
+func (d *driver) cmd(method string, params map[string]interface{}) (json.RawMessage, error) {
+	d.mu.Lock()
+	d.nextID++
+	id := d.nextID
+	ch := make(chan bidiMsg, 1)
+	d.waiters[id] = ch
+	d.mu.Unlock()
+	body, _ := json.Marshal(map[string]interface{}{"id": id, "method": method, "params": params}) //nolint:errcheck
+	if err := d.c.Write(d.ctx, websocket.MessageText, body); err != nil {
+		return nil, err
+	}
+	select {
+	case m := <-ch:
+		if m.Error != "" {
+			return nil, fmt.Errorf("%s: %s %s", method, m.Error, m.Msg)
+		}
+		return m.Result, nil
+	case <-d.ctx.Done():
+		return nil, d.ctx.Err()
+	}
+}
+
+func (d *driver) resetConsole() { d.mu.Lock(); d.console = nil; d.mu.Unlock() }
+func (d *driver) dumpConsole() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return strings.Join(d.console, "\n")
+}
+
+// connect dials BiDi, establishes the single session (waiting out a lagging
+// prior teardown), subscribes to console logs, and opens one tab to drive.
+func connect(ctx context.Context, port string) (*driver, string, error) {
+	c, _, err := websocket.Dial(ctx, "ws://127.0.0.1:"+port+"/session", nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("BiDi dial: %w", err)
+	}
+	c.SetReadLimit(96 << 20)
+	d := &driver{c: c, ctx: ctx, waiters: map[int]chan bidiMsg{}}
+	go d.pump()
+	var serr error
+	for i := 0; i < 15; i++ {
+		if _, serr = d.cmd("session.new", map[string]interface{}{"capabilities": map[string]interface{}{}}); serr == nil {
+			break
+		}
+		if !strings.Contains(serr.Error(), "Maximum number of active") {
+			return nil, "", fmt.Errorf("session.new: %w", serr)
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if serr != nil {
+		return nil, "", fmt.Errorf("session busy (restart Waterfox once to clear a stuck session): %w", serr)
+	}
+	_, _ = d.cmd("session.subscribe", map[string]interface{}{"events": []string{"log.entryAdded"}}) //nolint:errcheck
+	var bctx string
+	if cr, e := d.cmd("browsingContext.create", map[string]interface{}{"type": "tab"}); e == nil {
+		var cc struct {
+			Context string `json:"context"`
+		}
+		_ = json.Unmarshal(cr, &cc) //nolint:errcheck
+		bctx = cc.Context
+	}
+	if bctx == "" {
+		return nil, "", fmt.Errorf("could not create a browsing context")
+	}
+	return d, bctx, nil
+}
+
+func (d *driver) evalStr(bctx, expr string) string {
+	res, e := d.cmd("script.evaluate", map[string]interface{}{
+		"expression": expr, "target": map[string]interface{}{"context": bctx},
+		"awaitPromise": true, "resultOwnership": "none",
+	})
+	if e != nil {
+		return "ERROR: " + e.Error()
+	}
+	var r struct {
+		Result struct {
+			Value json.RawMessage `json:"value"`
+			Type  string          `json:"type"`
+		} `json:"result"`
+	}
+	_ = json.Unmarshal(res, &r) //nolint:errcheck
+	out := string(r.Result.Value)
+	if out == "" {
+		out = r.Result.Type
+	}
+	return strings.Trim(out, `"`)
+}
+
+func (d *driver) shoot(bctx, outPrefix string) {
+	if shot, e := d.cmd("browsingContext.captureScreenshot", map[string]interface{}{"context": bctx}); e == nil {
+		var s struct {
+			Data string `json:"data"`
+		}
+		_ = json.Unmarshal(shot, &s) //nolint:errcheck
+		if b, de := base64.StdEncoding.DecodeString(s.Data); de == nil {
+			_ = os.WriteFile(outPrefix+".png", b, 0o644) //nolint:errcheck,gosec
+		}
+	}
+}
+
+func serveMode() error {
+	if len(os.Args) < 4 {
+		return fmt.Errorf("usage: wfdrive serve <bidiPort> <ctrlAddr>")
+	}
+	port, ctrlAddr := os.Args[2], os.Args[3]
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d, bctx, err := connect(ctx, port)
+	if err != nil {
+		return err
+	}
+	end := func() {
+		_, _ = d.cmd("session.end", map[string]interface{}{}) //nolint:errcheck
+		d.c.Close(websocket.StatusNormalClosure, "")          //nolint:errcheck,gosec
+	}
+
+	srv := &http.Server{Addr: ctrlAddr, ReadHeaderTimeout: 5 * time.Second}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/nav", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		wait := 8
+		if n, e := strconv.Atoi(q.Get("wait")); e == nil {
+			wait = n
+		}
+		out := q.Get("out")
+		if out == "" {
+			out = "/tmp/wfdrive"
+		}
+		d.resetConsole()
+		if u := q.Get("url"); u != "" {
+			if _, e := d.cmd("browsingContext.navigate", map[string]interface{}{"context": bctx, "url": u, "wait": "complete"}); e != nil {
+				_, _ = fmt.Fprintf(w, `{"navWarning":%q}`+"\n", e.Error()) //nolint:errcheck,gosec
+			}
+		}
+		time.Sleep(time.Duration(wait) * time.Second)
+		evalOut := ""
+		if ev := q.Get("eval"); ev != "" {
+			evalOut = d.evalStr(bctx, ev)
+		}
+		d.shoot(bctx, out)
+		con := d.dumpConsole()
+		_ = os.WriteFile(out+".console.txt", []byte(con+"\n"), 0o644)                                         //nolint:errcheck,gosec
+		resp, _ := json.Marshal(map[string]interface{}{"png": out + ".png", "eval": evalOut, "console": con}) //nolint:errcheck
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp) //nolint:errcheck
+	})
+	mux.HandleFunc("/quit", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("bye\n"))                                            //nolint:errcheck
+		go func() { time.Sleep(200 * time.Millisecond); end(); _ = srv.Close() }() //nolint:errcheck
+	})
+	srv.Handler = mux
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() { <-sig; end(); _ = srv.Close() }() //nolint:errcheck
+
+	fmt.Printf("wfdrive serving control on http://%s (BiDi :%s, tab %s)\n", ctrlAddr, port, bctx)
+	if e := srv.ListenAndServe(); e != nil && e != http.ErrServerClosed {
+		end()
+		return e
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if err := serveMode(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Fprintln(os.Stderr, "usage: wfdrive serve <bidiPort> <ctrlAddr>   (persistent driver)")
+	os.Exit(2)
+}


### PR DESCRIPTION
Debugging tools for the wasm-visor / HV-UI headless harness, complementing the already-upstream `cmd/hvinspect` (Brave/Chromium over CDP). No new dependencies.

- **`cmd/cdpeval`** — evaluate JS against a *specific* CDP target (by its `webSocketDebuggerUrl`), so OOPIF iframes / workers that hvinspect's URL-matching can't disambiguate can be inspected directly. Main-module tool (reuses the existing `coder/websocket` dep).
- **`cmd/wfdrive`** — inspector/driver for Waterfox/Firefox over **WebDriver BiDi** — the BiDi analog of hvinspect's CDP driver. Persistent session + HTTP control port, screenshot + console capture. Main-module tool (`coder/websocket` only).
- **`cmd/hvinspect`** — add `HVINSPECT_RELOAD=hard` (clear HTTP cache + SW/CacheStorage, ignore-cache reload — for picking up a rebuilt wasm blob) and `SetIgnoreCertificateErrors` in attach mode.

Build + `golangci-lint` clean. `cmd/hvinspect` stays its own nested module (chromedp); `cdpeval`/`wfdrive` are main-module commands using only the already-vendored `coder/websocket`, so `go build ./...` covers them and nothing new enters the dependency graph.