### PR TITLE
feat(cxo): quiet-feed heartbeat republish to keep subscriber connections alive

### DIFF
--- a/pkg/cxo/treestore/publisher.go
+++ b/pkg/cxo/treestore/publisher.go
@@ -61,6 +61,17 @@ type Publisher struct {
 	// matches the encoded content.
 	dirtyGen uint64
 
+	// lastPublishNs is the UnixNano of the last successful publish (real
+	// change OR heartbeat). runLoop's heartbeat re-publishes the current
+	// Root when this is older than heartbeatInterval, so subscribers keep
+	// receiving an inbound Root inside the CXO idle-watchdog window and
+	// don't tear the connection down + re-dial (a full noise+PQ handshake)
+	// on a quiet/static feed. A feed with real changes publishes via the
+	// dirty path and resets this well inside the interval, so busy feeds
+	// never pay the heartbeat, and a quiet feed's republish is a warm
+	// encode-cache walk (no re-serialize).
+	lastPublishNs atomic.Int64
+
 	// allow gates which subscriber PKs may connect. nil-set means the
 	// allowlist is disabled (any subscriber is accepted). NewWithDMSG
 	// wires this state into the CXO node's OnSubscribeRemote hook
@@ -723,6 +734,18 @@ func (p *Publisher) Walk(prefix string, fn func(path string, value []byte) bool)
 // package-wide "test timed out" panic with no failing test named.
 const flushTimeout = 5 * time.Second
 
+// heartbeatInterval is how often runLoop re-publishes the current Root
+// on a QUIET feed (one with no real changes) so subscribers keep
+// receiving an inbound Root and their CXO connection stays alive. It
+// MUST be shorter than BOTH keepalive-relevant thresholds so a healthy-
+// but-quiet conn is never torn down + re-dialed (a full noise+PQ
+// handshake): the CXO node idle watchdog (idleWatchdogThreshold = 90s,
+// pkg/cxo/node) AND the subscriber reconnect-on-quiet watchdog
+// (reconnectQuietThreshold = 60s, pkg/cxo/treestore/subscriber.go). 45s
+// clears both with margin; a genuinely stalled feed still stops emitting
+// heartbeats, so the 60s reconnect safety net recovers it as intended.
+const heartbeatInterval = 45 * time.Second
+
 // Flush blocks until pending changes have been published, or
 // returns nil immediately if there are none. Useful in tests where
 // the caller wants deterministic post-Put state.
@@ -863,6 +886,12 @@ func (p *Publisher) markDirty() {
 // runLoop is the dedicated publish goroutine. It coalesces
 // mutations within batchWindow and writes one Root per batch.
 func (p *Publisher) runLoop() {
+	// Quiet-feed keepalive: check twice per interval so a "no publish for
+	// heartbeatInterval" condition is caught and republished comfortably
+	// inside the CXO idle watchdog (90s). Only feeds that have gone silent
+	// pay it; busy feeds publish via the dirty path and reset the clock.
+	hb := time.NewTicker(heartbeatInterval / 2)
+	defer hb.Stop()
 	for {
 		select {
 		case <-p.done:
@@ -870,6 +899,17 @@ func (p *Publisher) runLoop() {
 			// state (Close already flushed but be defensive).
 			_ = p.publishIfDirty() //nolint:errcheck
 			return
+		case <-hb.C:
+			// Re-publish the current Root if nothing has published for a
+			// full interval, so subscribers keep seeing an inbound Root and
+			// don't re-dial. Skip until the first real publish so we never
+			// emit an empty startup Root.
+			if last := p.lastPublishNs.Load(); last != 0 &&
+				time.Since(time.Unix(0, last)) >= heartbeatInterval {
+				if err := p.publishHeartbeat(); err != nil {
+					p.log.WithError(err).Debug("treestore: heartbeat republish failed")
+				}
+			}
 		case <-p.wakeup:
 			// Coalesce: wait the batch window, then publish.
 			timer := time.NewTimer(p.batchWindow)
@@ -887,7 +927,7 @@ func (p *Publisher) runLoop() {
 	}
 }
 
-func (p *Publisher) publishIfDirty() error {
+func (p *Publisher) doPublish(force bool) error {
 	// Decouple the in-memory snapshot phase from the CXO encode /
 	// bbolt-write phase. Holding p.mu through publishRoot was the
 	// original bug: encodeNode + Cache.WithBatch can take many
@@ -912,7 +952,7 @@ func (p *Publisher) publishIfDirty() error {
 	//     drop freshSubs to avoid pinning the live tree to a hash
 	//     that no longer matches its content.
 	p.mu.Lock()
-	if !p.dirty {
+	if !force && !p.dirty {
 		p.mu.Unlock()
 		return nil
 	}
@@ -961,8 +1001,23 @@ func (p *Publisher) publishIfDirty() error {
 	// If dirtyGen != gen a Put / Delete landed during publish; leave
 	// dirty set so runLoop republishes the new state on the next tick.
 	p.mu.Unlock()
+	p.lastPublishNs.Store(time.Now().UnixNano())
 	return nil
 }
+
+// publishIfDirty publishes the current Root only when there are
+// unpublished changes — the batch-window path driven by markDirty.
+func (p *Publisher) publishIfDirty() error { return p.doPublish(false) }
+
+// publishHeartbeat re-publishes the current Root even when the tree is
+// clean, so subscribers on a quiet/static feed receive an inbound Root
+// within the CXO idle-watchdog window (see heartbeatInterval) and keep
+// their connection instead of tearing it down and re-dialing (a full
+// noise+PQ handshake). Cheap: the encode-cache makes an unchanged tree a
+// warm shallow walk with no re-serialize, and a feed with real changes
+// publishes via publishIfDirty and resets the heartbeat clock, so busy
+// feeds never reach here.
+func (p *Publisher) publishHeartbeat() error { return p.doPublish(true) }
 
 // walkLivePath returns the memNode at the given path in n, or nil if
 // the path no longer exists or hits a leaf instead of a sub-tree at

--- a/pkg/cxo/treestore/publisher_heartbeat_test.go
+++ b/pkg/cxo/treestore/publisher_heartbeat_test.go
@@ -1,0 +1,46 @@
+// Package treestore — publisher_heartbeat_test.go: the quiet-feed
+// keepalive. runLoop re-publishes the current Root every heartbeatInterval
+// on a feed with no changes so subscribers keep receiving an inbound Root
+// inside the CXO idle-watchdog window and don't tear down + re-dial (a
+// full noise+PQ handshake). This guards the core invariant:
+// publishHeartbeat re-publishes a CLEAN tree, while publishIfDirty does not.
+package treestore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+)
+
+func TestPublisherHeartbeatRepublishesCleanTree(t *testing.T) {
+	_, sk := cipher.GenerateKeyPair()
+	pub, err := NewWithTCP("127.0.0.1:0", sk, PubConfig{
+		InMemoryDB:  true,
+		BatchWindow: 5 * time.Millisecond,
+	})
+	require.NoError(t, err, "NewWithTCP")
+	t.Cleanup(func() { _ = pub.Close() }) //nolint:errcheck
+
+	// A real change → runLoop publishes it and stamps lastPublishNs.
+	require.NoError(t, pub.Put("k", []byte("v")), "Put")
+	require.Eventually(t, func() bool { return pub.lastPublishNs.Load() != 0 },
+		5*time.Second, 5*time.Millisecond, "initial publish should stamp lastPublishNs")
+
+	// Tree is now clean (the change was published, nothing new). The
+	// dirty-path publish must be a no-op — no re-emit, clock unchanged.
+	before := pub.lastPublishNs.Load()
+	require.NoError(t, pub.publishIfDirty(), "publishIfDirty on clean tree")
+	require.Equal(t, before, pub.lastPublishNs.Load(),
+		"publishIfDirty must NOT re-publish a clean tree")
+
+	// The heartbeat re-publishes even though nothing changed: a new Root
+	// is emitted (broadcast to subscribers) and the clock advances. This
+	// is what keeps a quiet feed's subscriber connections alive.
+	time.Sleep(2 * time.Millisecond) // ensure a distinct UnixNano stamp
+	require.NoError(t, pub.publishHeartbeat(), "publishHeartbeat on clean tree")
+	require.Greater(t, pub.lastPublishNs.Load(), before,
+		"publishHeartbeat must re-publish a clean tree (quiet-feed keepalive)")
+}


### PR DESCRIPTION
## Problem

CXO connections are torn down and re-dialed — a full **noise + PQ (ML-KEM-768) handshake** — every **~90s** on any *quiet* feed, fleet-wide.

Root cause: the CXO node's idle watchdog closes a `Conn` after `idleWatchdogThreshold` (**90s**) with no **inbound** message, and **no keepalive is actually sent** — `conf.Pings` (118s) is dead config (no transport consumes it), and 118s > 90s regardless. So a *healthy* connection whose feed simply hasn't changed in 90s (transport graph, dmsg-server list, idle telemetry) looks dead and gets re-handshaked on next use.

Fleet-wide that churn dominates the **dmsg-discovery host's CPU** (measured ~90%, almost entirely GC of `mlkem.NewEncapsulationKey768` / secp256k1 handshake allocations) and inflates **dmsg-server inbound bandwidth**.

## Fix

The publisher re-publishes its current Root as a **no-change heartbeat** when a feed goes quiet, so subscribers keep receiving an inbound Root within the idle window and hold the connection open instead of re-dialing.

- `heartbeatInterval = 45s` — under **both** the node idle watchdog (90s) and the subscriber reconnect-on-quiet watchdog (60s), with margin. A genuinely stalled feed stops emitting heartbeats, so the 60s reconnect safety net still recovers it.
- `runLoop` gains a heartbeat ticker: if nothing has published for the interval, re-publish. **Busy feeds publish via the dirty path and reset the clock, so they never pay it**; a quiet feed's republish is a warm encode-cache walk (no re-serialize). Skipped until the first real publish (no empty startup Root).
- `publishIfDirty` refactored into a shared `doPublish(force)`; `publishHeartbeat = doPublish(true)` reuses the exact tested publish/promote path.

**Rollout-safe:** the heartbeat is an ordinary `Root` every node already handles — no new message type, no unknown-type disconnect during a mixed-version fleet. Applies to **all** publishers (visor telemetry + the TPD/SD/DMSGD aggregators) via the shared `treestore.Publisher`, so both ends of a connection heartbeat and it stays alive bidirectionally.

## Test

`TestPublisherHeartbeatRepublishesCleanTree`: after a change settles, `publishIfDirty()` on a clean tree is a no-op, but `publishHeartbeat()` re-publishes (advancing the publish clock) — the quiet-feed keepalive invariant. Full `pkg/cxo/treestore` suite green.

## Follow-up (separate PR)

Make continuously-held `cxosub` subscriptions persistent instead of `Connect → snapshot → Close` every cycle — the complementary half; the heartbeat then keeps those alive too.