### PR TITLE
ui: drop baseUrl, and make the root tsconfig checkable

### DIFF
--- a/static/skywire-manager-src/tsconfig.json
+++ b/static/skywire-manager-src/tsconfig.json
@@ -18,13 +18,15 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "strictNullChecks": false,
-    "baseUrl": "./",
-    "ignoreDeprecations": "6.0",
     "paths": {
       "src/*": [
         "./src/*"
       ]
-    }
+    },
+    "types": [
+      "jasmine",
+      "node"
+    ]
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,


### PR DESCRIPTION
TypeScript 6 deprecates `baseUrl` and 7 removes it. #3852 silenced the warning with `ignoreDeprecations` because removing it looked like a 206-error job.

**That was wrong, and worth correcting.** Those 206 errors have nothing to do with `baseUrl`.

The root tsconfig declares no `types`, so running `tsc` on it picks up every `.spec.ts` without jasmine's — 204 of the errors are `Cannot find name 'describe'` and relatives, and **all 204 are in spec files**. They were there before and after. What `ignoreDeprecations` changed is that **TS5101 stops the check dead**: silencing it did not add errors, it revealed the ones already being skipped.

### The actual change

The 265 imports written as `src/app/...` need a **path mapping**, not `baseUrl`:

```json
"paths": { "src/*": ["./src/*"] }
```

That does what `baseUrl` did for them and survives TypeScript 7. Both sub-configs extend this one, so they inherit it.

The root config also gets the `jasmine` and `node` types, taking it from 204 errors to **none** and making `tsc -p tsconfig.json` worth running. Its being unusable is precisely why a real deprecation sat behind a wall of meaningless output.

### Verified

Build clean, `ng lint` clean, **73/73** specs, `check-ui` green, browser smoke check renders, and `tsc -p tsconfig.json` now reports **0**.