### PR TITLE
feat(cli): add 'tp public [true|false]' to get/set is_public

### DIFF
--- a/cmd/skywire-cli/commands/tp/tp-public.go
+++ b/cmd/skywire-cli/commands/tp/tp-public.go
@@ -1,0 +1,58 @@
+// Package clitp cmd/skywire-cli/commands/tp/tp-public.go c4-vis-cli
+package clitp
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+)
+
+func init() {
+	publicCmd.Flags().StringVar(&clirpc.Addr, "rpc", clirpc.DefaultRPCAddr, "RPC server address (env: SKYWIRE_RPC)")
+}
+
+var publicCmd = &cobra.Command{
+	Use:   "public [true|false]",
+	Short: "Get or set whether the visor is public",
+	Long: `Get or set the visor's is_public config (advertise the visor's transports
+in service discovery). This is the CLI equivalent of the hypervisor UI's
+public toggle; both call the same SetIsPublic RPC, which writes and flushes
+the config. The new value takes effect on the next visor restart.
+
+	skywire cli tp public        - show current setting
+	skywire cli tp public true   - make the visor public
+	skywire cli tp public false  - make the visor non-public
+`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+
+		if len(args) == 0 {
+			isPublic := rpcClient.GetIsPublic()
+			internal.PrintOutput(cmd.Flags(), map[string]bool{"is_public": isPublic},
+				fmt.Sprintf("is_public: %t\n", isPublic))
+			return
+		}
+
+		var isPublic bool
+		switch args[0] {
+		case "true", "on", "yes", "1":
+			isPublic = true
+		case "false", "off", "no", "0":
+			isPublic = false
+		default:
+			internal.PrintFatalError(cmd.Flags(), fmt.Errorf("invalid argument: %s (use 'true' or 'false')", args[0]))
+		}
+
+		err = rpcClient.SetIsPublic(isPublic)
+		internal.Catch(cmd.Flags(), err)
+		internal.PrintOutput(cmd.Flags(), map[string]bool{"is_public": isPublic},
+			fmt.Sprintf("is_public set to %t (effective on next restart)\n", isPublic))
+	},
+}

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -65,6 +65,7 @@ func init() {
 		visorListCmd,
 		vizCmd,
 		autoCmd,
+		publicCmd,
 		metricsCmd,
 	)
 	tpCmd.Flags().StringSliceVarP(&filterTypes, "types", "t", filterTypes, "show transport(s) type(s) comma-separated")


### PR DESCRIPTION
The `SetIsPublic`/`GetIsPublic` RPCs were only reachable from the hypervisor UI's public toggle (`hypervisor_handlers_admin.go`) — there was no CLI equivalent. This adds `skywire cli tp public` for parity:

- `skywire cli tp public` — print the current `is_public` setting
- `skywire cli tp public true|false` — set it via the same `SetIsPublic` RPC (writes + flushes the config; effective on next restart, matching the UI)

Mirrors the existing `tp auto [on|off]` verb (which wraps `Start/StopPublicAutoconnect`). No behavior change to the RPC itself.