### PR TITLE
feat(router): routing-table observability (RoutingStats RPC + route table-stats)

### DIFF
--- a/cmd/skywire-cli/commands/route/table_stats.go
+++ b/cmd/skywire-cli/commands/route/table_stats.go
@@ -1,0 +1,63 @@
+// Package cliroute cmd/skywire-cli/commands/route/table_stats.go c4-vis-cli
+package cliroute
+
+import (
+	"fmt"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	internal "github.com/skycoin/skywire/cmd/skywire-cli/cliutil"
+	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
+)
+
+func init() {
+	routeCmd.AddCommand(tableStatsCmd)
+}
+
+var tableStatsCmd = &cobra.Command{
+	Use:   "table-stats",
+	Short: "Show routing-table observability counters (rule count, route-ID high-water, per-type)",
+	Long: `Report this visor's routing-table counters:
+
+  count    — live routing rules currently installed
+  next_id  — the monotonic route-ID high-water mark. RouteIDs are never
+             reused, so this only ever grows; watching it on a RELAY across a
+             churn soak surfaces reserved-ID leaks (it should climb only in
+             proportion to genuine new routes, not rotate-churn).
+  by_type  — rule count broken down by type (forward / consume / intermediary).
+
+On an intermediate/relay visor this is the metric the route-setup soak harness
+samples to prove that rotating-policy churn reclaims rules/IDs rather than
+leaking them.`,
+	Run: func(cmd *cobra.Command, _ []string) {
+		rpcClient, err := clirpc.Client(cmd.Flags())
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		stats, err := rpcClient.RoutingStats()
+		if err != nil {
+			internal.PrintFatalError(cmd.Flags(), err)
+		}
+		if isJSON, _ := cmd.Flags().GetBool(internal.JSONString); isJSON { //nolint:errcheck
+			internal.PrintOutput(cmd.Flags(), stats, "")
+			return
+		}
+		fmt.Printf("rules:    %d\n", stats.Count)
+		fmt.Printf("next_id:  %d  (route-ID high-water; never reused)\n", stats.NextID)
+		if len(stats.ByType) > 0 {
+			tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "by type\tcount") //nolint:errcheck,gosec
+			types := make([]string, 0, len(stats.ByType))
+			for t := range stats.ByType {
+				types = append(types, t)
+			}
+			sort.Strings(types)
+			for _, t := range types {
+				fmt.Fprintf(tw, "  %s\t%d\n", t, stats.ByType[t]) //nolint:errcheck,gosec
+			}
+			tw.Flush() //nolint:errcheck,gosec
+		}
+	},
+}

--- a/pkg/router/mock_router.go
+++ b/pkg/router/mock_router.go
@@ -522,6 +522,15 @@ func (_m *MockRouter) ActiveRouteStatuses() []RouteStatus {
 	return nil
 }
 
+// RoutingTableStats provides a mock function with no fields
+func (_m *MockRouter) RoutingTableStats() routing.RoutingTableStats {
+	ret := _m.Called()
+	if r, ok := ret.Get(0).(routing.RoutingTableStats); ok {
+		return r
+	}
+	return routing.RoutingTableStats{}
+}
+
 // GetLastRouteCalcTime provides a mock function with no fields
 func (_m *MockRouter) GetLastRouteCalcTime() time.Duration {
 	ret := _m.Called()

--- a/pkg/router/route_status.go
+++ b/pkg/router/route_status.go
@@ -56,6 +56,13 @@ type RouteTransport struct {
 	RvsRuleID routing.RouteID `json:"rvs_rule_id"`
 }
 
+// RoutingTableStats returns observability counters for this visor's routing
+// table (live rule count, route-ID high-water, per-type breakdown). On a relay
+// this is how the soak harness detects rule/reserved-ID leaks under churn.
+func (r *router) RoutingTableStats() routing.RoutingTableStats {
+	return r.rt.Stats()
+}
+
 // ActiveRouteStatuses returns the status of all active route groups.
 func (r *router) ActiveRouteStatuses() []RouteStatus {
 	r.mx.Lock()

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -395,6 +395,7 @@ type Router interface {
 	GetMuxRoutes() int
 	GetLastRouteCalcTime() time.Duration
 	ActiveRouteStatuses() []RouteStatus
+	RoutingTableStats() routing.RoutingTableStats
 	AddMuxRouteByHops(desc routing.RouteDescriptor, fwd, rev []routing.Hop) error
 	GrowMuxRoute(desc routing.RouteDescriptor, target, minHops int) (int, error)
 	RemoveMuxRouteByTransport(desc routing.RouteDescriptor, tpID uuid.UUID) error

--- a/pkg/routing/table.go
+++ b/pkg/routing/table.go
@@ -22,6 +22,16 @@ var (
 	ErrNoAvailableRoutes = errors.New("no available routeIDs")
 )
 
+// RoutingTableStats summarizes a routing table for observability: the live rule
+// count, the monotonic route-ID high-water mark (RouteIDs are never reused, so
+// this only ever grows — tracking it surfaces reservation leaks under churn),
+// and a per-rule-type breakdown.
+type RoutingTableStats struct {
+	Count  int            `json:"count"`
+	NextID RouteID        `json:"next_id"`
+	ByType map[string]int `json:"by_type"`
+}
+
 // Table represents a routing table implementation.
 type Table interface {
 	// ReserveKeys reserves n RouteIDs.
@@ -51,6 +61,10 @@ type Table interface {
 
 	// Count returns the number of RoutingRule entries stored.
 	Count() int
+
+	// Stats returns observability counters: live rule count, the monotonic
+	// route-ID high-water mark (never reused), and a per-type breakdown.
+	Stats() RoutingTableStats
 
 	// CollectGarbage checks all the stored rules, removes and returns ones that timed out.
 	CollectGarbage() []Rule
@@ -228,6 +242,17 @@ func (mt *memTable) Count() int {
 	defer mt.RUnlock()
 
 	return len(mt.rules)
+}
+
+func (mt *memTable) Stats() RoutingTableStats {
+	mt.RLock()
+	defer mt.RUnlock()
+
+	byType := make(map[string]int, 4)
+	for _, r := range mt.rules {
+		byType[r.Type().String()]++
+	}
+	return RoutingTableStats{Count: len(mt.rules), NextID: mt.nextID, ByType: byType}
 }
 
 func (mt *memTable) CollectGarbage() []Rule {

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -176,6 +176,7 @@ type API interface {
 	SaveRoutingRule(rule routing.Rule) error
 	RemoveRoutingRule(key routing.RouteID) error
 	RouteGroups() ([]RouteGroupInfo, error)
+	RoutingStats() (routing.RoutingTableStats, error)
 	// RoutingPolicies returns a snapshot of the currently-installed
 	// routing-policy state: the visor-wide default plus any per-app
 	// overrides. Empty struct when no policies are configured.

--- a/pkg/visor/api_routing.go
+++ b/pkg/visor/api_routing.go
@@ -46,6 +46,16 @@ func (v *Visor) RemoveRoutingRule(key routing.RouteID) error {
 // failed and this function returned an empty list. We now drive directly
 // off the router's active route-group set (rgsNs) via ActiveRouteStatuses,
 // which already holds the descriptor, hops, and initiator flag.
+// RoutingStats implements API. Returns this visor's routing-table observability
+// counters (live rule count, route-ID high-water, per-type breakdown). On a
+// relay these are how the soak harness detects rule/reserved-ID leaks.
+func (v *Visor) RoutingStats() (routing.RoutingTableStats, error) {
+	if v.router == nil {
+		return routing.RoutingTableStats{}, nil
+	}
+	return v.router.RoutingTableStats(), nil
+}
+
 func (v *Visor) RouteGroups() (rgs []RouteGroupInfo, err error) {
 	if v.router == nil {
 		return nil, nil

--- a/pkg/visor/proxied_visor_api.go
+++ b/pkg/visor/proxied_visor_api.go
@@ -145,6 +145,10 @@ func (p *proxiedVisorAPI) RouteGroups() ([]RouteGroupInfo, error) {
 	return s.RouteGroups, nil
 }
 
+func (p *proxiedVisorAPI) RoutingStats() (routing.RoutingTableStats, error) {
+	return routing.RoutingTableStats{}, ErrProxyNotSupported
+}
+
 func (p *proxiedVisorAPI) GetMinHops() (uint16, error) {
 	s, err := p.hvAPI.HVVisorSummary(p.targetPK)
 	if err != nil {

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -522,6 +522,10 @@ func (proxyDefaultAPI) RouteGroups() ([]RouteGroupInfo, error) {
 	return nil, ErrProxyNotSupported
 }
 
+func (proxyDefaultAPI) RoutingStats() (routing.RoutingTableStats, error) {
+	return routing.RoutingTableStats{}, ErrProxyNotSupported
+}
+
 func (proxyDefaultAPI) RoutingPolicies() (*RoutingPoliciesSummary, error) {
 	return nil, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -902,6 +902,13 @@ func (rc *rpcClient) RouteGroups() ([]RouteGroupInfo, error) {
 	return routegroups, err
 }
 
+// RoutingStats calls RoutingStats.
+func (rc *rpcClient) RoutingStats() (routing.RoutingTableStats, error) {
+	var stats routing.RoutingTableStats
+	err := rc.Call("RoutingStats", &struct{}{}, &stats)
+	return stats, err
+}
+
 // RoutingPolicies calls RoutingPolicies.
 func (rc *rpcClient) RoutingPolicies() (*RoutingPoliciesSummary, error) {
 	var summary RoutingPoliciesSummary

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -806,6 +806,11 @@ func (mc *mockRPCClient) RemoveRoutingRule(key routing.RouteID) error {
 	return nil
 }
 
+// RoutingStats implements API.
+func (mc *mockRPCClient) RoutingStats() (routing.RoutingTableStats, error) {
+	return mc.rt.Stats(), nil
+}
+
 // RouteGroups implements API.
 func (mc *mockRPCClient) RouteGroups() ([]RouteGroupInfo, error) {
 	var routeGroups []RouteGroupInfo

--- a/pkg/visor/rpc_routing.go
+++ b/pkg/visor/rpc_routing.go
@@ -46,6 +46,16 @@ func (r *RPC) RouteGroups(_ *struct{}, out *[]RouteGroupInfo) (err error) {
 	return err
 }
 
+// RoutingStats retrieves this visor's routing-table observability counters.
+func (r *RPC) RoutingStats(_ *struct{}, out *routing.RoutingTableStats) (err error) {
+	defer rpcutil.LogCall(r.log, "RoutingStats", nil)(out, &err)
+
+	stats, err := r.visor.RoutingStats()
+	*out = stats
+
+	return err
+}
+
 // RoutingPolicies returns the installed routing-policy summary
 // (visor-wide default + per-app overrides) for the hypervisor UI.
 func (r *RPC) RoutingPolicies(_ *struct{}, out *RoutingPoliciesSummary) (err error) {


### PR DESCRIPTION
**Phase 0 of #3843** (cascade verified-default epic) — the observability that makes the later churn/leak fixes *provable*.

- `routing.Table.Stats() → RoutingTableStats{Count, NextID, ByType}` (rule count; monotonic route-ID high-water — never reused, so it surfaces reserved-ID leaks; per-type breakdown).
- `router.RoutingTableStats()` → visor `RoutingStats()` API + RPC.
- `skywire cli route table-stats [--json]` so the soak harness can sample each **relay's** rule-count + high-water remotely (that's how the "no leak" acceptance gate is measured across intermediates).

Read-only, no behavior change. `go build ./...` + `go vet` pass. Follows the existing `RouteGroups` RPC wiring exactly.