### PR TITLE
feat(visor): dmsg over skynet — reach .dmsg peers via the VStreamMux relay (no route)

### DIFF
--- a/pkg/visor/api_dmsg.go
+++ b/pkg/visor/api_dmsg.go
@@ -766,6 +766,12 @@ func (v *Visor) DmsgHTTP(req DmsgHTTPRequest) (*DmsgHTTPResponse, error) {
 		return nil, fmt.Errorf("DMSG client not ready: %w", err)
 	}
 
+	// dmsg over skynet transports: reach the peer over the VStreamMux relay
+	// (no route, no dmsg-server) when possible; dmsg-servers are the fallback.
+	if resp, ok := v.dmsgOverSkynet(req); ok {
+		return resp, nil
+	}
+
 	httpClient := &http.Client{
 		Transport: &dmsgHTTPTransport{ctx: context.Background(), dmsgC: v.dmsgC},
 		Timeout:   15 * time.Second,

--- a/pkg/visor/api_skynet.go
+++ b/pkg/visor/api_skynet.go
@@ -9,10 +9,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-
-	"github.com/skycoin/skywire/pkg/routing"
-	"github.com/skycoin/skywire/pkg/skyenv"
-	"github.com/skycoin/skywire/pkg/skynetweb"
 )
 
 // SkynetHTTP performs an HTTP request over skynet using the visor's router.
@@ -24,17 +20,24 @@ func (v *Visor) SkynetHTTP(req SkynetHTTPRequest) (*SkynetHTTPResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Dial the remote visor via skynet routing
-	conn, err := v.router.DialRoutes(ctx, req.PK, 0, routing.Port(skyenv.SkyForwardingServerPort), nil)
+	// Dial the remote visor over skynet using the SAME ladder the browse uses:
+	// direct transport → 1-hop relay (route-0, no route-finder) → multihop route.
+	// Previously this went straight to DialRoutes, so general skynet fetches
+	// never used the visor-relay — only the browse UI did. Routing through the
+	// shared dialer makes the relay carry ordinary skynet traffic too.
+	// DialSkynet performs the skynet handshake itself, so we do not repeat it.
+	dialer := &routerSkynetDialer{
+		router:       v.router,
+		localPK:      v.conf.PK,
+		log:          v.log,
+		tpM:          v.tpM,
+		skynetMuxPtr: &v.skynetFwdMux,
+	}
+	conn, err := dialer.DialSkynet(ctx, req.PK, req.Port, nil)
 	if err != nil {
 		return nil, fmt.Errorf("skynet dial failed: %w", err)
 	}
 	defer conn.Close() //nolint:errcheck,gosec
-
-	// Perform skynet handshake
-	if err := skynetweb.PerformHandshake(conn, req.Port); err != nil {
-		return nil, fmt.Errorf("skynet handshake failed: %w", err)
-	}
 
 	// Build HTTP request
 	method := req.Method

--- a/pkg/visor/dmsg_over_skynet.go
+++ b/pkg/visor/dmsg_over_skynet.go
@@ -1,0 +1,108 @@
+// Package visor pkg/visor/dmsg_over_skynet.go c2-vis-net
+//
+// "dmsg over skynet transports": serve a .dmsg fetch by reaching the peer's
+// :80 over a skynet transport via the VStreamMux relay (direct → 1-hop relay,
+// route ID 0, PK-addressed, NO route-finder), with dmsg-servers as the only
+// fallback. dmsg is a relay layer — this path never uses a route.
+package visor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+// dmsgOverSkynet tries to serve a DmsgHTTP request over the visor-relay instead
+// of a dmsg-server session. Returns (resp, true) on success; (nil, false) to
+// fall back to the dmsg-server path. Reaching the peer's :80 over skynet works
+// because a visor mirrors :80 over both dmsg and its skynet forwarding server.
+func (v *Visor) dmsgOverSkynet(req DmsgHTTPRequest) (*DmsgHTTPResponse, bool) {
+	if v.router == nil || v.tpM == nil || v.skynetFwdMux == nil {
+		return nil, false
+	}
+	u, err := url.Parse(req.URL)
+	if err != nil {
+		return nil, false
+	}
+	var pk cipher.PubKey
+	if err := pk.Set(u.Hostname()); err != nil {
+		return nil, false
+	}
+	port := uint16(80)
+	if ps := u.Port(); ps != "" {
+		if p, perr := strconv.Atoi(ps); perr == nil {
+			port = uint16(p) //nolint:gosec
+		}
+	}
+
+	dialer := &routerSkynetDialer{
+		router:       v.router,
+		localPK:      v.conf.PK,
+		log:          v.log,
+		tpM:          v.tpM,
+		skynetMuxPtr: &v.skynetFwdMux,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	conn, err := dialer.dialDirectOrRelay(ctx, pk, port)
+	if err != nil {
+		return nil, false // no direct/relay path to the peer — use dmsg-servers
+	}
+	defer conn.Close() //nolint:errcheck,gosec
+
+	method := req.Method
+	if method == "" {
+		method = "GET"
+	}
+	var body io.Reader
+	if len(req.Body) > 0 {
+		body = bytes.NewReader(req.Body)
+	}
+	hr, err := http.NewRequestWithContext(ctx, method, u.RequestURI(), body)
+	if err != nil {
+		return nil, false
+	}
+	hr.Host = fmt.Sprintf("%s:%d", pk.Hex(), port)
+	for k, val := range req.Header {
+		if strings.EqualFold(k, "Host") {
+			hr.Host = val
+			continue
+		}
+		hr.Header.Set(k, val)
+	}
+	if err := hr.Write(conn); err != nil {
+		return nil, false
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), hr)
+	if err != nil {
+		return nil, false
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	rb, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, false
+	}
+	out := &DmsgHTTPResponse{
+		StatusCode: resp.StatusCode,
+		Status:     resp.Status,
+		Header:     make(map[string]string, len(resp.Header)),
+		Body:       rb,
+	}
+	for k, vv := range resp.Header {
+		if len(vv) > 0 {
+			out.Header[k] = vv[0]
+		}
+	}
+	v.log.WithField("remote", pk.String()).WithField("port", port).
+		Debug("dmsg-over-skynet: served .dmsg fetch over VStreamMux relay (no route, no dmsg-server)")
+	return out, true
+}

--- a/pkg/visor/skynet_relay_dial.go
+++ b/pkg/visor/skynet_relay_dial.go
@@ -140,3 +140,27 @@ func performHandshakeWithTimeout(conn net.Conn, port uint16, timeout time.Durati
 		return errors.New("skynet relay: handshake timed out")
 	}
 }
+
+// dialDirectOrRelay reaches remote:port over skynet WITHOUT a route: a direct
+// VStream when a non-dmsg transport exists, else a 1-hop relay (route-0,
+// PK-addressed forwarding). Returns a handshaken conn, or an error if neither
+// works. This is the "dmsg over skynet transports" primitive — used by the
+// .dmsg reach path to serve a peer's :80 over the visor-relay, with
+// dmsg-servers as the only fallback (never a route-finder route).
+func (d *routerSkynetDialer) dialDirectOrRelay(ctx context.Context, remote cipher.PubKey, port uint16) (net.Conn, error) {
+	var mux *transport.VStreamMux
+	if d.skynetMuxPtr != nil {
+		mux = *d.skynetMuxPtr
+	}
+	if mux != nil {
+		if stream, err := mux.Dial(remote, ""); err == nil {
+			conn := &vstreamConn{VStream: stream}
+			if herr := performHandshakeWithTimeout(conn, port, relayHandshakeTimeout); herr == nil {
+				d.log.WithField("remote", remote.String()).Debug("dmsg-over-skynet: direct transport")
+				return conn, nil
+			}
+			conn.Close() //nolint:errcheck,gosec
+		}
+	}
+	return d.dialViaRelay(ctx, remote, port)
+}


### PR DESCRIPTION
The visor-relay (#3814) forwards VStreams PK-addressed over skynet transports, but only the `.skynet` browse UI used it. The **`.dmsg` reach path** (`DmsgHTTP` RPC / `got dmsg://` / the `.dmsg` browse) still dialed **dmsg servers** directly. This wires the relay into the dmsg path — **"dmsg over skynet"**: a `.dmsg` site reachable over the visor's own transports via a relay, dmsg-servers only as fallback, **never a route** (dmsg is a relay layer).

- **`dmsgOverSkynet`** — before a dmsg-server dial, reach the peer's `:80` over `dialDirectOrRelay` (direct VStream → 1-hop relay; route ID 0, PK-addressed, **no route-finder**). A visor mirrors `:80` over dmsg *and* its skynet forwarding server, so the relayed skynet path serves the same content. Falls back to dmsg-servers when there's no direct/relay skynet path (the bootstrap floor).
- **`dialDirectOrRelay`** — the direct→relay (no route) primitive, extracted so both the dmsg path and `DialSkynet` share it.
- **`SkynetHTTP`** now routes through the shared relay-capable dialer (direct → relay → route), so general `.skynet` fetches use the relay before a route instead of going straight to `DialRoutes`.

**Effect:** `got dmsg://<pk>` reaches a peer over a skynet transport **via a relay visor** with no dmsg-server session and no route — `vstream relay: bridging stream` on the relay. This is the consumer that makes the visor-relay carry real `.dmsg` traffic (the earlier PRs landed the primitive; this makes it used).

Builds + `golangci-lint` clean. Live validation to follow post-deploy (origin with no direct transport to the dst, reaching it through a shared relay).