### PR TITLE
build: drop goimports-reviser from make format (unused; churned third_party)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -493,7 +493,7 @@ test-windows: ## Run tests on windows
 install-linters: ## Install linters
 	${OPTS} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	GOPRIVATE=github.com/skycoin/* go get -u
-	${OPTS} go install golang.org/x/tools/cmd/goimports@latest github.com/incu6us/goimports-reviser/v2@latest github.com/FiloSottile/vendorcheck@latest
+	${OPTS} go install golang.org/x/tools/cmd/goimports@latest github.com/FiloSottile/vendorcheck@latest
 
 install-linters-windows: ## Install linters
 	${OPTS} go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest golang.org/x/tools/cmd/goimports@latest
@@ -501,16 +501,15 @@ install-linters-windows: ## Install linters
 tidy: ## Tidies and vendors dependencies.
 	${OPTS} go mod tidy -v
 
-format: tidy ## Formats the code. Must have goimports and goimports-reviser installed (use make install-linters).
+format: tidy ## Formats the code. Must have goimports installed (use make install-linters).
 	@if grep -qE '^(replace|exclude)' go.mod; then \
 		echo "ERROR: go.mod contains replace or exclude directives which break go install @version and Docker builds"; \
 		grep -E '^(replace|exclude)' go.mod; \
 		exit 1; \
 	fi
 	${OPTS} goimports -w -local ${PROJECT_BASE} ./pkg ./cmd ./internal
-	find . -type f -name '*.go' -not -path "./.git/*" -not -path "./vendor/*"  -exec goimports-reviser -project-name ${PROJECT_BASE} {} \;
 
-format-windows: tidy ## Formats the code. Must have goimports and goimports-reviser installed (use make install-linters).
+format-windows: tidy ## Formats the code. Must have goimports installed (use make install-linters).
 	powershell 'Get-ChildItem -Directory | where Name -NotMatch vendor | % { Get-ChildItem $$_ -Recurse -Include *.go } | % {goimports -w -local ${PROJECT_BASE} $$_ }'
 
 dep: tidy ## Sorts dependencies

--- a/third_party/0magnet/websh/shell/awk.go
+++ b/third_party/0magnet/websh/shell/awk.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"strings"
 
-	goawkinterp "github.com/benhoyt/goawk/interp"
-	"github.com/benhoyt/goawk/parser"
 	"github.com/skycoin/skywire/third_party/0magnet/afero"
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/interp"
+	goawkinterp "github.com/benhoyt/goawk/interp"
+	"github.com/benhoyt/goawk/parser"
 )
 
 func init() {

--- a/third_party/0magnet/websh/shell/jq.go
+++ b/third_party/0magnet/websh/shell/jq.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/itchyny/gojq"
 	"github.com/skycoin/skywire/third_party/0magnet/afero"
 	"github.com/skycoin/skywire/third_party/0magnet/sh/v3/interp"
+	"github.com/itchyny/gojq"
 )
 
 func init() {


### PR DESCRIPTION
`goimports-reviser` isn't enforced anywhere and only causes harm:

- **Not enforced.** golangci-lint's only import/format check is `gofmt` (no `gci`/`goimports`/`gofumpt` linter is enabled in `.golangci.yml`); it isn't run by `make check` or any CI gate; and `make format-windows` already omits it (Windows contributors have formatted without it all along).
- **Redundant.** `make format` runs `goimports -w -local ${PROJECT_BASE}` immediately before it, which already does the same std/third-party/local grouping (plus import add/remove). `goimports-reviser -project-name` on top is duplicate work — a leftover from when the local-org import prefix was in flux (org move and back).
- **Harmful.** It's the only step that runs over the whole tree (`find . -exec`), so it's the sole reason imports in the vendored `third_party/0magnet/*` copies got reordered — manufacturing spurious divergence from the upstream 0magnet source of truth — and it's what makes `make format` slow.

Remove it from the `format` target and `install-linters`. `make format` is now `goimports -w -local ${PROJECT_BASE} ./pkg ./cmd ./internal`, matching `format-windows`. Also restore the two vendored files it had drifted (`third_party/0magnet/websh/shell/awk.go`, `jq.go`) to upstream import order.

Supersedes the original "exclude third_party from the reviser" approach — removing the unused tool is strictly better than working around it. Dev-tooling only; no runtime change. Import formatting the repo depends on (gofmt) is unaffected.