### PR TITLE
router: reclaim retired mux legs immediately via CloseLegRetired (Phase 1a)

### DIFF
--- a/pkg/router/noise_route_group.go
+++ b/pkg/router/noise_route_group.go
@@ -97,3 +97,9 @@ func (nrg *NoiseRouteGroup) RouteHopDetails() []RouteHopInfo {
 func (nrg *NoiseRouteGroup) handlePacket(packet routing.Packet) error {
 	return nrg.rg.handlePacket(packet)
 }
+
+// pruneLegByConsumeRule removes a single retired mux leg without closing the
+// group. See RouteGroup.pruneLegByConsumeRule.
+func (nrg *NoiseRouteGroup) pruneLegByConsumeRule(routeID routing.RouteID) bool {
+	return nrg.rg.pruneLegByConsumeRule(routeID)
+}

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -1459,6 +1459,66 @@ func (rg *RouteGroup) pruneDeadTransports() []int {
 	return droppedIdx
 }
 
+// pruneLegByConsumeRule removes the single mux leg whose consume (reverse) rule
+// matches routeID, WITHOUT closing the route group — the endpoint counterpart to
+// a remote peer retiring one leg (routing.CloseLegRetired). It reclaims that
+// leg's forward+consume rules and drops it from the mux, leaving the group and
+// its other legs live. Returns true if a leg was pruned; false if this is the
+// group's last leg (or the rule wasn't found), in which case the caller falls
+// back to a normal whole-group close. Mirrors pruneDeadTransports' slice/rule
+// bookkeeping; tolerates pruning index 0 exactly as the dead-transport path does
+// (the mux selector is rebuilt and tps[0]-hardcoded probes re-target the new
+// primary leg).
+func (rg *RouteGroup) pruneLegByConsumeRule(routeID routing.RouteID) bool {
+	rg.mu.Lock()
+	if len(rg.tps) <= 1 || len(rg.rvs) <= 1 {
+		rg.mu.Unlock()
+		return false // last leg — let the caller do a full close
+	}
+	idx := -1
+	for i, rv := range rg.rvs {
+		if rv != nil && rv.KeyRouteID() == routeID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		rg.mu.Unlock()
+		return false
+	}
+
+	var deadRuleIDs []routing.RouteID
+	if idx < len(rg.fwd) {
+		deadRuleIDs = append(deadRuleIDs, rg.fwd[idx].KeyRouteID())
+	}
+	if idx < len(rg.rvs) {
+		deadRuleIDs = append(deadRuleIDs, rg.rvs[idx].KeyRouteID())
+	}
+
+	if idx < len(rg.tps) {
+		rg.tps = append(rg.tps[:idx], rg.tps[idx+1:]...)
+	}
+	if idx < len(rg.fwd) {
+		rg.fwd = append(rg.fwd[:idx], rg.fwd[idx+1:]...)
+	}
+	if idx < len(rg.rvs) {
+		rg.rvs = append(rg.rvs[:idx], rg.rvs[idx+1:]...)
+	}
+
+	if len(deadRuleIDs) > 0 {
+		rg.rt.DelRules(deadRuleIDs)
+	}
+	if rg.mux != nil {
+		rg.mux.removeLegs(idx)
+		rg.mux.rebuildWeights(rg.tps)
+	}
+	rg.logger.Infof("Retired remote mux leg %d (consume rule %d); %d legs remain", idx, routeID, len(rg.tps))
+	rg.mu.Unlock()
+
+	rg.fireLegChange("retired-remote", idx)
+	return true
+}
+
 func (rg *RouteGroup) sendKeepAlive() error {
 	rg.mu.Lock()
 	defer rg.mu.Unlock()

--- a/pkg/router/route_group_leg_retire_test.go
+++ b/pkg/router/route_group_leg_retire_test.go
@@ -1,0 +1,80 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/skycoin/skywire/pkg/routing"
+)
+
+// TestPruneLegByConsumeRule verifies the endpoint side of a remote leg-retire
+// (routing.CloseLegRetired): the leg whose consume rule the close arrived on is
+// dropped and its forward+consume rules reclaimed, while the route group and
+// its other legs stay live. This is the Phase 1a reclamation path — it lets a
+// rotated/retired mux leg free its rules immediately instead of waiting out the
+// idle-rule GC.
+func TestPruneLegByConsumeRule(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 3)
+
+	// createMuxRouteGroup assigns leg i the consume rule RouteID(i+100).
+	// Retire the middle leg.
+	const retiredConsumeID = routing.RouteID(1 + 100)
+
+	rg.mu.Lock()
+	before := rg.rt.Count()
+	rg.mu.Unlock()
+	require.Equal(t, 6, before, "3 legs => 3 forward + 3 consume rules")
+
+	ok := rg.pruneLegByConsumeRule(retiredConsumeID)
+	require.True(t, ok, "a non-last leg must be prunable")
+
+	rg.mu.Lock()
+	remaining := len(rg.tps)
+	fwdN, rvsN := len(rg.fwd), len(rg.rvs)
+	after := rg.rt.Count()
+	rg.mu.Unlock()
+
+	require.Equal(t, 2, remaining, "one leg retired, two remain")
+	require.Equal(t, 2, fwdN, "forward rules compacted in lockstep")
+	require.Equal(t, 2, rvsN, "consume rules compacted in lockstep")
+	require.Equal(t, 4, after, "retired leg's forward+consume rules reclaimed")
+	require.False(t, rg.isClosed(), "route group stays live after a single leg retire")
+
+	// The retired consume rule must be gone; a surviving leg's rule must remain.
+	_, err := rg.rt.Rule(retiredConsumeID)
+	require.Error(t, err, "retired leg's consume rule should be deleted")
+	_, err = rg.rt.Rule(routing.RouteID(0 + 100))
+	require.NoError(t, err, "surviving leg's consume rule should remain")
+}
+
+// TestPruneLegByConsumeRuleLastLegFallsBack verifies that retiring the last
+// remaining leg is refused (returns false) so the caller falls back to a normal
+// whole-group close rather than leaving a legless route group.
+func TestPruneLegByConsumeRuleLastLegFallsBack(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 1)
+
+	ok := rg.pruneLegByConsumeRule(routing.RouteID(0 + 100))
+	require.False(t, ok, "the last leg must not be prunable — caller does a full close")
+
+	rg.mu.Lock()
+	remaining := len(rg.tps)
+	rg.mu.Unlock()
+	require.Equal(t, 1, remaining, "last leg preserved")
+	require.False(t, rg.isClosed())
+}
+
+// TestPruneLegByConsumeRuleUnknownRuleNoop verifies that a consume-rule ID that
+// isn't part of this group is a no-op (returns false, group untouched) — a
+// stray/duplicate close must not disturb live legs.
+func TestPruneLegByConsumeRuleUnknownRuleNoop(t *testing.T) {
+	rg, _, _ := createMuxRouteGroup(t, 3)
+
+	ok := rg.pruneLegByConsumeRule(routing.RouteID(9999))
+	require.False(t, ok)
+
+	rg.mu.Lock()
+	remaining := len(rg.tps)
+	rg.mu.Unlock()
+	require.Equal(t, 3, remaining, "unknown rule must not prune any leg")
+}

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -165,32 +165,54 @@ func (r *router) handleClosePacket(ctx context.Context, packet routing.Packet) e
 		return err
 	}
 
-	defer func() {
-		r.rt.DelRules([]routing.RouteID{routeID})
-	}()
-
 	if t := rule.Type(); t == routing.RuleIntermediary {
+		// Intermediary: reclaim this hop's rule and forward the close onward.
+		// Identical for CloseRequested and CloseLegRetired — a transited relay
+		// tears down the leg's rule either way, which is exactly the reclamation
+		// CloseLegRetired exists to trigger without waiting out the idle GC.
+		defer func() {
+			r.rt.DelRules([]routing.RouteID{routeID})
+		}()
 		return r.forwardPacket(ctx, packet, rule)
 	}
 
+	// Endpoint (consume rule).
 	desc := rule.RouteDescriptor()
 	nrg, ok := r.noiseRouteGroup(desc)
 	if !ok {
+		r.rt.DelRules([]routing.RouteID{routeID})
 		return errRouteDescNotExist
 	}
-
-	defer r.removeNoiseRouteGroup(desc)
-	// Reap the faithful-UDP sibling (if any) with the reliable route (#2607).
-	defer r.closeDatagramSibling(desc)
-
 	if nrg == nil {
+		r.rt.DelRules([]routing.RouteID{routeID})
+		r.removeNoiseRouteGroup(desc)
 		return errNilNoiseRG
 	}
 
 	closeCode, err := closeCodeFromPacket(packet)
 	if err != nil {
+		r.rt.DelRules([]routing.RouteID{routeID})
 		return err
 	}
+
+	// CloseLegRetired: a remote peer retired ONE leg of a mux group. Prune only
+	// the leg whose consume rule this is and keep the group (and its other legs)
+	// live. pruneLegByConsumeRule itself reclaims the leg's forward+consume
+	// rules, so we do NOT run the whole-group DelRules / removeNoiseRouteGroup
+	// teardown here. If it returns false (this was the group's last leg) fall
+	// through to a normal full close.
+	if closeCode == routing.CloseLegRetired {
+		if nrg.pruneLegByConsumeRule(routeID) {
+			return nil
+		}
+	}
+
+	defer func() {
+		r.rt.DelRules([]routing.RouteID{routeID})
+	}()
+	defer r.removeNoiseRouteGroup(desc)
+	// Reap the faithful-UDP sibling (if any) with the reliable route (#2607).
+	defer r.closeDatagramSibling(desc)
 
 	if nrg.isClosed() {
 		return io.ErrClosedPipe

--- a/pkg/routing/packet.go
+++ b/pkg/routing/packet.go
@@ -130,6 +130,8 @@ func (cc CloseCode) String() string {
 	switch cc {
 	case CloseRequested:
 		return "Closing requested by visor"
+	case CloseLegRetired:
+		return "Single mux leg retired"
 	default:
 		return fmt.Sprintf("Unknown(%d)", byte(cc))
 	}
@@ -138,6 +140,18 @@ func (cc CloseCode) String() string {
 const (
 	// CloseRequested is used when a closing is requested by visor.
 	CloseRequested CloseCode = iota
+	// CloseLegRetired closes ONE leg of a multiplexed route group without
+	// tearing down the whole group. Intermediary relays handle it exactly like
+	// CloseRequested (delete the leg's intermediary rule, forward onward), so
+	// they reclaim the retired leg's rules immediately instead of waiting out
+	// the ~10-minute idle-rule GC. The DESTINATION endpoint treats it specially:
+	// it prunes only the leg whose consume rule the packet arrived on and keeps
+	// the route group (and its other legs) alive. A visor that predates this
+	// code falls back to the default branch and closes the whole group, so a
+	// source must only emit CloseLegRetired to peers known to support it (gated
+	// separately from this receive-side handling, which is inert until a source
+	// opts in).
+	CloseLegRetired
 )
 
 // RouteID represents ID of a Route in a Packet.


### PR DESCRIPTION
## What

Adds a `CloseLegRetired` close code and the **endpoint receive-side** handling so a single multiplexed-route leg can be torn down without collapsing the whole route group.

## Why

Today, when a mux leg is rotated out or pruned, the source just closes its local transport and deletes its own rules — it sends **no routing close** down the leg. So every transited relay keeps that leg's intermediary rules until the ~10-minute idle-rule GC, and the reserved route IDs are never reclaimed. Under a rotating policy (`spread-bw`, 15s interval) that piles up dozens of stale rule-sets per relay before the first GC even fires. This is cascade-independent — it affects legacy route setup today.

A naive fix ("just send a close down the retired leg") is **wrong**: all mux legs share one `RouteDescriptor`, so at the destination endpoint the leg's consume rule resolves to the shared route group and the close tears down **every** leg. Intermediaries, by contrast, already do the right thing — `handleClosePacket` on a `RuleIntermediary` deletes the hop's rule and forwards the close onward.

## How

- New `routing.CloseLegRetired` close code. Intermediaries handle it identically to `CloseRequested` (delete + forward → immediate per-hop reclamation).
- At the destination endpoint, a `CloseLegRetired` close now prunes **only** the leg whose consume rule it arrived on (`RouteGroup.pruneLegByConsumeRule`) and keeps the group + its other legs live. The whole-group teardown still runs on the last leg (fallback) or on a plain `CloseRequested`.
- The full-close ack handshake is **untouched** — `CloseRequested` follows the exact same path as before, so there's no risk to the initiator's per-leg ack accounting.

## Scope / rollout

**Receive-side only, and inert until a source emits `CloseLegRetired`.** A peer predating this code falls back to a full close, so the source-side emit (rotation / liveness-prune) is gated on fleet support and lands in a follow-up — mirroring the staged "visors update first" rollout. This PR is the safe half that must saturate the fleet first.

## Testing

New `pkg/router` unit tests: leg pruned + forward/consume rules reclaimed while the group stays live; last-leg retire falls back to a full close; unknown-rule close is a no-op. Full `pkg/router` + `pkg/routing` suites pass; `go build .` clean.