### PR TITLE
dmsg-disc: reconcile server sessions against the live registry (self-heal address drift)

### DIFF
--- a/pkg/services/dmsgdisc/dmsgdisc.go
+++ b/pkg/services/dmsgdisc/dmsgdisc.go
@@ -251,9 +251,7 @@ func (s *service) runDMSG(
 	// server disc is already connected to). Distinct from updateServers,
 	// which resolves from the redis store — empty at cold-start, so it can
 	// never bootstrap an empty deployment on its own.
-	go connectConfiguredServers(ctx, servers, dClient, dmsgDC, log)
-
-	go updateServers(ctx, a, dClient, dmsgDC, cfg.DmsgServerType, log)
+	go connectConfiguredServers(ctx, servers, a, dClient, dmsgDC, cfg.DmsgServerType, log)
 
 	wl := deployment.Prod.SurveyWhitelist
 	if cfg.TestEnvironment {
@@ -395,25 +393,37 @@ func pollServersUntilFound(ctx context.Context, a *api.API, dmsgServerType strin
 // still unreachable, then steady 30s maintenance so dropped sessions are
 // re-established promptly. EnsureSession is idempotent — already-connected
 // servers cost a cheap map check.
-func connectConfiguredServers(ctx context.Context, servers []*disc.Entry, dClient disc.APIClient, dmsgC *dmsg.Client, log logrus.FieldLogger) {
+func connectConfiguredServers(ctx context.Context, servers []*disc.Entry, a *api.API, dClient disc.APIClient, dmsgC *dmsg.Client, dmsgServerType string, log logrus.FieldLogger) {
 	const minInterval, maxInterval = time.Second, 30 * time.Second
 	interval := minInterval
 	for {
+		// A direct-client service must hold a session to EVERY dmsg server to be
+		// equally reachable (a client relaying through a server the disc is NOT on
+		// gets "dmsg error 202 - cannot connect to delegated server"). So each tick
+		// reconcile the dial set against the LIVE registry, not just the static
+		// config: dial the UNION of the static/embedded seed set and every
+		// registered server, with the REGISTERED address winning per PK. This
+		// self-heals server address drift — a stale configured port would otherwise
+		// silently drop a server forever — and picks up servers that register after
+		// cold-start. The static set is the cold-start floor: the registry is empty
+		// until the first server registers, so it can't bring an empty deployment
+		// up on its own. (Folds in the old 10-minute updateServers loop.)
+		set := reconcileServerSet(ctx, servers, a, dmsgServerType, log)
 		connected := 0
-		for _, server := range servers {
+		for _, server := range set {
 			dClient.PostEntry(ctx, server) //nolint:errcheck,gosec
 			if err := dmsgC.EnsureSession(ctx, server); err != nil {
 				log.WithField("remote_pk", server.Static).WithError(err).
-					Debug("dmsg-disc: dialing configured dmsg-server")
+					Debug("dmsg-disc: dialing dmsg-server")
 				continue
 			}
 			connected++
 		}
-		if connected == len(servers) {
+		if connected == len(set) {
 			interval = maxInterval // fully connected: drop to maintenance cadence
 		} else {
-			log.WithField("connected", connected).WithField("total", len(servers)).
-				Info("dmsg-disc: bootstrapping configured dmsg-server sessions")
+			log.WithField("connected", connected).WithField("total", len(set)).
+				Info("dmsg-disc: maintaining dmsg-server sessions")
 			if interval < maxInterval {
 				if interval *= 2; interval > maxInterval {
 					interval = maxInterval
@@ -428,36 +438,42 @@ func connectConfiguredServers(ctx context.Context, servers []*disc.Entry, dClien
 	}
 }
 
-// updateServers periodically re-resolves the dmsg-server transit set
-// and re-establishes sessions to anything new. Was the original
-// runtime sync mechanism before the embedded keyring + config-file
-// preload landed; kept for the case where new servers register after
-// startup.
-func updateServers(ctx context.Context, a *api.API, dClient disc.APIClient, dmsgC *dmsg.Client, dmsgServerType string, log logrus.FieldLogger) {
-	ticker := time.NewTicker(10 * time.Minute)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			servers, err := a.AllServers(ctx, log)
-			if err != nil {
-				log.WithError(err).Error("error getting dmsg-servers")
-				continue
-			}
-			if dmsgServerType != "" {
-				servers = filterServersByType(servers, dmsgServerType)
-			}
-			for _, server := range servers {
-				dClient.PostEntry(ctx, server) //nolint:errcheck,gosec
-				if err := dmsgC.EnsureSession(ctx, server); err != nil {
-					log.WithField("remote_pk", server.Static).WithError(err).
-						Warn("failed to establish session")
-				}
-			}
+// reconcileServerSet merges the static/embedded seed servers with the live
+// registry (AllServers), deduped by PK, with the REGISTERED entry winning so
+// each server's CURRENT address is dialed even when the static config has
+// drifted. A registry-fetch error degrades to the static seed set for that tick
+// (cold-start, before anything has registered, or a transient registry blip).
+func reconcileServerSet(ctx context.Context, static []*disc.Entry, a *api.API, dmsgServerType string, log logrus.FieldLogger) []*disc.Entry {
+	reg, err := a.AllServers(ctx, log)
+	if err != nil {
+		log.WithError(err).Debug("dmsg-disc: registry fetch failed; using static seed set this tick")
+		reg = nil
+	} else if dmsgServerType != "" {
+		reg = filterServersByType(reg, dmsgServerType)
+	}
+	return mergeServersByPK(static, reg)
+}
+
+// mergeServersByPK unions the static seed set with the registered set, deduped
+// by PK, with a registered entry (current address) winning over a static one.
+// Pure — unit-tested.
+func mergeServersByPK(static, registered []*disc.Entry) []*disc.Entry {
+	byPK := make(map[cipher.PubKey]*disc.Entry, len(static)+len(registered))
+	for _, s := range static {
+		if s != nil {
+			byPK[s.Static] = s
 		}
 	}
+	for _, s := range registered {
+		if s != nil && s.Server != nil {
+			byPK[s.Static] = s // registered (current) address wins over static config
+		}
+	}
+	out := make([]*disc.Entry, 0, len(byPK))
+	for _, s := range byPK {
+		out = append(out, s)
+	}
+	return out
 }
 
 func filterServersByType(in []*disc.Entry, dmsgServerType string) []*disc.Entry {

--- a/pkg/services/dmsgdisc/dmsgdisc_test.go
+++ b/pkg/services/dmsgdisc/dmsgdisc_test.go
@@ -157,19 +157,20 @@ func TestPollServersUntilFound_Found(t *testing.T) {
 	require.Equal(t, srvPK, out[0].Static)
 }
 
-func TestUpdateServers_CtxCanceled(t *testing.T) {
+func TestConnectConfiguredServers_CtxCanceled(t *testing.T) {
 	a := newMockAPI(t)
-	// Returns immediately on a canceled ctx (the 10-minute ticker never
-	// fires). Just must not block or panic.
+	// With a canceled ctx and no servers (mock store empty, no static seed) the
+	// maintenance loop reconciles to an empty set and returns on the first select
+	// instead of waiting out the interval. Must not block or panic.
 	done := make(chan struct{})
 	go func() {
-		updateServers(canceledCtx(), a, nil, nil, "", testLog())
+		connectConfiguredServers(canceledCtx(), nil, a, nil, nil, "", testLog())
 		close(done)
 	}()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("updateServers did not return on canceled ctx")
+		t.Fatal("connectConfiguredServers did not return on canceled ctx")
 	}
 }
 

--- a/pkg/services/dmsgdisc/reconcile_test.go
+++ b/pkg/services/dmsgdisc/reconcile_test.go
@@ -1,0 +1,78 @@
+// Package dmsgdisc reconcile_test.go: unit tests for mergeServersByPK, the pure
+// static-config ∪ live-registry reconciliation that keeps the discovery's
+// dmsg-server session set current (registered address wins over drifted config).
+package dmsgdisc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/dmsg/disc"
+)
+
+func srvEntry(t *testing.T, addr string) *disc.Entry {
+	t.Helper()
+	pk, _ := cipher.GenerateKeyPair()
+	return &disc.Entry{Static: pk, Server: &disc.Server{Address: addr}}
+}
+
+func withPK(pk cipher.PubKey, addr string) *disc.Entry {
+	return &disc.Entry{Static: pk, Server: &disc.Server{Address: addr}}
+}
+
+func addrOf(set []*disc.Entry, pk cipher.PubKey) string {
+	for _, e := range set {
+		if e.Static == pk {
+			return e.Server.Address
+		}
+	}
+	return ""
+}
+
+func TestMergeServersByPK(t *testing.T) {
+	drifted := srvEntry(t, "1.1.1.1:30081") // same PK, stale static address
+	staticOnly := srvEntry(t, "2.2.2.2:30082")
+	registeredOnly := srvEntry(t, "3.3.3.3:30083")
+
+	static := []*disc.Entry{
+		withPK(drifted.Static, "1.1.1.1:30081"), // stale port in config
+		staticOnly,
+	}
+	registered := []*disc.Entry{
+		withPK(drifted.Static, "1.1.1.1:30088"), // server re-registered at :30088
+		registeredOnly,
+	}
+
+	out := mergeServersByPK(static, registered)
+
+	// union of all distinct PKs, deduped
+	require.Len(t, out, 3)
+	// drift self-heals: registered (current) address wins over the stale config
+	require.Equal(t, "1.1.1.1:30088", addrOf(out, drifted.Static))
+	// a static-only server (not yet registered) is retained — cold-start floor
+	require.Equal(t, "2.2.2.2:30082", addrOf(out, staticOnly.Static))
+	// a registered-only server (registered after cold-start) is picked up
+	require.Equal(t, "3.3.3.3:30083", addrOf(out, registeredOnly.Static))
+}
+
+func TestMergeServersByPK_EmptyRegistry(t *testing.T) {
+	// Registry empty / unreachable (cold-start, or fetch error → nil): fall back
+	// to exactly the static seed set so bootstrap still works.
+	s1 := srvEntry(t, "1.1.1.1:30081")
+	s2 := srvEntry(t, "2.2.2.2:30082")
+	out := mergeServersByPK([]*disc.Entry{s1, s2}, nil)
+	require.Len(t, out, 2)
+	require.Equal(t, "1.1.1.1:30081", addrOf(out, s1.Static))
+}
+
+func TestMergeServersByPK_SkipsNilAndServerless(t *testing.T) {
+	good := srvEntry(t, "1.1.1.1:30081")
+	out := mergeServersByPK(
+		[]*disc.Entry{nil, good},
+		[]*disc.Entry{nil, {Static: cipher.PubKey{}, Server: nil}}, // serverless registry entry ignored
+	)
+	require.Len(t, out, 1)
+	require.Equal(t, "1.1.1.1:30081", addrOf(out, good.Static))
+}


### PR DESCRIPTION
## What

The dmsg-discovery is a **direct client** — it doesn't register itself, so clients reach it by relaying through a dmsg server it's also connected to. It therefore **must hold a session to every dmsg server** to stay equally reachable; miss one and any client relaying through that server gets `dmsg error 202 - cannot connect to delegated server`.

It maintained its server sessions from **two** loops in `pkg/services/dmsgdisc/dmsgdisc.go`:
- `connectConfiguredServers` — tight (1s→30s), dials the **static** configured set
- `updateServers` — 10-minute, dials the **live registry** (`AllServers`)

The static config drifts. When a server re-registers at a new address, the static entry goes stale, the tight loop dials the dead address forever, and the slow registry loop doesn't reliably close the gap.

**Observed live:** the discovery held sessions to **8 of 9** servers because one server's configured address had drifted (`:30081` → `:30088`), silently dropping it — which intermittently `202`'d browser carrier-convergence lookups relaying through that server. Hand-fixing the static address + restarting is the fragility this removes.

## Change

Fold the two loops into one. Each maintenance tick, dial the **union** of the static seed set and the live registry, deduped by PK, with the **registered (current) address winning** (`reconcileServerSet` → pure `mergeServersByPK`). This self-heals address drift within one cycle and picks up servers that register after cold-start. The static set stays the cold-start floor (the registry is empty until the first server registers, so it can't bootstrap an empty deployment alone); a registry-fetch error degrades to the static set for that tick.

## Test

- `mergeServersByPK` unit-tested: drift (registered wins over stale config), cold-start (empty registry → static seed), new-server pickup, nil/serverless safety.
- Full `pkg/services/dmsgdisc` package tests pass; `go vet` clean.

Part of #3838 (self-healing registry-driven server mesh). Follow-ups there: servers meshing to each other, and optional `0.0.0.0` public address with peer-learned public IP to kill address drift at the source.