### PR TITLE
cli: visor info reports WT registration, distinct peers, and no invented latency

### DIFF
--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -836,22 +836,7 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 	var arSelf *visor.ARSelfRegistration
 	if reg, regErr := rpcClient.ARSelfInfo(); regErr == nil {
 		arSelf = reg
-		if reg != nil && len(reg.Entries) > 0 {
-			msg += "AR Registration:\n"
-			for _, e := range reg.Entries {
-				addr := formatARAddr(e)
-				// The WT certificate hash is what a browser has to pin to
-				// dial this visor, so it belongs beside the endpoint it
-				// applies to. Abbreviated: it is 64 hex characters, and the
-				// full value is in --json for anyone who needs to paste it.
-				if e.CertHash != "" {
-					addr += fmt.Sprintf(" (cert %s)", abbrevHash(e.CertHash))
-				}
-				msg += fmt.Sprintf("  %-6s %s\n", strings.ToUpper(e.Type), addr)
-			}
-		} else {
-			msg += "AR Registration: (none)\n"
-		}
+		msg += renderARSection(reg)
 	}
 
 	// Hypervisor section: (a) whether this visor serves the
@@ -918,6 +903,39 @@ func dmsgLatency(summary *visor.Summary) string {
 		return ""
 	}
 	return summary.DmsgStats.RoundTrip.String()
+}
+
+// renderARSection renders the visor's own AR registration.
+//
+// Split out from the summary so the distinction it exists to draw can be
+// tested: a transport type the visor CHECKED and is not registered for is
+// reported as such, while a type it never mentioned produces no line at all.
+// Only the visor knows which of those it means, and an older one — reached
+// over --via or --rpc, since locally the CLI and the visor are one binary —
+// reports no Queried list, so its silence must stay silent here.
+func renderARSection(reg *visor.ARSelfRegistration) string {
+	if reg == nil || len(reg.Entries) == 0 {
+		return "AR Registration: (none)\n"
+	}
+	msg := "AR Registration:\n"
+	have := make(map[string]bool, len(reg.Entries))
+	for _, e := range reg.Entries {
+		have[e.Type] = true
+		addr := formatARAddr(e)
+		// The WT certificate hash is what a browser has to pin to dial this
+		// visor, so it belongs beside the endpoint it applies to. Abbreviated:
+		// it is 64 hex characters, and --json carries the full value.
+		if e.CertHash != "" {
+			addr += fmt.Sprintf(" (cert %s)", abbrevHash(e.CertHash))
+		}
+		msg += fmt.Sprintf("  %-6s %s\n", strings.ToUpper(e.Type), addr)
+	}
+	for _, tpType := range reg.Queried {
+		if !have[tpType] {
+			msg += fmt.Sprintf("  %-6s (not registered)\n", strings.ToUpper(tpType))
+		}
+	}
+	return msg
 }
 
 // abbrevHash shortens a hex digest for a summary line, keeping enough of both

--- a/cmd/skywire-cli/commands/visor/info.go
+++ b/cmd/skywire-cli/commands/visor/info.go
@@ -199,7 +199,7 @@ var summaryCmd = &cobra.Command{
 			RegionName:           summary.Overview.RegionName,
 			CityName:             summary.Overview.CityName,
 			DMSGServers:          summary.DMSGServers,
-			DmsgLatency:          summary.DmsgStats.RoundTrip.String(),
+			DmsgLatency:          dmsgLatency(summary),
 			VisorVersion:         summary.Overview.BuildInfo.Version,
 			ConfigVersion:        summary.ConfigVersion,
 			UptimeTracker:        summary.Health.ServicesHealth,
@@ -791,26 +791,42 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 	}
 
 	msg += fmt.Sprintf("DMSG Servers (%d connected):\n              %s\n", len(summary.DMSGServers), dmsgServersStr)
-	msg += fmt.Sprintf("DMSG Latency: %s\n", summary.DmsgStats.RoundTrip)
+	// Only when it was actually measured. The tracker keys on the visor's own
+	// PK and usually holds no entry for it, leaving the zero value — which
+	// printed as a confident "DMSG Latency: 0s" directly under a list of
+	// servers whose real round-trips were hundreds of milliseconds. Say
+	// nothing rather than something false; the per-server figures above are
+	// the measured ones.
+	if summary.DmsgStats != nil && summary.DmsgStats.RoundTrip > 0 {
+		msg += fmt.Sprintf("DMSG Latency: %s\n", summary.DmsgStats.RoundTrip)
+	}
 
-	// Transport summary by type
+	// Transport summary by type, and by how many DISTINCT peers those
+	// transports reach. The totals alone cannot tell ten links to ten visors
+	// from ten links to three, which is the question being asked of this line
+	// most of the time.
 	tpCounts := make(map[string]int)
+	peers := make(map[cipher.PubKey]struct{})
 	for _, tp := range summary.Overview.Transports {
 		tpCounts[string(tp.Type)]++
+		peers[tp.Remote] = struct{}{}
 	}
 	tpTotal := len(summary.Overview.Transports)
 	tpStr := fmt.Sprintf("%d", tpTotal)
 	if tpTotal > 0 {
-		tpStr += " ("
-		first := true
-		for tpType, count := range tpCounts {
-			if !first {
-				tpStr += ", "
-			}
-			tpStr += fmt.Sprintf("%s: %d", strings.ToUpper(tpType), count)
-			first = false
+		// Sorted: ranging a map rendered these in a different order run to
+		// run, which makes two otherwise identical summaries look different.
+		types := make([]string, 0, len(tpCounts))
+		for tpType := range tpCounts {
+			types = append(types, tpType)
 		}
-		tpStr += ")"
+		sort.Strings(types)
+		parts := make([]string, 0, len(types))
+		for _, tpType := range types {
+			parts = append(parts, fmt.Sprintf("%s: %d", strings.ToUpper(tpType), tpCounts[tpType]))
+		}
+		tpStr += " (" + strings.Join(parts, ", ") + ")"
+		tpStr += fmt.Sprintf(" to %s", pluralVisors(len(peers)))
 	}
 	msg += fmt.Sprintf("Transports: %s\n", tpStr)
 
@@ -824,6 +840,13 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 			msg += "AR Registration:\n"
 			for _, e := range reg.Entries {
 				addr := formatARAddr(e)
+				// The WT certificate hash is what a browser has to pin to
+				// dial this visor, so it belongs beside the endpoint it
+				// applies to. Abbreviated: it is 64 hex characters, and the
+				// full value is in --json for anyone who needs to paste it.
+				if e.CertHash != "" {
+					addr += fmt.Sprintf(" (cert %s)", abbrevHash(e.CertHash))
+				}
 				msg += fmt.Sprintf("  %-6s %s\n", strings.ToUpper(e.Type), addr)
 			}
 		} else {
@@ -880,6 +903,39 @@ func buildSummaryMessageWithData(rpcClient visor.API) (string, *visor.Summary, *
 	}
 
 	return msg, summary, arSelf, nil
+}
+
+// dmsgLatency renders the visor's dmsg round-trip, or empty when there is no
+// measurement. The tracker keys on the visor's own public key and usually has
+// no entry for it, so the summary carries a zero value that is not a latency of
+// zero — it is the absence of one. Reporting it as "0s" beside per-server
+// round-trips in the hundreds of milliseconds is worse than reporting nothing.
+//
+// Nil-safe because it must be: the hypervisor path deliberately leaves this nil
+// when stats are missing, and this call site used to dereference it blind.
+func dmsgLatency(summary *visor.Summary) string {
+	if summary.DmsgStats == nil || summary.DmsgStats.RoundTrip <= 0 {
+		return ""
+	}
+	return summary.DmsgStats.RoundTrip.String()
+}
+
+// abbrevHash shortens a hex digest for a summary line, keeping enough of both
+// ends to compare against another rendering of the same hash by eye.
+func abbrevHash(h string) string {
+	const keep = 8
+	if len(h) <= 2*keep+1 {
+		return h
+	}
+	return h[:keep] + "…" + h[len(h)-keep:]
+}
+
+// pluralVisors renders a distinct-peer count with its noun agreed.
+func pluralVisors(n int) string {
+	if n == 1 {
+		return "1 visor"
+	}
+	return fmt.Sprintf("%d visors", n)
 }
 
 func formatARAddr(e visor.ARSelfEntry) string {

--- a/cmd/skywire-cli/commands/visor/info_format_test.go
+++ b/cmd/skywire-cli/commands/visor/info_format_test.go
@@ -7,6 +7,7 @@
 package clivisor
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -134,4 +135,53 @@ func TestDmsgLatencyUnmeasured(t *testing.T) {
 	if got := dmsgLatency(measured); got != "8ms" {
 		t.Errorf("measured: got %q, want 8ms", got)
 	}
+}
+
+// The point of ARSelfRegistration.Queried: "asked and not registered" and
+// "never asked" must not render the same. Only the first is an answer.
+func TestRenderARSection(t *testing.T) {
+	stcpr := visor.ARSelfEntry{Type: "stcpr", RemoteAddr: "1.2.3.4:7777"}
+	wt := visor.ARSelfEntry{
+		Type:       "wt",
+		RemoteAddr: "1.2.3.4:7773",
+		CertHash:   "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	}
+
+	t.Run("modern visor, WT checked and unregistered, says so", func(t *testing.T) {
+		got := renderARSection(&visor.ARSelfRegistration{
+			Entries: []visor.ARSelfEntry{stcpr},
+			Queried: []string{"stcpr", "sudph", "wt"},
+		})
+		for _, want := range []string{"SUDPH  (not registered)", "WT     (not registered)"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in:\n%s", want, got)
+			}
+		}
+	})
+
+	t.Run("old visor reports no Queried, so WT is not mentioned", func(t *testing.T) {
+		got := renderARSection(&visor.ARSelfRegistration{
+			Entries: []visor.ARSelfEntry{stcpr},
+		})
+		if strings.Contains(got, "WT") || strings.Contains(got, "not registered") {
+			t.Errorf("claimed something about WT from a visor that never mentioned it:\n%s", got)
+		}
+	})
+
+	t.Run("WT registration shows the cert hash abbreviated", func(t *testing.T) {
+		got := renderARSection(&visor.ARSelfRegistration{
+			Entries: []visor.ARSelfEntry{wt},
+			Queried: []string{"wt"},
+		})
+		if !strings.Contains(got, "(cert 9f86d081…b0f00a08)") {
+			t.Errorf("cert hash not rendered:\n%s", got)
+		}
+	})
+
+	t.Run("nothing registered stays a single line", func(t *testing.T) {
+		got := renderARSection(&visor.ARSelfRegistration{Queried: []string{"stcpr", "wt"}})
+		if got != "AR Registration: (none)\n" {
+			t.Errorf("got %q", got)
+		}
+	})
 }

--- a/cmd/skywire-cli/commands/visor/info_format_test.go
+++ b/cmd/skywire-cli/commands/visor/info_format_test.go
@@ -8,6 +8,9 @@ package clivisor
 
 import (
 	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 
 	"github.com/skycoin/skywire/pkg/visor"
 )
@@ -91,5 +94,44 @@ func TestFormatARAddr(t *testing.T) {
 				t.Errorf("formatARAddr(%+v):\n  got:  %q\n  want: %q", c.in, got, c.want)
 			}
 		})
+	}
+}
+
+func TestAbbrevHash(t *testing.T) {
+	const full = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	got := abbrevHash(full)
+	if got != "9f86d081…b0f00a08" {
+		t.Fatalf("abbrevHash(%q) = %q", full, got)
+	}
+	// Short enough to show whole: left alone rather than padded or cut.
+	if s := abbrevHash("abc123"); s != "abc123" {
+		t.Fatalf("abbrevHash short = %q, want it unchanged", s)
+	}
+}
+
+func TestPluralVisors(t *testing.T) {
+	for n, want := range map[int]string{0: "0 visors", 1: "1 visor", 7: "7 visors"} {
+		if got := pluralVisors(n); got != want {
+			t.Errorf("pluralVisors(%d) = %q, want %q", n, got, want)
+		}
+	}
+}
+
+// A latency the visor never measured must not be reported as zero. The
+// tracker keys on the visor's own PK and usually holds no entry for it, so the
+// summary carries a zero value that means "unknown", not "instant".
+func TestDmsgLatencyUnmeasured(t *testing.T) {
+	if got := dmsgLatency(&visor.Summary{}); got != "" {
+		t.Errorf("nil DmsgStats: got %q, want empty", got)
+	}
+	zero := &visor.Summary{DmsgStats: &dmsgtracker.DmsgClientSummary{}}
+	if got := dmsgLatency(zero); got != "" {
+		t.Errorf("zero RoundTrip: got %q, want empty", got)
+	}
+	measured := &visor.Summary{DmsgStats: &dmsgtracker.DmsgClientSummary{
+		RoundTrip: 8 * time.Millisecond,
+	}}
+	if got := dmsgLatency(measured); got != "8ms" {
+		t.Errorf("measured: got %q, want 8ms", got)
 	}
 }

--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -82,6 +82,21 @@ type ARSelfEntry struct {
 // Empty when the visor has not (yet) bound any transport with AR.
 type ARSelfRegistration struct {
 	Entries []ARSelfEntry `json:"entries,omitempty"`
+	// Queried lists the transport types this visor actually checked, whether or
+	// not it is registered for them. It exists so a caller can tell "asked, not
+	// registered" from "never asked".
+	//
+	// Without it the two are the same silence, and the CLI cannot say which it
+	// is looking at: a type missing from Entries might be unregistered, or the
+	// answering visor might predate that type entirely. That is not
+	// hypothetical here — `--via dmsg://<pk>` and `--rpc` point these commands
+	// at other people's visors across the mesh, running whatever version they
+	// are running. Locally it cannot happen, because the CLI and the visor are
+	// the same binary.
+	//
+	// Empty from a visor too old to report it, which is itself the signal:
+	// nothing can be concluded from a type's absence.
+	Queried []string `json:"queried,omitempty"`
 }
 
 // arSelfState caches the visor's own AR-side bind state, populated by a
@@ -140,7 +155,7 @@ func (s *arSelfState) snapshot() map[string]addrresolver.VisorData { //nolint:un
 // ARSelfInfo returns the visor's own cached AR registration. Reads the
 // in-memory cache populated by the refresh loop — no HTTP round-trip.
 func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
-	out := &ARSelfRegistration{}
+	out := &ARSelfRegistration{Queried: append([]string(nil), arSelfTypes...)}
 	for _, tpType := range arSelfTypes {
 		d, ok := v.arSelf.get(tpType)
 		if !ok {

--- a/pkg/visor/api_ar.go
+++ b/pkg/visor/api_ar.go
@@ -36,7 +36,7 @@ func (v *Visor) CheckAREntry(pk string) ([]string, error) {
 
 	// Try each transport type — only report whether the entry exists,
 	// not the resolved address (privacy).
-	for _, tpType := range []string{"stcpr", "sudph"} {
+	for _, tpType := range arSelfTypes {
 		_, err := arClient.Resolve(ctx, tpType, pubKey)
 		if err == nil {
 			types = append(types, tpType)
@@ -45,6 +45,14 @@ func (v *Visor) CheckAREntry(pk string) ([]string, error) {
 
 	return types, nil
 }
+
+// arSelfTypes are the transport types whose AR registration this visor tracks
+// for itself. WT is here because a visor that serves WebTransport binds an
+// endpoint AND a certificate hash with AR (BindWT), and a browser has to pin
+// that hash to dial it — so "am I registered for WT, and under which cert?" is
+// a question an operator needs answered, and it was previously unanswerable
+// from the CLI.
+var arSelfTypes = []string{"stcpr", "sudph", "wt"}
 
 // ARSelfEntry is one transport-type-row of this visor's own AR registration:
 // the IP:port it is reachable on according to the address-resolver.
@@ -55,11 +63,18 @@ func (v *Visor) CheckAREntry(pk string) ([]string, error) {
 // that don't capture family — same backward-compat shape as the underlying
 // addrresolver.VisorData (#2715).
 type ARSelfEntry struct {
-	Type         string   `json:"type"`                     // "stcpr" or "sudph"
+	Type         string   `json:"type"`                     // "stcpr", "sudph" or "wt"
 	RemoteAddr   string   `json:"remote_addr,omitempty"`    // public IPv4 as AR sees the visor
 	RemoteAddrV6 string   `json:"remote_addr_v6,omitempty"` // public IPv6 as AR sees the visor (#1525 Phase 4a)
 	Port         string   `json:"port,omitempty"`           // listen port
 	Addresses    []string `json:"addresses,omitempty"`      // local interface addresses the visor advertised
+	// CertHash is the SHA-256 of the self-signed certificate a WebTransport
+	// dialler must pin, lowercase hex. WT only — the other carriers have no
+	// certificate. Empty from a visor too old to report it, which is why the
+	// CLI omits the field rather than rendering "(none)": absent here means
+	// "not said", and only a visor that knows about WT can distinguish that
+	// from "not registered".
+	CertHash string `json:"cert_hash,omitempty"`
 }
 
 // ARSelfRegistration is the visor's own AR record across transport types.
@@ -126,7 +141,7 @@ func (s *arSelfState) snapshot() map[string]addrresolver.VisorData { //nolint:un
 // in-memory cache populated by the refresh loop — no HTTP round-trip.
 func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
 	out := &ARSelfRegistration{}
-	for _, tpType := range []string{"stcpr", "sudph"} {
+	for _, tpType := range arSelfTypes {
 		d, ok := v.arSelf.get(tpType)
 		if !ok {
 			continue
@@ -137,6 +152,7 @@ func (v *Visor) ARSelfInfo() (*ARSelfRegistration, error) {
 			RemoteAddrV6: d.RemoteAddrV6,
 			Port:         d.Port,
 			Addresses:    append([]string(nil), d.Addresses...),
+			CertHash:     d.CertHash, // WT only; empty for the other carriers
 		})
 	}
 	return out, nil
@@ -187,7 +203,7 @@ func (v *Visor) arSelfRefreshOnce(ctx context.Context, _ *logging.Logger) {
 		return
 	}
 
-	for _, tpType := range []string{"stcpr", "sudph"} {
+	for _, tpType := range arSelfTypes {
 		rctx, rcancel := context.WithTimeout(ctx, 10*time.Second)
 		data, err := arClient.Resolve(rctx, tpType, v.conf.PK)
 		rcancel()


### PR DESCRIPTION
Three things `skywire cli visor info` was not saying, or saying wrongly.

## WT registration, with the certificate hash

A visor serving WebTransport binds an endpoint AND a certificate hash with the
address resolver, and a browser has to pin that hash to dial it. "Am I
registered for WT, and under which cert?" had no answer from the CLI: the AR
section listed stcpr and sudph only.

```
AR Registration:
  STCPR  1.2.3.4:7777
  SUDPH  1.2.3.4:55555
  WT     1.2.3.4:7773 (cert 9f86d081…b0f00a08)
```

The hash is abbreviated in the summary — 64 hex characters would swamp the line
— and complete in `--json`. Nothing new is resolved to get it: `CertHash` was
already on the `VisorData` that `/resolve/wt` returns; nothing consumed it.

## Absence that can be read

A type missing from `ARSelfInfo` meant two different things and looked
identical: the visor checked and is not registered, or the visor predates that
type and never checked. Rendering it "(not registered)" invents an answer;
omitting it quietly reads as one.

`ARSelfRegistration` now reports which types it queried, so the difference is a
fact rather than an inference. A queried type with no entry says "(not
registered)"; a type the visor never mentioned prints nothing. An older visor
sends no `Queried` list at all, which is itself the signal.

This only matters across versions, and it is not hypothetical — `--via
dmsg://<pk>` and `--rpc` point these commands at other people's visors, running
whatever they are running. Locally it cannot happen, since the CLI and the visor
are the same binary.

## Counts that answer the question, and a latency that was invented

`Transports: 10 (STCPR: 6, SUDPH: 4) to 7 visors` — the totals alone cannot tell
ten links to ten peers from ten links to three, which is usually what is being
asked. The per-type counts are now sorted; they came from ranging a map, so two
identical summaries rendered in different orders.

`DMSG Latency: 0s` is gone unless it was measured. The tracker keys on the
visor's own public key and generally holds no entry for it, so the summary
carried a zero value meaning "unknown" — printed as a confident `0s` directly
beneath servers whose real round-trips were 8ms to 820ms. The nil case is
handled too: the hypervisor path already passes nil deliberately
(`hypervisor_handlers_visors.go` says so), while this call site dereferenced it
blind.

## Tests

`renderARSection` is split out so the asked-versus-never-asked distinction is
testable without an RPC client, with cases for both readings, the cert-hash
rendering, and the unmeasured-latency cases. The existing `TestFormatARAddr`
suite is unchanged and still passes.
