### PR TITLE
transport: recover all transport types from a TPID (not just the legacy four)

### DIFF
--- a/pkg/transport/coverage_test.go
+++ b/pkg/transport/coverage_test.go
@@ -240,9 +240,18 @@ func TestTypeFromTransportID(t *testing.T) {
 	pkA, _ := cipher.GenerateKeyPair()
 	pkB, _ := cipher.GenerateKeyPair()
 
-	for _, ty := range []types.Type{types.STCPR, types.SUDPH, types.STCP, types.DMSG} {
+	// Every canonical known type must round-trip, including the newer
+	// transports (squicr/webrtc/swsr/swtr) that the old hard-coded list missed.
+	for _, ty := range types.Known() {
 		id := MakeTransportID(pkA, pkB, ty)
-		require.Equal(t, ty, TypeFromTransportID(id, pkA, pkB))
+		require.Equal(t, ty, TypeFromTransportID(id, pkA, pkB), "type %q must be recoverable from its TPID", ty)
+	}
+	// A transport registered under a legacy wire name resolves to its canonical
+	// type (its TPID differs from the canonical-named one, so this exercises the
+	// legacy-alias fallback).
+	for _, legacy := range []types.Type{types.QUICLegacy, types.QUICLegacy2, types.WSLegacy, types.WTLegacy} {
+		id := MakeTransportID(pkA, pkB, legacy)
+		require.Equal(t, types.NormalizeType(legacy), TypeFromTransportID(id, pkA, pkB), "legacy %q must normalize", legacy)
 	}
 	// An ID that matches no known type yields "".
 	require.Equal(t, types.Type(""), TypeFromTransportID(MakeTransportID(pkA, pkB, "weird"), pkA, pkB))

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -37,13 +37,29 @@ func SortEdges(keyA, keyB cipher.PubKey) [2]cipher.PubKey {
 }
 
 // TypeFromTransportID determines the transport type by comparing the given
-// transport ID against computed IDs for known transport types.
-// Returns empty string if no match is found.
+// transport ID against computed IDs for known transport types. A TPID is a
+// one-way SHA-256 of (sorted keys ‖ type string) — the type is not stored in a
+// recoverable field — so the only way to recover it is to replay MakeTransportID
+// for each candidate type (with the endpoint keys) and match. Returns empty
+// string if no match is found.
+//
+// The candidate set is types.Known() (the canonical single source of truth, so
+// it never drifts as new transport types are added — the reason the old
+// hard-coded {STCPR,SUDPH,STCP,DMSG} list silently returned "" for squicr /
+// webrtc / swsr / swtr) plus the legacy pre-rename wire names, since a transport
+// an older visor registered under "quic"/"ws"/"wt" was hashed with that string
+// and so has a different TPID than its canonical-named equivalent.
 func TypeFromTransportID(tpID uuid.UUID, keyA, keyB cipher.PubKey) types.Type {
-	knownTypes := []types.Type{types.STCPR, types.SUDPH, types.STCP, types.DMSG}
-	for _, t := range knownTypes {
+	for _, t := range types.Known() {
 		if MakeTransportID(keyA, keyB, t) == tpID {
 			return t
+		}
+	}
+	// Legacy wire names produce distinct IDs; normalize back to canonical so
+	// callers see a stable type regardless of which name created the transport.
+	for _, t := range []types.Type{types.QUICLegacy, types.QUICLegacy2, types.WSLegacy, types.WTLegacy} {
+		if MakeTransportID(keyA, keyB, t) == tpID {
+			return types.NormalizeType(t)
 		}
 	}
 	return ""


### PR DESCRIPTION
## Problem

`TypeFromTransportID` enumerated a hard-coded `{STCPR, SUDPH, STCP, DMSG}` and returned `""` for every newer transport type — `squicr` (QUIC), `webrtc`, `swsr` (WS), `swtr` (WT). So any route hop riding one of the new transports shows a **blank type** in `ping --show-route`, the HV UI route display, and anywhere else that recovers a hop's type from its TPID.

Example (`ping --show-route` over a webrtc first hop): `… @ 25713934-b098-0a4d-be6b-49dee6b80b26 ()` — the empty `()` is the missing type.

## Why the reverse-map is the only option

A TPID is `uuid.NewHash(SHA-256, sortedKeyA ‖ sortedKeyB ‖ typeString)` — a one-way hash; the type isn't stored in a recoverable field. The only way to recover it is to replay `MakeTransportID(keyA, keyB, t)` for each candidate type `t` and match. (No collisions — distinct type strings give distinct SHA-256, so the match is exact.)

## Fix

Iterate `types.Known()` — the canonical single source of truth, whose own doc says to use it "instead of hard-coding a subset that drifts as new types are added" — plus the legacy pre-rename wire names (`quic`/`squic`/`ws`/`wt`), which hash to distinct IDs and are normalized back to their canonical type. This won't silently drift again as types are added.

Display/observability only — routing keys off the TPID directly and never used the reverse-mapped type.

## Test

`TestTypeFromTransportID` now covers every `types.Known()` type round-tripping and each legacy alias normalizing to canonical; the no-match case still yields `""`. `go test ./pkg/transport/` green; `go vet` clean.