### PR TITLE
feat(dmsg): registration-over-CXO always-on + HTTP keepalive stretch (follow-up to #3828)

### DIFF
--- a/pkg/dmsg/discovery/api/registration_ingest.go
+++ b/pkg/dmsg/discovery/api/registration_ingest.go
@@ -29,7 +29,7 @@ import (
 // finds the store already at that sequence. Keep this in sync with
 // (*API).setEntry — deliberately duplicated (not refactored out of the
 // hot HTTP path) to keep this additive, opt-in path from touching
-// production registration behaviour.
+// production registration behavior.
 func (a *API) IngestEntryFromCXO(ctx context.Context, entry *disc.Entry, reporter cipher.PubKey) {
 	if entry == nil {
 		return
@@ -73,9 +73,23 @@ func (a *API) IngestEntryFromCXO(ctx context.Context, entry *disc.Entry, reporte
 		log.WithError(err).WithField("reporter", reporter).Debug("registration-cxo: store lookup failed")
 		return
 	}
-	// Idempotent: we already hold this (or a newer) entry — the HTTP path or
-	// an earlier Root already applied it. Not an error.
-	if entry.Sequence <= old.Sequence {
+	// Stale: we already hold a strictly newer entry — never roll back.
+	if entry.Sequence < old.Sequence {
+		return
+	}
+	// Equal sequence = the feed's periodic no-change heartbeat. The content
+	// didn't change, so there's nothing to re-mirror, but this is precisely
+	// the signal that replaces the HTTP keepalive re-PUT: refresh the stored
+	// entry's TTL (and the uptime heartbeat) off the STORED entry so the
+	// visor's registration stays alive without a Noise+PQ handshake. Refresh
+	// off `old`, not the incoming entry, so an equal-sequence body we can't
+	// distinguish from the canonical one can never overwrite it.
+	if entry.Sequence == old.Sequence {
+		if e := a.db.SetEntry(ctx, old, a.clientEntryTTL); e != nil {
+			log.WithError(e).WithField("reporter", reporter).Debug("registration-cxo: TTL refresh failed")
+			return
+		}
+		_ = a.db.RecordHeartbeat(ctx, old.Static, old.ClientType) //nolint:errcheck
 		return
 	}
 	if err := old.ValidateIteration(entry); err != nil {

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -116,6 +116,18 @@ type EntityCommon struct {
 	// once per successful update, for the primary discovery only.
 	entryPublishHook atomic.Pointer[EntryPublishFunc]
 
+	// cxoKeepaliveHealthyFn, when set and returning true, means this CLIENT's
+	// discovery entry is being kept alive over a healthy registration-over-CXO
+	// feed (installed by the visor; see pkg/visor/init_registration_cxo.go).
+	// While true, the periodic NO-CHANGE HTTP keepalive re-registration is
+	// stretched to cxoHealthyUpdateInterval, so the expensive Noise+PQ
+	// handshake fires far less often; that stretched interval stays well under
+	// the dmsg-discovery client-entry TTL, so the HTTP path alone keeps the
+	// entry alive even if CXO ingest silently stalls (fallback), and
+	// delegated-server CHANGES still publish immediately via the nudge path.
+	// Nil on servers and on clients not publishing over CXO.
+	cxoKeepaliveHealthyFn atomic.Pointer[func() bool]
+
 	// peerSessionsFunc returns peer server sessions for mesh forwarding.
 	// Only set on Server entities; nil for clients.
 	peerSessionsFunc func() []*SessionCommon
@@ -1090,8 +1102,15 @@ func (c *EntityCommon) updateClientEntryLoop(ctx context.Context, done chan stru
 			return
 
 		case <-t.C:
-			if lastUpdate, due := c.updateIsDue(); !due {
-				t.Reset(c.updateInterval - time.Since(lastUpdate))
+			if _, due := c.updateIsDue(); !due {
+				// Re-evaluate every base updateInterval rather than sleeping
+				// the full (possibly CXO-stretched) remaining time: this
+				// bounds how long a keepalive stays stretched after the CXO
+				// feed drops (effectiveUpdateInterval falls back to the base
+				// interval the moment cxoKeepaliveHealthyFn goes false), and
+				// avoids a negative Reset when the effective interval exceeds
+				// the base one.
+				t.Reset(c.updateInterval)
 				continue
 			}
 
@@ -1195,8 +1214,39 @@ func getClientEntry(ctx context.Context, dc disc.APIClient, clientPK cipher.PubK
 
 func (c *EntityCommon) updateIsDue() (lastUpdate time.Time, isDue bool) {
 	lastUpdate = time.Unix(0, atomic.LoadInt64(&c.lastUpdate))
-	isDue = time.Since(lastUpdate) >= c.updateInterval
+	isDue = time.Since(lastUpdate) >= c.effectiveUpdateInterval()
 	return lastUpdate, isDue
+}
+
+// cxoHealthyUpdateInterval is the stretched spacing between no-change client
+// discovery re-registrations while a registration-over-CXO keepalive is
+// healthy. Chosen well under the dmsg-discovery client-entry TTL (60m) so the
+// HTTP re-PUT alone keeps the entry alive even if CXO ingest silently stalls,
+// while cutting the periodic Noise+PQ handshake rate by an order of magnitude.
+const cxoHealthyUpdateInterval = 30 * time.Minute
+
+// effectiveUpdateInterval is c.updateInterval, stretched to
+// cxoHealthyUpdateInterval when a registration-over-CXO keepalive reports
+// healthy. Servers and non-CXO clients (nil fn) always get c.updateInterval.
+func (c *EntityCommon) effectiveUpdateInterval() time.Duration {
+	if fn := c.cxoKeepaliveHealthyFn.Load(); fn != nil && (*fn)() {
+		if cxoHealthyUpdateInterval > c.updateInterval {
+			return cxoHealthyUpdateInterval
+		}
+	}
+	return c.updateInterval
+}
+
+// SetCXOKeepaliveHealthyFunc installs (or, with nil, clears) the predicate
+// that reports whether this client's registration-over-CXO keepalive is
+// healthy. See cxoKeepaliveHealthyFn. Safe to call concurrently with the
+// entry-update loop.
+func (c *EntityCommon) SetCXOKeepaliveHealthyFunc(fn func() bool) {
+	if fn == nil {
+		c.cxoKeepaliveHealthyFn.Store(nil)
+		return
+	}
+	c.cxoKeepaliveHealthyFn.Store(&fn)
 }
 
 // updatedWithin reports whether the last discovery-entry update happened within

--- a/pkg/dmsgc/spec/spec.go
+++ b/pkg/dmsgc/spec/spec.go
@@ -52,12 +52,6 @@ type Deployment struct {
 	// hypervisors with their embedded dmsg server enabled — see
 	// LANDmsgServerInfo.DiscoveryURL.
 	HypervisorDiscovery string `json:"hypervisor_discovery,omitempty"`
-
-	// RegistrationCXO opts this visor into publishing its own signed
-	// discovery entry as a CXO feed to this deployment's dmsg-discovery
-	// (registration-over-CXO), in addition to the HTTP PUT. See the
-	// DmsgConfig.RegistrationCXO mirror field. Experimental; default false.
-	RegistrationCXO bool `json:"registration_cxo,omitempty"`
 }
 
 // DmsgConfig is the visor-side dmsg subsystem configuration.
@@ -100,15 +94,6 @@ type DmsgConfig struct {
 	// rewards-eligible), a stealthy leaf reaching only statically-known
 	// services/servers. Experimental; default stays discovery.
 	DirectOnly bool `json:"direct_only,omitempty"`
-
-	// RegistrationCXO opts this visor into publishing its own signed
-	// discovery entry as a CXO feed (registration-over-CXO) IN ADDITION to
-	// the HTTP PUT, letting dmsg-discovery ingest registrations off a
-	// persistent connection instead of a timer-driven re-PUT (each a fresh
-	// Noise+PQ handshake). Experimental; default false. Inert unless the
-	// target dmsg-discovery also runs the registration aggregator, so it is
-	// safe to enable ahead of the server rollout.
-	RegistrationCXO bool `json:"registration_cxo,omitempty"`
 }
 
 // MarshalJSON and UnmarshalJSON live in spec_native.go under
@@ -135,7 +120,6 @@ func (c *DmsgConfig) mirrorPrimary() {
 	c.Protocol = d.Protocol
 	c.LANServers = d.LANServers
 	c.HypervisorDiscovery = d.HypervisorDiscovery
-	c.RegistrationCXO = d.RegistrationCXO
 }
 
 // toDeployment snapshots the legacy top-level fields into a Deployment.
@@ -149,7 +133,6 @@ func (c *DmsgConfig) toDeployment() Deployment {
 		Protocol:             c.Protocol,
 		LANServers:           c.LANServers,
 		HypervisorDiscovery:  c.HypervisorDiscovery,
-		RegistrationCXO:      c.RegistrationCXO,
 	}
 }
 

--- a/pkg/services/dmsgdisc/config.go
+++ b/pkg/services/dmsgdisc/config.go
@@ -76,15 +76,6 @@ type Config struct {
 	PProfMode string `json:"pprof_mode,omitempty"`
 	PProfAddr string `json:"pprof_addr,omitempty"`
 
-	// RegistrationCXO enables the registration-over-CXO aggregator: a CXO
-	// node on DmsgDMSGDRegistrationCXOPort that visors (opted in via their
-	// own dmsg.registration_cxo) publish their signed entry to and announce
-	// to, letting the discovery ingest registrations off a persistent
-	// connection instead of the timer-driven HTTP PUT (each a fresh Noise +
-	// PQ handshake). HTTP PUT remains the fallback; ingest is idempotent.
-	// Experimental; default false. Requires a dmsg-capable mode (a SecKey).
-	RegistrationCXO bool `json:"registration_cxo,omitempty"`
-
 	// DmsgServers is the static dmsg-server transit set the
 	// discovery preloads at startup. Replaces the runtime read of
 	// deployment.Prod.DmsgServers — operators ship a config file

--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -288,12 +288,13 @@ func (s *service) runDMSG(
 		}()
 	}
 
-	// Registration-over-CXO aggregator: opt-in fan-in path where visors
-	// publish their signed entry as a CXO feed instead of re-PUTting it
-	// over HTTP on a timer. Needs the dmsg client; the API is the Sink
-	// (IngestEntryFromCXO). Best-effort — HTTP registration is unaffected
-	// if it fails to start.
-	if cfg.RegistrationCXO && dmsgDC != nil {
+	// Registration-over-CXO aggregator: always-on fan-in path where visors
+	// publish their signed entry as a CXO feed instead of re-PUTting it over
+	// HTTP on a timer. Inert until visors subscribe (just a listener), and
+	// the same aggregator pattern runs at fleet scale in TPD, so it needs no
+	// gate. Needs the dmsg client; the API is the Sink (IngestEntryFromCXO).
+	// Best-effort — HTTP registration is unaffected if it fails to start.
+	if dmsgDC != nil {
 		agg, aerr := regcxo.New(dmsgDC, a, regcxo.Config{Logger: log})
 		if aerr != nil {
 			log.WithError(aerr).Error("Failed to start registration-over-CXO aggregator, continuing without it")

--- a/pkg/visor/init_registration_cxo.go
+++ b/pkg/visor/init_registration_cxo.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
+	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/cxo/treestore"
 	dmsgdisc "github.com/skycoin/skywire/pkg/dmsg/disc"
 	"github.com/skycoin/skywire/pkg/logging"
@@ -43,10 +45,6 @@ const registrationEntryPath = "entry"
 const registrationBatchWindow = 5 * time.Second
 
 func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error {
-	if v.conf.Dmsg == nil || !v.conf.Dmsg.RegistrationCXO {
-		log.Debug("Registration-CXO: not opted in (dmsg.registration_cxo=false); skipping")
-		return nil
-	}
 	if v.dmsgC == nil {
 		log.Warn("Registration-CXO: dmsg client absent; publisher not started")
 		return nil
@@ -93,11 +91,25 @@ func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error
 
 	// Dial dmsg-discovery so its aggregator sees the inbound conn and
 	// subscribes to our feed (PK = our PK). ConnectPK is idempotent, so the
-	// same loop handles initial announce + reconnect. Reuses the telemetry
-	// announce loop (identical shape).
-	go runAnnounceLoop(v.ctx, pub, dmsgdPK, log)
+	// same loop handles initial announce + reconnect. Each success stamps
+	// lastAnnounceOK, which drives the keepalive-health predicate below.
+	lastAnnounceOK := new(atomic.Int64)
+	go runRegistrationAnnounceLoop(v.ctx, pub, dmsgdPK, lastAnnounceOK, log)
+
+	// Tell the dmsg client the CXO registration keepalive is healthy while we
+	// have recently reached dmsg-discovery over the feed conn. While healthy,
+	// the client stretches its periodic HTTP keepalive re-PUT (see
+	// EntityCommon.cxoKeepaliveHealthyFn); if the feed conn drops, announces
+	// stop succeeding and this falls back to false within the window, so the
+	// frequent HTTP keepalive resumes. Delegated-server CHANGES are unaffected
+	// (they publish immediately over both HTTP and CXO).
+	v.dmsgC.SetCXOKeepaliveHealthyFunc(func() bool {
+		last := lastAnnounceOK.Load()
+		return last != 0 && time.Since(time.Unix(0, last)) < cxoKeepaliveHealthyWindow
+	})
 
 	v.pushCloseStack("registration_cxo", func() error {
+		v.dmsgC.SetCXOKeepaliveHealthyFunc(nil)
 		v.dmsgC.SetEntryPublishHook(nil)
 		return pub.Close()
 	})
@@ -106,4 +118,43 @@ func initRegistrationCXO(_ context.Context, v *Visor, log *logging.Logger) error
 		WithField("port", skyenv.DmsgDMSGDRegistrationCXOPort).
 		Info("Registration-CXO: publisher running (entry mirrored to dmsg-discovery)")
 	return nil
+}
+
+// registrationAnnounceInterval is how often the visor pokes its CXO feed conn
+// to dmsg-discovery. Short enough that a recovered visor/dmsg-disc re-links
+// within the health window.
+const registrationAnnounceInterval = 30 * time.Second
+
+// cxoKeepaliveHealthyWindow is how long after the last successful announce the
+// registration-over-CXO keepalive is still considered healthy. ~3 announce
+// intervals of slack, so one missed announce doesn't flap the HTTP-keepalive
+// fallback, while a genuinely dropped feed conn falls back within a minute or
+// two.
+const cxoKeepaliveHealthyWindow = 95 * time.Second
+
+// runRegistrationAnnounceLoop dials dmsg-discovery on a ticker (ConnectPK is
+// idempotent — a live conn is a no-op, a dropped one redials) and stamps
+// lastOK with the wall-clock time of each success. lastOK drives the client's
+// keepalive-health predicate.
+func runRegistrationAnnounceLoop(ctx context.Context, pub *treestore.Publisher, dmsgdPK cipher.PubKey, lastOK *atomic.Int64, log *logging.Logger) {
+	t := time.NewTicker(registrationAnnounceInterval)
+	defer t.Stop()
+	announce := func() {
+		dctx, cancel := context.WithTimeout(ctx, registrationAnnounceInterval/2)
+		defer cancel()
+		if err := pub.AnnounceTo(dctx, dmsgdPK); err != nil {
+			log.WithError(err).WithField("dmsgd_pk", dmsgdPK).Trace("Registration-CXO: announce to dmsg-discovery failed")
+			return
+		}
+		lastOK.Store(time.Now().UnixNano())
+	}
+	announce()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			announce()
+		}
+	}
 }


### PR DESCRIPTION
Follow-up to #3828. Turns registration-over-CXO from an opt-in dual-write foundation into an always-on, real load reduction — and fixes the misspell that reddened #3828's post-merge lint.

## Why no flag

There is one dmsg-discovery, so a server-side flag buys no A/B — enabling it *is* enabling it globally. The aggregator is inert without publishers (just a listener) and the same CXO-aggregator pattern already runs at fleet scale in TPD, so it needs no gate. And with dual-write alone, an opt-in flag only ever gates *added* cost (a second write path) with no payoff. The payoff lives in reducing the HTTP handshake rate, which this PR adds.

## What's here

- **Drop both `registration_cxo` gates → always-on.** Removes `DmsgConfig`/`Deployment.RegistrationCXO` (visor) and `dmsgdisc.Config.RegistrationCXO` (server). Visors always publish their signed-entry feed; dmsg-disc always runs the aggregator.

- **HTTP keepalive stretch — the actual win.** While the visor's CXO announce-conn to dmsg-disc is healthy (`cxoKeepaliveHealthyFn`, driven by announce success within a 95s window), the dmsg client stretches its periodic **no-change** keepalive re-registration from ~1 min to **30 min** (`cxoHealthyUpdateInterval`, well under the 60-min client-entry TTL). That cuts the periodic Noise+PQ handshake rate ~30×. Delegated-server **changes** still publish immediately over both HTTP and CXO; if the feed conn drops, health falls back within the window and the frequent HTTP keepalive resumes. The update timer keeps waking at the base interval, so fallback latency stays low and the not-due `Reset` can't go negative.

- **CXO carries the keepalive.** `IngestEntryFromCXO` now refreshes the stored entry's TTL + uptime heartbeat on an **equal-sequence** Root (the feed's ~45s treestore heartbeat), off the **stored** entry, so registration stays alive over CXO between the rare HTTP re-PUTs. Strictly-stale sequences are still dropped; strictly-newer still fully applied.

- **Fix `behaviour`→`behavior` misspell** in `registration_ingest.go` (the lone lint failure on #3828's merge — this greens develop).

## Safety

Registration can't break: HTTP remains authoritative and, at 30-min re-PUT, keeps the entry alive by itself even if CXO ingest silently stalls (30 < 60-min TTL). Idempotent, first-writer-wins ingest is unchanged.

Builds (`go build .`), `go vet`, and `golangci-lint` clean; ingest unit test green. No AI attribution.