### PR TITLE
fix(dmsg): carrier_converge_test compiles (noteCarrierFailure reason arg)

### DIFF
--- a/pkg/dmsg/dmsg/carrier_converge_test.go
+++ b/pkg/dmsg/dmsg/carrier_converge_test.go
@@ -18,7 +18,7 @@ func TestCarrierConvergeBackoff(t *testing.T) {
 
 	require.False(t, ce.carrierBackedOff(pk), "a never-tried server must not be backed off")
 
-	ce.noteCarrierFailure(pk)
+	ce.noteCarrierFailure(pk, "test: unreachable")
 	require.True(t, ce.carrierBackedOff(pk), "a just-failed server must be backed off")
 
 	ce.clearCarrierFailure(pk)
@@ -26,6 +26,6 @@ func TestCarrierConvergeBackoff(t *testing.T) {
 
 	// Distinct servers don't share backoff state.
 	other, _ := cipher.GenerateKeyPair()
-	ce.noteCarrierFailure(pk)
+	ce.noteCarrierFailure(pk, "test: unreachable")
 	require.False(t, ce.carrierBackedOff(other), "backoff is per-server")
 }


### PR DESCRIPTION
`noteCarrierFailure` gained a `reason string` arg in #3835 (for the per-session convergence Notes), but `carrier_converge_test.go` still called it with one arg — breaking the test build on develop (this is what reddened #3835's test lanes). Pass a reason in the two call sites. One-line-per-call test fix; `go vet ./pkg/dmsg/dmsg` and the test pass.