### PR TITLE
feat(dmsg): registration-over-CXO — visor entry as a CXO feed, dmsg-disc aggregates (opt-in)

### DIFF
--- a/docs/design/dmsg-bootstrap-floor.md
+++ b/docs/design/dmsg-bootstrap-floor.md
@@ -215,6 +215,55 @@ simpler.
    `sessions_count`; once it has transports and relays, it need not hold more.
 4. dmsg servers remain only as the bootstrap/fallback floor.
 
+## Registration over CXO (the fan-in direction)
+
+The load investigation (dmsg-discovery pinned at ~90% CPU, GC-bound on
+noise + ML-KEM-768 handshake allocations) traced most of dmsg-disc's inbound
+work to **periodic client-entry registration over HTTP-over-dmsg**: every visor
+re-`PUT`s its entry on a timer, and each `PUT` is a fresh dmsg stream — a full
+noise + PQ handshake. This is the same connect→handshake→close churn the
+quiet-feed heartbeat (the CXO idle-watchdog fix) removed for *persistent* CXO
+connections — but registration never used a persistent connection.
+
+Move registration onto CXO, mirroring the telemetry→TPD pattern:
+
+1. **A visor publishes its own signed `disc.Entry` as a CXO feed** (feed PK = the
+   visor's PK, a dedicated dmsg port). This reuses the exact `treestore.Publisher`
+   the visor already runs for telemetry (`pkg/visor/init_stats.go`), and the
+   quiet-feed heartbeat keeps the connection alive — so registration becomes **one
+   persistent push per visor, re-published only on actual change** (the delegated-
+   server set changes), instead of a periodic re-`PUT`. The signature model maps
+   1:1: a CXO feed is signed by its publisher, and the entry is already
+   self-signed by the same visor.
+
+2. **dmsg-disc runs a CXO aggregator** that subscribes to visor entry feeds
+   (fan-in, like TPD's `cxoaggregator`), verifies the entry signature + monotonic
+   sequence, and ingests into its store (`SetEntry`) — so lookups and the HTTP API
+   keep working unchanged. dmsg-disc already publishes the inverse
+   `ClientsByServerCXOPublisher` feed (fan-out), so the CXO plumbing on the
+   dmsg-disc side is established; this adds the subscribe side.
+
+3. **Backward-compatible & additive.** The HTTP `PUT /dmsg-discovery/entry` path
+   stays for un-migrated clients; a visor that can't reach dmsg-disc over CXO
+   falls back to HTTP.
+
+**Layering.** The entry publisher lives at the **visor** level (`pkg/visor`), not
+in `pkg/dmsg` — CXO imports dmsg, so having dmsg publish its own entry over CXO
+would be an import cycle. The visor reads the dmsg client's current entry and
+publishes it; it already orchestrates both dmsg and CXO. Bootstrap is unaffected:
+a visor dials dmsg servers directly (no entry needed), then publishes *which*
+servers it's on — after a dmsg session already exists.
+
+**Lookup stays measure-first / configurable.** The fan-out
+`ClientsByServerCXOPublisher` already lets a visor mirror the entry set from
+dmsg-disc over CXO. Whether a visor subscribes to it (a full local mirror) vs.
+does on-demand HTTP lookups should be **configurable** — leaf / resource-
+constrained boards on-demand, hub visors (public visors, hypervisors, the
+resolving proxies) full-sync — because most visors only ever resolve their
+handful of transport peers, and a full mirror over-provisions constrained boards
+(the eMMC/microSD case). Measure the actual per-visor lookup rate before
+defaulting anything to full-sync; the dominant churn was registration, not lookup.
+
 ## Open questions
 
 - **Relay discovery / rendezvous.** With visors as relays, how does a visor pick

--- a/pkg/dmsg/discovery/api/registration_ingest.go
+++ b/pkg/dmsg/discovery/api/registration_ingest.go
@@ -1,0 +1,105 @@
+// Package api pkg/dmsg/discovery/api/registration_ingest.go c1-net-dmsg
+//
+// Registration-over-CXO ingest: the server side of the fan-in path where
+// visors publish their own signed discovery entry as a CXO feed instead
+// of re-PUTting it over HTTP on a timer (each PUT a fresh Noise + PQ
+// handshake — the load that dominates dmsg-discovery CPU). The CXO
+// aggregator (pkg/dmsg/discovery/regcxo) calls IngestEntryFromCXO for
+// each entry it replicates.
+package api
+
+import (
+	"context"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+// IngestEntryFromCXO applies a client discovery entry received over the
+// registration-over-CXO feed. reporter is the feed's publisher PK (the
+// visor); it MUST equal entry.Static since a visor may only publish its
+// own entry.
+//
+// It mirrors the validation and side effects of the HTTP setEntry handler
+// (Validate, VerifySignature, sequence-iteration guard, SetEntry, DHT
+// mirror, clients-by-server CXO publish, heartbeat) with ONE difference:
+// a stale-or-equal sequence is a silent idempotent no-op rather than an
+// error. During the migration a visor dual-writes the same entry over
+// HTTP and CXO, so whichever path lands first wins and the other simply
+// finds the store already at that sequence. Keep this in sync with
+// (*API).setEntry — deliberately duplicated (not refactored out of the
+// hot HTTP path) to keep this additive, opt-in path from touching
+// production registration behaviour.
+func (a *API) IngestEntryFromCXO(ctx context.Context, entry *disc.Entry, reporter cipher.PubKey) {
+	if entry == nil {
+		return
+	}
+	// Registration-over-CXO is for client (visor) entries only. Server
+	// entries register over HTTP; a client must not be able to publish a
+	// server entry (which advertises a reachable address) via its own feed.
+	if entry.Client == nil || entry.Server != nil {
+		log.WithField("reporter", reporter).Debug("registration-cxo: ignoring non-client entry")
+		return
+	}
+	// A visor may only publish its OWN entry: the feed PK (reporter) signs
+	// the Root and entry.Static is what the entry signature covers.
+	// Requiring them equal stops a visor from registering another PK.
+	if entry.Static != reporter {
+		log.WithField("reporter", reporter).WithField("entry_pk", entry.Static).
+			Warn("registration-cxo: entry.Static != feed PK; dropping")
+		return
+	}
+	// Client entries skip timestamp validation (they no longer refresh on a
+	// timer), matching setEntry's validateTimestamp=false for clients.
+	if err := entry.Validate(false); err != nil {
+		log.WithError(err).WithField("reporter", reporter).Debug("registration-cxo: entry validation failed")
+		return
+	}
+	if err := entry.VerifySignature(); err != nil {
+		log.WithField("reporter", reporter).Debug("registration-cxo: signature verification failed")
+		return
+	}
+
+	old, err := a.db.Entry(ctx, entry.Static)
+	if err == disc.ErrKeyNotFound {
+		if e := a.db.SetEntry(ctx, entry, a.clientEntryTTL); e != nil {
+			log.WithError(e).WithField("reporter", reporter).Debug("registration-cxo: SetEntry (insert) failed")
+			return
+		}
+		a.afterEntrySetFromCXO(ctx, nil, entry)
+		return
+	}
+	if err != nil {
+		log.WithError(err).WithField("reporter", reporter).Debug("registration-cxo: store lookup failed")
+		return
+	}
+	// Idempotent: we already hold this (or a newer) entry — the HTTP path or
+	// an earlier Root already applied it. Not an error.
+	if entry.Sequence <= old.Sequence {
+		return
+	}
+	if err := old.ValidateIteration(entry); err != nil {
+		// A sequence gap or non-monotonic timestamp — let the HTTP path,
+		// which has the read-modify-write retry, own the reconciliation.
+		log.WithError(err).WithField("reporter", reporter).Debug("registration-cxo: iteration invalid; deferring to HTTP")
+		return
+	}
+	if e := a.db.SetEntry(ctx, entry, a.clientEntryTTL); e != nil {
+		log.WithError(e).WithField("reporter", reporter).Debug("registration-cxo: SetEntry (update) failed")
+		return
+	}
+	a.afterEntrySetFromCXO(ctx, old, entry)
+	log.WithField("reporter", reporter).WithField("sequence", entry.Sequence).
+		Debug("registration-cxo: entry ingested")
+}
+
+// afterEntrySetFromCXO fans the post-store side effects that setEntry runs
+// inline: DHT mirror, clients-by-server CXO fan-out, and the uptime
+// heartbeat. All are best-effort and nil-safe.
+func (a *API) afterEntrySetFromCXO(ctx context.Context, old, entry *disc.Entry) {
+	if a.dhtMirror != nil {
+		a.dhtMirror.Mirror(entry.Static, entry, entry.Sequence)
+	}
+	a.cxoPublisher.PublishSetEntry(old, entry)
+	_ = a.db.RecordHeartbeat(ctx, entry.Static, entry.ClientType) //nolint:errcheck
+}

--- a/pkg/dmsg/discovery/api/registration_ingest_test.go
+++ b/pkg/dmsg/discovery/api/registration_ingest_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
+)
+
+// signedClientEntryAtSeq builds a signed client entry for a fixed key at the
+// given sequence — unlike the shared signedClientEntry helper, which mints a
+// fresh key each call, this lets a test iterate the SAME entry's sequence.
+func signedClientEntryAtSeq(t *testing.T, pk cipher.PubKey, sk cipher.SecKey, seq uint64) *disc.Entry {
+	t.Helper()
+	e := disc.NewClientEntry(pk, seq, nil)
+	require.NoError(t, e.Sign(sk))
+	return e
+}
+
+// TestIngestEntryFromCXO_InsertAndIdempotentUpdate covers the core
+// registration-over-CXO ingest contract: a fresh entry inserts, a strictly
+// newer sequence updates, and a stale-or-equal sequence is a silent no-op
+// (so dual-write with the HTTP path never conflicts).
+func TestIngestEntryFromCXO_InsertAndIdempotentUpdate(t *testing.T) {
+	ctx := context.Background()
+	db := store.NewMock()
+	a := newAPI(db)
+	pk, sk := cipher.GenerateKeyPair()
+
+	// 1. Fresh insert (absent → seq 0).
+	e0 := signedClientEntryAtSeq(t, pk, sk, 0)
+	a.IngestEntryFromCXO(ctx, e0, pk)
+	got, err := db.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, uint64(0), got.Sequence)
+
+	// 2. Strictly-newer update applies.
+	e1 := signedClientEntryAtSeq(t, pk, sk, 1)
+	a.IngestEntryFromCXO(ctx, e1, pk)
+	got, err = db.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), got.Sequence)
+
+	// 3. Re-ingesting the SAME sequence is an idempotent no-op (this is
+	//    exactly what happens when the HTTP PUT landed first): store stays
+	//    at seq 1, no error, no panic.
+	a.IngestEntryFromCXO(ctx, e1, pk)
+	got, err = db.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), got.Sequence)
+
+	// 4. A STALE (lower) sequence is dropped — never rolls the entry back.
+	a.IngestEntryFromCXO(ctx, e0, pk)
+	got, err = db.Entry(ctx, pk)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), got.Sequence)
+}
+
+// TestIngestEntryFromCXO_RejectsForeignAndServerEntries ensures a visor can
+// only publish its OWN client entry: a mismatched reporter PK or a server
+// entry is dropped without touching the store.
+func TestIngestEntryFromCXO_RejectsForeignAndServerEntries(t *testing.T) {
+	ctx := context.Background()
+	db := store.NewMock()
+	a := newAPI(db)
+	pk, sk := cipher.GenerateKeyPair()
+	otherPK, _ := cipher.GenerateKeyPair()
+
+	// entry.Static == pk, but reporter (feed PK) is someone else → drop.
+	e := signedClientEntryAtSeq(t, pk, sk, 0)
+	a.IngestEntryFromCXO(ctx, e, otherPK)
+	_, err := db.Entry(ctx, pk)
+	require.Equal(t, disc.ErrKeyNotFound, err, "foreign-reporter entry must not be stored")
+
+	// A correct reporter but a tampered signature (re-sign with wrong key)
+	// must also be rejected.
+	badSK := func() cipher.SecKey { _, s := cipher.GenerateKeyPair(); return s }()
+	eBad := disc.NewClientEntry(pk, 0, nil)
+	require.NoError(t, eBad.Sign(badSK)) // signed by the wrong key
+	a.IngestEntryFromCXO(ctx, eBad, pk)
+	_, err = db.Entry(ctx, pk)
+	require.Equal(t, disc.ErrKeyNotFound, err, "bad-signature entry must not be stored")
+}

--- a/pkg/dmsg/discovery/regcxo/aggregator.go
+++ b/pkg/dmsg/discovery/regcxo/aggregator.go
@@ -1,0 +1,355 @@
+// Package regcxo pkg/dmsg/discovery/regcxo/aggregator.go c1-net-dmsg
+//
+// Registration-over-CXO aggregator — the dmsg-discovery side of the
+// fan-in path. Visors that opt into registration_cxo publish their own
+// signed disc.Entry as a single-leaf CXO feed and AnnounceTo this
+// service; the aggregator owns one CXO Node listening on
+// DmsgDMSGDRegistrationCXOPort, subscribes to each visor's feed on
+// connect, and on every filled Root reads the "entry" leaf and hands the
+// entry to the Sink (the discovery API's IngestEntryFromCXO).
+//
+// This moves client-entry registration off the timer-driven HTTP PUT —
+// each a fresh dmsg stream with a full Noise + post-quantum handshake,
+// the load that dominates dmsg-discovery CPU — onto a persistent CXO
+// connection kept warm by the treestore heartbeat. HTTP PUT remains the
+// fallback, so ingest is idempotent (see Sink.IngestEntryFromCXO).
+//
+// Structure mirrors pkg/transport-discovery/cxoaggregator, trimmed to a
+// single "entry" leaf: same connect-driven subscribe, same grace-gated
+// orphan-feed reclaim that keeps the in-memory CXDS from growing without
+// bound as visor PKs churn.
+package regcxo
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	skycipher "github.com/skycoin/skycoin/src/cipher"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cxo/cxoutils"
+	"github.com/skycoin/skywire/pkg/cxo/node"
+	cxotransport "github.com/skycoin/skywire/pkg/cxo/node/transport"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject"
+	"github.com/skycoin/skywire/pkg/cxo/skyobject/registry"
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/dmsg/dmsg"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// registrationEntryPath is the single leaf path a visor publishes its
+// discovery entry at. MUST match pkg/visor's registrationEntryPath.
+const registrationEntryPath = "entry"
+
+// Sink ingests entries replicated from visor registration feeds. The
+// discovery API satisfies it via (*api.API).IngestEntryFromCXO.
+type Sink interface {
+	IngestEntryFromCXO(ctx context.Context, entry *disc.Entry, reporter cipher.PubKey)
+}
+
+// Config tunes the aggregator loops. Zero values get sane defaults.
+type Config struct {
+	ReconcileInterval time.Duration
+	CleanupInterval   time.Duration
+	MaxFillingTime    time.Duration
+	Logger            *logging.Logger
+	InMemoryDB        bool
+	DataDir           string
+}
+
+// orphanGraceTicks is how many consecutive cleanup ticks a feed must
+// have zero connected conns before it is reclaimed. At the 2-minute
+// default CleanupInterval this is a ~4-minute grace — long enough to
+// ride out a visor's dmsg reconnect without churning a stable feed.
+const orphanGraceTicks = 2
+
+// Aggregator owns one CXO Node listening on DMSG; visors dial in,
+// subscribe happens per-conn during reconcile, and OnRootFilled reads
+// the entry leaf and forwards it to the Sink.
+type Aggregator struct {
+	cxoNode *node.Node
+	sink    Sink
+	conf    Config
+	log     *logging.Logger
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan struct{}
+
+	// nudge triggers an immediate reconcile out of band from the ticker.
+	// Buffered(1) so a burst of connects coalesces into one pending
+	// reconcile (idempotent — it walks the full conn set anyway).
+	nudge chan struct{}
+
+	// orphanStrikes counts consecutive cleanup ticks a feed has had no
+	// connected conn. Touched only from cleanup() (single goroutine).
+	orphanStrikes map[skycipher.PubKey]int
+}
+
+// New constructs an Aggregator: a CXO Node with DMSG enabled on
+// DmsgDMSGDRegistrationCXOPort so remote visors can dial in, wired to
+// forward each filled Root's entry leaf to sink.
+func New(dmsgC *dmsg.Client, sink Sink, conf Config) (*Aggregator, error) {
+	if conf.ReconcileInterval <= 0 {
+		conf.ReconcileInterval = 30 * time.Second
+	}
+	if conf.CleanupInterval <= 0 {
+		conf.CleanupInterval = 2 * time.Minute
+	}
+	if conf.MaxFillingTime <= 0 {
+		conf.MaxFillingTime = 90 * time.Second
+	}
+	if conf.Logger == nil {
+		conf.Logger = logging.MustGetLogger("dmsgd-registration-cxo")
+	}
+
+	cfg := node.NewConfig()
+	cfg.MaxFillingTime = conf.MaxFillingTime
+	cfg.Config = skyobject.NewConfig()
+	cfg.Config.InMemoryDB = conf.InMemoryDB || conf.DataDir == ""
+	if conf.DataDir != "" {
+		cfg.Config.DataDir = conf.DataDir
+	}
+
+	cxoNode, err := node.NewNode(cfg)
+	if err != nil {
+		return nil, err
+	}
+	factory := cxotransport.NewDMSGFactory(dmsgC, skyenv.DmsgDMSGDRegistrationCXOPort)
+	if err := cxoNode.EnableDMSG(factory); err != nil {
+		_ = cxoNode.Close() //nolint:errcheck
+		return nil, err
+	}
+
+	a := &Aggregator{
+		cxoNode:       cxoNode,
+		sink:          sink,
+		conf:          conf,
+		log:           conf.Logger,
+		done:          make(chan struct{}),
+		nudge:         make(chan struct{}, 1),
+		orphanStrikes: make(map[skycipher.PubKey]int),
+	}
+
+	// Subscribe the moment a visor dials in, rather than waiting up to a
+	// full ReconcileInterval. The conn's handshake completes (peerID set)
+	// before OnConnect fires, so the nudged reconcile can subscribe at
+	// once; it stays idempotent via alreadySubscribed.
+	cxoNode.Config().OnConnect = func(_ *node.Conn) error {
+		select {
+		case a.nudge <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+	cxoNode.Config().OnRootFilled = func(_ *node.Node, r *registry.Root) {
+		a.handleRootFilled(r)
+	}
+	cxoNode.Config().OnFillingBreaks = func(_ *node.Node, r *registry.Root, reason error) {
+		a.log.WithError(reason).WithField("visor", cipher.PubKey(r.Pub)).
+			Debug("registration-cxo aggregator: root filling broke")
+	}
+	return a, nil
+}
+
+// Run starts the reconcile + cleanup loops. Returns immediately; the loop
+// runs until ctx is canceled or Close is called. Idempotent.
+func (a *Aggregator) Run(ctx context.Context) {
+	a.mu.Lock()
+	if a.cancel != nil {
+		a.mu.Unlock()
+		return
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	a.cancel = cancel
+	a.mu.Unlock()
+	go a.loop(loopCtx)
+}
+
+// Close stops the loops and tears down the CXO node. Idempotent.
+func (a *Aggregator) Close() error {
+	a.mu.Lock()
+	cancel := a.cancel
+	a.cancel = nil
+	a.mu.Unlock()
+	if cancel != nil {
+		cancel()
+		<-a.done
+	}
+	return a.cxoNode.Close()
+}
+
+// FeedPK returns the aggregator's own CXO node identity.
+func (a *Aggregator) FeedPK() cipher.PubKey { return cipher.PubKey(a.cxoNode.ID()) }
+
+func (a *Aggregator) loop(ctx context.Context) {
+	defer close(a.done)
+	t := time.NewTicker(a.conf.ReconcileInterval)
+	defer t.Stop()
+	ct := time.NewTicker(a.conf.CleanupInterval)
+	defer ct.Stop()
+
+	a.reconcile()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			a.reconcile()
+		case <-ct.C:
+			a.cleanup()
+		case <-a.nudge:
+			a.reconcile()
+		}
+	}
+}
+
+// reconcile subscribes to every connected visor's own feed (feed PK ==
+// peer PK) that isn't already subscribed. Dropped conns simply aren't in
+// the list anymore.
+func (a *Aggregator) reconcile() {
+	for _, conn := range a.cxoNode.Connections() {
+		peerPK := conn.PeerID()
+		if peerPK == (skycipher.PubKey{}) {
+			continue
+		}
+		if alreadySubscribed(conn, peerPK) {
+			continue
+		}
+		if err := conn.Subscribe(peerPK); err != nil {
+			a.log.WithError(err).WithField("visor", cipher.PubKey(peerPK)).
+				Debug("registration-cxo aggregator: Subscribe failed; will retry next reconcile")
+			continue
+		}
+		a.log.WithField("visor", cipher.PubKey(peerPK)).
+			Debug("registration-cxo aggregator: subscribed to visor feed")
+	}
+}
+
+func alreadySubscribed(conn *node.Conn, feed skycipher.PubKey) bool {
+	for _, f := range conn.Feeds() {
+		if f == feed {
+			return true
+		}
+	}
+	return false
+}
+
+// cleanup prunes superseded Roots (keeping only the latest per feed) and
+// reclaims feeds whose visor has gone away, then sweeps ownerless
+// objects. Without this the in-memory store grows without bound as visor
+// PKs churn (each keeps its final Root tree pinned).
+func (a *Aggregator) cleanup() {
+	c := a.cxoNode.Container()
+	if err := cxoutils.RemoveRootObjects(c, 1); err != nil {
+		a.log.WithError(err).Debug("registration-cxo aggregator: RemoveRootObjects failed; will retry next tick")
+		return
+	}
+	a.reclaimOrphanFeeds(c)
+	if err := cxoutils.RemoveObjects(c); err != nil {
+		a.log.WithError(err).Debug("registration-cxo aggregator: RemoveObjects failed; will retry next tick")
+	}
+}
+
+// reclaimOrphanFeeds un-shares and hard-deletes feeds that no longer have
+// a connected conn, grace-gated by orphanGraceTicks so a brief drop +
+// redial keeps the feed.
+func (a *Aggregator) reclaimOrphanFeeds(c *skyobject.Container) {
+	connected := make(map[skycipher.PubKey]struct{})
+	for _, conn := range a.cxoNode.Connections() {
+		if pk := conn.PeerID(); pk != (skycipher.PubKey{}) {
+			connected[pk] = struct{}{}
+		}
+	}
+	self := a.cxoNode.ID()
+	for _, feed := range c.Feeds() {
+		if feed == self {
+			delete(a.orphanStrikes, feed)
+			continue
+		}
+		if _, ok := connected[feed]; ok {
+			delete(a.orphanStrikes, feed)
+			continue
+		}
+		a.orphanStrikes[feed]++
+		if a.orphanStrikes[feed] < orphanGraceTicks {
+			continue
+		}
+		delete(a.orphanStrikes, feed)
+		if err := a.cxoNode.DontShare(feed); err != nil {
+			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
+				Debug("registration-cxo aggregator: DontShare orphan feed failed; will retry next tick")
+			continue
+		}
+		if err := c.DelFeed(feed); err != nil {
+			a.log.WithError(err).WithField("visor", cipher.PubKey(feed)).
+				Debug("registration-cxo aggregator: DelFeed orphan feed failed; will retry next tick")
+			continue
+		}
+		a.log.WithField("visor", cipher.PubKey(feed)).
+			Debug("registration-cxo aggregator: reclaimed orphan feed (no connected conn)")
+	}
+}
+
+// handleRootFilled reads the "entry" leaf from a filled Root and forwards
+// the decoded disc.Entry to the Sink. r.Pub is the visor whose feed
+// produced this Root — the reporter PK the ingest checks against
+// entry.Static.
+func (a *Aggregator) handleRootFilled(r *registry.Root) {
+	if r == nil || len(r.Refs) == 0 {
+		return
+	}
+	reporter := cipher.PubKey(r.Pub)
+	if reporter == (cipher.PubKey{}) {
+		a.log.Debug("registration-cxo aggregator: dropping root with zero publisher PK")
+		return
+	}
+	pack, err := a.cxoNode.Container().Pack(r, treestore.Registry)
+	if err != nil {
+		a.log.WithError(err).Debug("registration-cxo aggregator: get pack failed")
+		return
+	}
+	var rootNode treestore.TreeNode
+	if err := r.Refs[0].Value(pack, &rootNode); err != nil {
+		a.log.WithError(err).Debug("registration-cxo aggregator: decode root TreeNode failed")
+		return
+	}
+
+	leaf, ok := findLeaf(pack, &rootNode, registrationEntryPath)
+	if !ok || len(leaf) == 0 {
+		return
+	}
+	entry := new(disc.Entry)
+	if err := json.Unmarshal(leaf, entry); err != nil {
+		a.log.WithError(err).WithField("visor", reporter).
+			Debug("registration-cxo aggregator: entry leaf decode failed")
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	a.sink.IngestEntryFromCXO(ctx, entry, reporter)
+}
+
+// findLeaf returns the leaf value stored directly under n at the given
+// top-level name. The registration feed is flat (one "entry" leaf), so a
+// single level of lookup suffices — no recursive walk.
+func findLeaf(pack registry.Pack, n *treestore.TreeNode, name string) ([]byte, bool) {
+	count, err := n.Children.Len(pack)
+	if err != nil {
+		return nil, false
+	}
+	for i := 0; i < count; i++ {
+		var entry treestore.TreeEntry
+		if _, err := n.Children.ValueByIndex(pack, i, &entry); err != nil {
+			continue
+		}
+		if entry.Name == name && len(entry.Leaf) > 0 {
+			return entry.Leaf, true
+		}
+	}
+	return nil, false
+}

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -103,6 +103,19 @@ type EntityCommon struct {
 	setSessionCallback func(ctx context.Context) error
 	delSessionCallback func(ctx context.Context) error
 
+	// entryPublishHook, when set, is invoked with the freshly-registered
+	// client entry after each successful discovery registration (the POST or
+	// PUT that dmsg-discovery accepted). The visor uses it to mirror the
+	// canonical entry onto a CXO feed (registration-over-CXO) so quiet
+	// visors need not re-PUT over dmsg on a timer — each such PUT is a fresh
+	// Noise+PQ handshake and those dominate dmsg-discovery CPU. The hook
+	// receives the entry with its authoritative Sequence/Signature (PutEntry
+	// mutates them in place), so a CXO subscriber can ingest it verbatim.
+	// This package cannot import CXO (CXO imports dmsg — cycle), hence the
+	// callback. Nil for servers and clients that do not opt in; fired at most
+	// once per successful update, for the primary discovery only.
+	entryPublishHook atomic.Pointer[EntryPublishFunc]
+
 	// peerSessionsFunc returns peer server sessions for mesh forwarding.
 	// Only set on Server entities; nil for clients.
 	peerSessionsFunc func() []*SessionCommon
@@ -773,6 +786,38 @@ func (c *EntityCommon) initilizeClientEntry(ctx context.Context, clientType stri
 	return firstErr
 }
 
+// EntryPublishFunc receives a copy of the client's discovery entry each time it
+// is successfully (re)registered with the primary discovery. See
+// EntityCommon.SetEntryPublishHook and entryPublishHook.
+type EntryPublishFunc = func(*disc.Entry)
+
+// SetEntryPublishHook installs (or, with nil, clears) a callback invoked with
+// the client's canonical discovery entry after each successful registration
+// with the primary discovery. Used by the visor to mirror the entry onto a CXO
+// feed. Safe to call concurrently with the entry-update loop.
+//
+// The hook runs synchronously on the entry-update goroutine, so it MUST NOT
+// block — a well-behaved installer only hands the entry to a batched/async
+// sink (e.g. treestore.Publisher.Put, which coalesces into the next
+// BatchWindow tick) and returns immediately.
+func (c *EntityCommon) SetEntryPublishHook(fn EntryPublishFunc) {
+	if fn == nil {
+		c.entryPublishHook.Store(nil)
+		return
+	}
+	c.entryPublishHook.Store(&fn)
+}
+
+// fireEntryPublishHook invokes the installed publish hook, if any, with entry.
+func (c *EntityCommon) fireEntryPublishHook(entry *disc.Entry) {
+	if entry == nil {
+		return
+	}
+	if fn := c.entryPublishHook.Load(); fn != nil {
+		(*fn)(entry)
+	}
+}
+
 func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}, clientType string) (err error) {
 	if isClosed(done) {
 		return nil
@@ -830,8 +875,10 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 	if isClosed(done) {
 		return nil
 	}
-	for _, ep := range endpoints {
-		if updateErr := c.updateClientEntryOnEndpoint(ctx, ep, clientType, srvPKs, mustPublish); updateErr != nil {
+	var publishedEntry *disc.Entry
+	for i, ep := range endpoints {
+		entry, updateErr := c.updateClientEntryOnEndpoint(ctx, ep, clientType, srvPKs, mustPublish)
+		if updateErr != nil {
 			if firstErr == nil {
 				firstErr = updateErr
 			}
@@ -839,6 +886,17 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 			continue
 		}
 		anyOK = true
+		// Mirror only the PRIMARY discovery's entry onto the CXO feed:
+		// sequences are per-discovery, and the primary (endpoints[0], ==
+		// c.dc) is the canonical one. entry is nil when nothing was written
+		// (short-circuit), in which case we don't disturb the CXO feed —
+		// the publisher's heartbeat keeps it warm without a re-publish.
+		if i == 0 {
+			publishedEntry = entry
+		}
+	}
+	if publishedEntry != nil {
+		c.fireEntryPublishHook(publishedEntry)
 	}
 	if anyOK {
 		c.recordUpdate()
@@ -870,7 +928,13 @@ func (c *EntityCommon) updateClientEntry(ctx context.Context, done chan struct{}
 // (UpdateInterval, 5 min for clients) came round. Callers pass mustPublish for
 // the first publish only, so the steady-state suppression that keeps reconnect
 // storms off the discovery is unaffected.
-func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, clientType string, srvPKs []cipher.PubKey, mustPublish bool) error {
+// updateClientEntryOnEndpoint (re)registers this client's entry with a single
+// discovery endpoint. On a successful POST/PUT it returns the canonical entry
+// that dmsg-discovery accepted (Sequence/Signature authoritative — PutEntry
+// mutates them in place); it returns (nil, nil) when no update was needed and
+// (nil, err) on failure. The caller uses the returned entry to mirror the
+// registration onto a CXO feed for the primary discovery only.
+func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *discoveryEndpoint, clientType string, srvPKs []cipher.PubKey, mustPublish bool) (*disc.Entry, error) {
 	entry, err := ep.Client.Entry(ctx, c.pk)
 	if err != nil {
 		// Only register a fresh sequence-0 entry when the entry is
@@ -879,14 +943,17 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 		// entry is rejected 422 "not old + 1". Return the error and let the
 		// update loop retry on the next tick.
 		if !isEntryNotFound(err) {
-			return err
+			return nil, err
 		}
 		entry = disc.NewClientEntry(c.pk, 0, srvPKs)
 		entry.ClientType = clientType
 		if err := entry.Sign(c.sk); err != nil {
-			return err
+			return nil, err
 		}
-		return ep.Client.PostEntry(ctx, entry)
+		if err := ep.Client.PostEntry(ctx, entry); err != nil {
+			return nil, err
+		}
+		return entry, nil
 	}
 
 	// The entry might be a server entry (e.g., debug client running on a dmsg server).
@@ -895,9 +962,12 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 		entry = disc.NewClientEntry(c.pk, 0, srvPKs)
 		entry.ClientType = clientType
 		if err := entry.Sign(c.sk); err != nil {
-			return err
+			return nil, err
 		}
-		return ep.Client.PostEntry(ctx, entry)
+		if err := ep.Client.PostEntry(ctx, entry); err != nil {
+			return nil, err
+		}
+		return entry, nil
 	}
 
 	// Whether the client's CURRENT delegated servers is the same as what would be advertised.
@@ -906,13 +976,16 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 	// No update is needed if delegated servers has no delta, an entry update is
 	// not due, and this is not the client's first publish.
 	if _, due := c.updateIsDue(); sameSrvPKs && !due && !mustPublish {
-		return nil
+		return nil, nil
 	}
 
 	entry.ClientType = clientType
 	entry.Client.DelegatedServers = srvPKs
 	c.log.WithField("entry", entry).Debug("Updating entry.\n")
-	return ep.Client.PutEntry(ctx, c.sk, entry)
+	if err := ep.Client.PutEntry(ctx, c.sk, entry); err != nil {
+		return nil, err
+	}
+	return entry, nil
 }
 
 // entryUpdateDebounce is how long to wait after a nudge before updating

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -52,6 +52,12 @@ type Deployment struct {
 	// hypervisors with their embedded dmsg server enabled — see
 	// LANDmsgServerInfo.DiscoveryURL.
 	HypervisorDiscovery string `json:"hypervisor_discovery,omitempty"`
+
+	// RegistrationCXO opts this visor into publishing its own signed
+	// discovery entry as a CXO feed to this deployment's dmsg-discovery
+	// (registration-over-CXO), in addition to the HTTP PUT. See the
+	// DmsgConfig.RegistrationCXO mirror field. Experimental; default false.
+	RegistrationCXO bool `json:"registration_cxo,omitempty"`
 }
 
 // DmsgConfig is the visor-side dmsg subsystem configuration.
@@ -94,6 +100,15 @@ type DmsgConfig struct {
 	// rewards-eligible), a stealthy leaf reaching only statically-known
 	// services/servers. Experimental; default stays discovery.
 	DirectOnly bool `json:"direct_only,omitempty"`
+
+	// RegistrationCXO opts this visor into publishing its own signed
+	// discovery entry as a CXO feed (registration-over-CXO) IN ADDITION to
+	// the HTTP PUT, letting dmsg-discovery ingest registrations off a
+	// persistent connection instead of a timer-driven re-PUT (each a fresh
+	// Noise+PQ handshake). Experimental; default false. Inert unless the
+	// target dmsg-discovery also runs the registration aggregator, so it is
+	// safe to enable ahead of the server rollout.
+	RegistrationCXO bool `json:"registration_cxo,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under
@@ -120,6 +135,7 @@ func (c *DmsgConfig) mirrorPrimary() {
 	c.Protocol = d.Protocol
 	c.LANServers = d.LANServers
 	c.HypervisorDiscovery = d.HypervisorDiscovery
+	c.RegistrationCXO = d.RegistrationCXO
 }
 
 // toDeployment snapshots the legacy top-level fields into a Deployment.
@@ -133,6 +149,7 @@ func (c *DmsgConfig) toDeployment() Deployment {
 		Protocol:             c.Protocol,
 		LANServers:           c.LANServers,
 		HypervisorDiscovery:  c.HypervisorDiscovery,
+		RegistrationCXO:      c.RegistrationCXO,
 	}
 }
 

--- a/pkg/services/dmsgdisc/config.go
+++ b/pkg/services/dmsgdisc/config.go
@@ -76,6 +76,15 @@ type Config struct {
 	PProfMode string `json:"pprof_mode,omitempty"`
 	PProfAddr string `json:"pprof_addr,omitempty"`
 
+	// RegistrationCXO enables the registration-over-CXO aggregator: a CXO
+	// node on DmsgDMSGDRegistrationCXOPort that visors (opted in via their
+	// own dmsg.registration_cxo) publish their signed entry to and announce
+	// to, letting the discovery ingest registrations off a persistent
+	// connection instead of the timer-driven HTTP PUT (each a fresh Noise +
+	// PQ handshake). HTTP PUT remains the fallback; ingest is idempotent.
+	// Experimental; default false. Requires a dmsg-capable mode (a SecKey).
+	RegistrationCXO bool `json:"registration_cxo,omitempty"`
+
 	// DmsgServers is the static dmsg-server transit set the
 	// discovery preloads at startup. Replaces the runtime read of
 	// deployment.Prod.DmsgServers — operators ship a config file

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -37,12 +37,14 @@ import (
 	"github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/dmsg/disc/metrics"
 	"github.com/skycoin/skywire/pkg/dmsg/discovery/api"
+	"github.com/skycoin/skywire/pkg/dmsg/discovery/regcxo"
 	"github.com/skycoin/skywire/pkg/dmsg/discovery/store"
 	dmsg "github.com/skycoin/skywire/pkg/dmsg/dmsg"
 	"github.com/skycoin/skywire/pkg/dmsg/dmsghttp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/metricsutil"
 	"github.com/skycoin/skywire/pkg/services"
+	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/svcmode"
 )
 
@@ -284,6 +286,27 @@ func (s *service) runDMSG(
 			<-ctx.Done()
 			pub.Close() //nolint:errcheck,gosec
 		}()
+	}
+
+	// Registration-over-CXO aggregator: opt-in fan-in path where visors
+	// publish their signed entry as a CXO feed instead of re-PUTting it
+	// over HTTP on a timer. Needs the dmsg client; the API is the Sink
+	// (IngestEntryFromCXO). Best-effort — HTTP registration is unaffected
+	// if it fails to start.
+	if cfg.RegistrationCXO && dmsgDC != nil {
+		agg, aerr := regcxo.New(dmsgDC, a, regcxo.Config{Logger: log})
+		if aerr != nil {
+			log.WithError(aerr).Error("Failed to start registration-over-CXO aggregator, continuing without it")
+		} else {
+			agg.Run(ctx)
+			go func() {
+				<-ctx.Done()
+				agg.Close() //nolint:errcheck,gosec
+			}()
+			log.WithField("feed_pk", agg.FeedPK()).
+				WithField("port", skyenv.DmsgDMSGDRegistrationCXOPort).
+				Info("Registration-over-CXO aggregator running")
+		}
 	}
 
 	return nil

--- a/pkg/skyenv/ports_test.go
+++ b/pkg/skyenv/ports_test.go
@@ -37,6 +37,7 @@ func TestVisorPortsAreUnique(t *testing.T) {
 		"DmsgSDServicesCXOPort":           DmsgSDServicesCXOPort,
 		"DmsgDMSGDClientsByServerCXOPort": DmsgDMSGDClientsByServerCXOPort,
 		"DmsgTPDAllTransportsCXOPort":     DmsgTPDAllTransportsCXOPort,
+		"DmsgDMSGDRegistrationCXOPort":    DmsgDMSGDRegistrationCXOPort,
 		"DmsgWebRTCSignalPort":            DmsgWebRTCSignalPort,
 		"SkychatVoiceSignalPort":          SkychatVoiceSignalPort,
 		"SkychatVoiceMediaPort":           SkychatVoiceMediaPort,

--- a/pkg/skyenv/skyenv.go
+++ b/pkg/skyenv/skyenv.go
@@ -108,6 +108,19 @@ const (
 	// subscribe to one TPD feed without dragging in the others.
 	DmsgTPDAllTransportsCXOPort uint16 = 55
 
+	// DmsgDMSGDRegistrationCXOPort is the dmsg port the dmsg-discovery's CXO
+	// client-entry REGISTRATION aggregator binds (and each visor's entry
+	// publisher binds for the reverse subscribe). A visor publishes its own
+	// signed disc.Entry as a CXO feed here and announces to dmsg-disc, which
+	// subscribes back and ingests the entry — moving registration off the
+	// timer-driven HTTP PUT (each a fresh Noise+PQ handshake) that dominates
+	// dmsg-discovery CPU. Distinct from DmsgCXOPort (50, the visor's telemetry
+	// publisher) so the entry feed runs on its own CXO node without colliding
+	// with the stats listener on the same visor. Numbered 67 (not adjacent to
+	// the 50–55 CXO block) because 56 is DmsgWebRTCSignalPort; the value only
+	// needs to be collision-free, which the ports_test guards.
+	DmsgDMSGDRegistrationCXOPort uint16 = 67
+
 	// DmsgWebRTCSignalPort is the dmsg port the WebRTC carrier exchanges its SDP
 	// offer/answer + ICE candidates on (a visor dials a peer here to open a
 	// signaling stream; the answerer listens). It MUST live in this registry: it

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -149,6 +149,9 @@ var (
 	voiceMod vinit.Module
 	// coinNodesMod forwards + advertises configured fibercoin nodes
 	coinNodesMod vinit.Module
+	// regCXOMod publishes this visor's discovery entry as a CXO feed
+	// (registration-over-CXO) when opted in
+	regCXOMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
 	// config initialization
@@ -258,8 +261,14 @@ func registerModules(logger *logging.MasterLogger) {
 	// dmsg + health-gated type=coin SD registration. Depends on dmsgC (forward
 	// + SD dmsg client) and skyFwd (dmsg forwarder). See init_coinnode.go.
 	coinNodesMod = maker("coin_nodes", initCoinNodes, &dmsgC, &skyFwd)
+	// Registration-over-CXO publisher: when opted in (Dmsg.RegistrationCXO),
+	// mirror this visor's signed discovery entry onto a CXO feed that
+	// dmsg-discovery aggregates, off the timer-driven HTTP re-PUT. Depends on
+	// dmsgC (the entry it publishes + the feed's transport). See
+	// init_registration_cxo.go.
+	regCXOMod = maker("registration_cxo", initRegistrationCXO, &dmsgC)
 	vis = vinit.MakeModule("visor", vinit.DoNothing, logger, &ebc, &ar, &disc, &ptyModule,
-		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod)
+		&tr, &rt, &launch, &cli, &hvs, &ut, &pv, &pvs, &trs, &stcpC, &stcprC, &quicC, &wsC, &wtC, &skyFwd, &pi, &dmsgPi, &dmsgServerLatency, &systemSurvey, &tc, &tpdco, &embTPS, &embRouteSetup, &embDmsgWeb, &embFwdProxy, &embSkynetWeb, &meshProxy, &embSkymailBridge, &uiServer, &nodeHealth, &selfProbe, &skynetPorts, &statsMod, &cxoUserFeedsMod, &pairingMod, &groupingMod, &voiceMod, &coinNodesMod, &regCXOMod)
 
 	// Hypervisor includes the full visor module tree so all services
 	// (CLI, transports, pings, public visor, etc.) run in hypervisor mode.

--- a/pkg/visor/init_registration_cxo.go
+++ b/pkg/visor/init_registration_cxo.go
@@ -1,0 +1,109 @@
+// Package visor pkg/visor/init_registration_cxo.go c3-vis-core
+//
+// Registration-over-CXO publisher. When the visor opts in
+// (Dmsg.RegistrationCXO), it publishes its own signed discovery entry as
+// a CXO feed on DmsgDMSGDRegistrationCXOPort and announces to the
+// deployment's dmsg-discovery, which subscribes back and ingests the
+// entry. This moves client-entry registration off the timer-driven HTTP
+// PUT — each a fresh dmsg stream with a full Noise + post-quantum
+// handshake, the load that dominates dmsg-discovery CPU — onto a
+// persistent CXO connection kept warm by the treestore heartbeat.
+//
+// The entry is published verbatim from the dmsg client's canonical
+// registration path (see EntityCommon.SetEntryPublishHook): the same
+// bytes, sequence and signature dmsg-discovery accepts over HTTP, so the
+// CXO ingest is a drop-in mirror. HTTP PUT is kept alongside as the
+// fallback, so this is safe to enable ahead of the server-side
+// aggregator rollout — it is simply inert until a dmsg-discovery
+// subscribes to the feed.
+package visor
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cxo/treestore"
+	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
+	"github.com/skycoin/skywire/pkg/logging"
+	"github.com/skycoin/skywire/pkg/skyenv"
+)
+
+// registrationEntryPath is the single CXO leaf path the visor publishes
+// its discovery entry at. The dmsg-discovery aggregator reads this leaf,
+// unmarshals a disc.Entry, and ingests it. One leaf per feed (feed PK =
+// visor PK = entry.Static), so there is never more than this one value.
+const registrationEntryPath = "entry"
+
+// registrationBatchWindow coalesces entry mutations into the CXO
+// datastore. Registrations change rarely (only when the delegated-server
+// set changes), so a short window adds no latency while still batching
+// the startup burst of session establishes into one publish.
+const registrationBatchWindow = 5 * time.Second
+
+func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error {
+	if v.conf.Dmsg == nil || !v.conf.Dmsg.RegistrationCXO {
+		log.Debug("Registration-CXO: not opted in (dmsg.registration_cxo=false); skipping")
+		return nil
+	}
+	if v.dmsgC == nil {
+		log.Warn("Registration-CXO: dmsg client absent; publisher not started")
+		return nil
+	}
+	// The whole point is to announce to dmsg-discovery so it subscribes
+	// back. Without a dmsg:// discovery PK there is no announce target, so
+	// the feed would never be consumed — skip rather than run an orphan
+	// publisher.
+	dmsgdPK, ok := dmsgdCXOPeer(v)
+	if !ok {
+		log.Warn("Registration-CXO: no dmsg.discovery_dmsg PK; cannot announce to dmsg-discovery; skipping")
+		return nil
+	}
+
+	dataDir := filepath.Join(v.conf.LocalPath, "cxo-registration")
+	pub, err := treestore.NewWithDMSG(v.dmsgC, v.conf.SK, treestore.PubConfig{
+		DmsgPort:    skyenv.DmsgDMSGDRegistrationCXOPort,
+		BatchWindow: registrationBatchWindow,
+		Logger:      log,
+		DataDir:     dataDir,
+		// The entry is content-addressed and rebuilt from the dmsg client's
+		// live registration on every restart, so skipping per-tx fdatasync
+		// is safe (matches the telemetry publisher).
+		NoSyncCXDS: true,
+	})
+	if err != nil {
+		log.WithError(err).Warn("Registration-CXO: publisher init failed; continuing with HTTP registration only")
+		return nil
+	}
+
+	// Mirror every successful primary-discovery registration onto the feed.
+	// The hook runs on the dmsg entry-update goroutine and must not block;
+	// Put coalesces into the next BatchWindow tick, so it returns at once.
+	v.dmsgC.SetEntryPublishHook(func(entry *dmsgdisc.Entry) {
+		b, mErr := json.Marshal(entry)
+		if mErr != nil {
+			log.WithError(mErr).Debug("Registration-CXO: marshal entry failed")
+			return
+		}
+		if pErr := pub.Put(registrationEntryPath, b); pErr != nil {
+			log.WithError(pErr).Debug("Registration-CXO: CXO Put failed")
+		}
+	})
+
+	// Dial dmsg-discovery so its aggregator sees the inbound conn and
+	// subscribes to our feed (PK = our PK). ConnectPK is idempotent, so the
+	// same loop handles initial announce + reconnect. Reuses the telemetry
+	// announce loop (identical shape).
+	go runAnnounceLoop(v.ctx, pub, dmsgdPK, log)
+
+	v.pushCloseStack("registration_cxo", func() error {
+		v.dmsgC.SetEntryPublishHook(nil)
+		return pub.Close()
+	})
+
+	log.WithField("feed_pk", pub.Feed()).WithField("dmsgd_pk", dmsgdPK).
+		WithField("port", skyenv.DmsgDMSGDRegistrationCXOPort).
+		Info("Registration-CXO: publisher running (entry mirrored to dmsg-discovery)")
+	return nil
+}


### PR DESCRIPTION
## Why

dmsg client-entry **registration** rides periodic HTTP-over-dmsg `PUT`s to dmsg-discovery. Each PUT is a fresh dmsg stream with a full Noise + post-quantum (ML-KEM-768) handshake, and fleet-wide these dominate dmsg-discovery CPU (measured ~90%, ~55% in GC on the handshake path). This moves registration onto a **persistent CXO feed** kept warm by the quiet-feed heartbeat (#3826): a visor registers once and re-publishes only when its delegated-server set actually changes — no timer-driven re-PUT, no periodic handshake. Mirrors the telemetry→TPD fan-in.

**Opt-in and default-off on both ends; HTTP PUT stays as the fallback**, so a visor and a dmsg-discovery can be migrated independently and the CXO ingest is idempotent against the HTTP path.

## What's here (end to end)

**RFC** — `docs/design/dmsg-bootstrap-floor.md` gains the registration-over-CXO design (fan-in publish, idempotent aggregate/ingest, HTTP fallback, measure-first/configurable lookup).

**The seam** (`pkg/dmsg/dmsg`) — `EntityCommon.SetEntryPublishHook`: a callback fired with the client's *canonical* entry (authoritative `Sequence`/`Signature`, since `PutEntry` mutates them in place) after each successful registration with the **primary** discovery. `pkg/dmsg` can't import CXO (cycle), so the visor installs the hook.

**Visor publisher** (`pkg/visor/init_registration_cxo.go`, opt-in `dmsg.registration_cxo`) — publishes the entry as a single-leaf CXO feed on the new `DmsgDMSGDRegistrationCXOPort` (67) and announces to the deployment's dmsg-discovery, reusing the telemetry announce loop.

**dmsg-disc aggregator** (`pkg/dmsg/discovery/regcxo`, opt-in `registration_cxo`) — a CXO node modeled on the proven TPD `cxoaggregator` (connect-driven subscribe + grace-gated orphan-feed reclaim), trimmed to the one `entry` leaf. A `Sink` interface keeps the heavy CXO-node deps out of the api package.

**Idempotent ingest** (`pkg/dmsg/discovery/api/IngestEntryFromCXO`) — mirrors `setEntry`'s validation + side effects (`SetEntry`, DHT mirror, clients-by-server fan-out, uptime heartbeat) but treats a **stale-or-equal sequence as a silent no-op**, so HTTP+CXO dual-write never conflicts (`ValidateIteration` requires *strictly* greater, so whichever path lands first wins and the other skips). A visor may only publish its **own** client entry (`reporter == entry.Static`; server entries rejected). Deliberately duplicated rather than refactored out of the hot HTTP path. Unit-tested: insert / idempotent-skip / stale-drop / foreign-reporter / bad-signature.

## Config

- Visor: `dmsg.registration_cxo` (per-deployment; round-trips like the other deployment fields).
- dmsg-discovery: `registration_cxo` (needs a dmsg-capable mode).

Both default false. `DmsgDMSGDRegistrationCXOPort = 67` (distinct from the visor's telemetry publisher on 50; 56 is WebRTC), guarded by the ports uniqueness test.

Builds clean (`go build .`), `go vet` clean, new packages tested. No AI attribution.