### PR TITLE
cli/proxy: show route in `proxy status` + nest mux ops under `proxy mux`

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux.go
+++ b/cmd/skywire-cli/commands/proxy/mux.go
@@ -1,0 +1,66 @@
+// Package skysocksc cmd/skywire-cli/commands/proxy/mux.go c4-vis-cli
+package skysocksc
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// muxCmd groups the mux'd-route-group operations for a proxy session under a
+// single `proxy mux` parent, instead of a flat pile of `proxy mux-*` commands.
+var muxCmd = &cobra.Command{
+	Use:   "mux",
+	Short: "Mux'd route-group operations for an active proxy session",
+	Long: `Inspect and reshape the multiplexed route group behind a running
+skysocks-client (or vpn-client) session:
+
+  info   per-leg traffic for the active route group(s)
+  set    reconcile the legs to a target set
+  add    add a leg from a piped route
+  rm     remove a leg by transport id
+  mode   change the mux scheduler weighting at runtime
+  auto   adapt legs off live latency to a preset`,
+}
+
+func init() {
+	RootCmd.AddCommand(muxCmd)
+}
+
+// addMuxSub nests sub under the `mux` parent (with its short verb as Use) and
+// preserves the old flat `proxy mux-<verb>` invocation as a hidden alias so
+// existing scripts / muscle-memory keep working. The alias shares sub's Run and
+// flag set (all bound to the same package-level vars), so there is no behavioral
+// drift between the two forms. Call AFTER sub's flags are registered.
+func addMuxSub(sub *cobra.Command, oldName string) {
+	muxCmd.AddCommand(sub)
+
+	alias := &cobra.Command{
+		Use:                   oldName + useArgs(sub.Use),
+		Short:                 sub.Short + " (deprecated: use `proxy mux " + firstWord(sub.Use) + "`)",
+		Hidden:                true,
+		Args:                  sub.Args,
+		DisableFlagsInUseLine: sub.DisableFlagsInUseLine,
+		Run:                   sub.Run,
+		RunE:                  sub.RunE,
+	}
+	alias.Flags().AddFlagSet(sub.Flags())
+	RootCmd.AddCommand(alias)
+}
+
+// firstWord returns the verb of a cobra Use line ("rm <tp-id>" -> "rm").
+func firstWord(use string) string {
+	if i := strings.IndexByte(use, ' '); i >= 0 {
+		return use[:i]
+	}
+	return use
+}
+
+// useArgs returns the argument suffix of a Use line ("rm <tp-id>" -> " <tp-id>",
+// "info" -> ""), so the alias keeps the same usage hint as the nested command.
+func useArgs(use string) string {
+	if i := strings.IndexByte(use, ' '); i >= 0 {
+		return use[i:]
+	}
+	return ""
+}

--- a/cmd/skywire-cli/commands/proxy/mux_auto.go
+++ b/cmd/skywire-cli/commands/proxy/mux_auto.go
@@ -64,11 +64,11 @@ func init() {
 	muxAutoCmd.Flags().DurationVarP(&muxAutoWatch, "watch", "w", 0, "re-evaluate every interval (e.g. 5s); 0 = decide once and exit")
 	muxAutoCmd.Flags().BoolVar(&muxAutoDry, "dry-run", false, "print the prune/grow decision without acting")
 	muxAutoCmd.Flags().IntVar(&muxAutoMinHops, "min-hops", 2, "hop-count floor for legs added when growing toward the preset (>=2 keeps grown legs multihop)")
-	RootCmd.AddCommand(muxAutoCmd)
+	addMuxSub(muxAutoCmd, "mux-auto")
 }
 
 var muxAutoCmd = &cobra.Command{
-	Use:   "mux-auto <fastest|balanced|resilient>",
+	Use:   "auto <fastest|balanced|resilient>",
 	Short: "Adapt a proxy session's mux legs to a preset off live latency",
 	Long: `Adaptive control loop: read the live per-leg latency (mux-info) and
 prune a running proxy's mux toward the preset's intent. The primary route

--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -26,11 +26,11 @@ func init() {
 	muxInfoCmd.Flags().StringVarP(&muxInfoApp, "name", "n", "skysocks-client", "app name to query (e.g. skysocks-client, vpn-client)")
 	muxInfoCmd.Flags().DurationVarP(&muxInfoWatch, "watch", "w", 0, "refresh interval; 0 prints once and exits (e.g. 1s, 500ms)")
 	muxInfoCmd.Flags().BoolVarP(&muxInfoVerbose, "verbose", "v", false, "show full PKs / transport IDs (default: short hex prefixes)")
-	RootCmd.AddCommand(muxInfoCmd)
+	addMuxSub(muxInfoCmd, "mux-info")
 }
 
 var muxInfoCmd = &cobra.Command{
-	Use:   "mux-info",
+	Use:   "info",
 	Short: "Show per-mux-leg traffic for an active proxy session",
 	Long: `Show per-mux-leg traffic for active route groups belonging to a named app.
 
@@ -43,10 +43,10 @@ The query is local to this visor; what you see is your visor's view
 of what it sent/received on each leg, not the peer's view.
 
 Examples:
-  skywire cli proxy mux-info                   # one snapshot, default app
-  skywire cli proxy mux-info --watch 1s        # refresh every second
-  skywire cli proxy mux-info -n vpn-client     # query a different app
-  skywire cli proxy mux-info --json            # machine-readable`,
+  skywire cli proxy mux info                    # one snapshot, default app
+  skywire cli proxy mux info --watch 1s         # refresh every second
+  skywire cli proxy mux info -n vpn-client      # query a different app
+  skywire cli proxy mux info --json             # machine-readable`,
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, _ []string) {
 		rpcClient, err := clirpc.Client(cmd.Flags())

--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -57,9 +57,9 @@ func init() {
 	muxAddCmd.Flags().StringVar(&muxAddRouteSrc, "route", "-", "route JSON file ('-' = stdin); shape is 'cli route calc --json' output")
 	muxRmCmd.Flags().StringVarP(&muxOpsApp, "name", "n", "skysocks-client", "app whose route group to modify")
 	muxRmCmd.Flags().Uint16Var(&muxOpsSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
-	RootCmd.AddCommand(muxAddCmd)
-	RootCmd.AddCommand(muxRmCmd)
-	RootCmd.AddCommand(muxModeCmd)
+	addMuxSub(muxAddCmd, "mux-add")
+	addMuxSub(muxRmCmd, "mux-rm")
+	addMuxSub(muxModeCmd, "mux-mode")
 }
 
 // routePair mirrors the shape 'cli route calc --json' emits.
@@ -104,7 +104,7 @@ func readRoutePair(src string) (routePair, error) {
 }
 
 var muxAddCmd = &cobra.Command{
-	Use:   "mux-add",
+	Use:   "add",
 	Short: "Add a leg to an active proxy session's mux'd rg from a piped route",
 	Long: `Add a mux leg over a caller-supplied route. The route is read
 as JSON (default: stdin; --route <file> reads from a file) and uses
@@ -152,7 +152,7 @@ Example:
 }
 
 var muxRmCmd = &cobra.Command{
-	Use:   "mux-rm <tp-id>",
+	Use:   "rm <tp-id>",
 	Short: "Remove a leg from an active proxy session's mux'd route group",
 	Long: `Remove the mux leg routed via the specified transport.
 
@@ -189,7 +189,7 @@ Example:
 }
 
 var muxModeCmd = &cobra.Command{
-	Use:   "mux-mode <auto|equal>",
+	Use:   "mode <auto|equal>",
 	Short: "Change mux scheduler weighting at runtime",
 	Long: `Set the mux transport-selection mode for the visor.
 

--- a/cmd/skywire-cli/commands/proxy/mux_set.go
+++ b/cmd/skywire-cli/commands/proxy/mux_set.go
@@ -49,7 +49,7 @@ func init() {
 	muxSetCmd.Flags().Uint16Var(&muxSetSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
 	muxSetCmd.Flags().StringVar(&muxSetFile, "legs", "-", "leg-set JSON file ('-' = stdin): array of {forward,reverse} pairs ('cli route calc --json' shape)")
 	muxSetCmd.Flags().BoolVar(&muxSetPrune, "prune", false, "also remove current legs not in the target set (exact reconcile). Careful: the primary route is a leg too — include it or it's removed")
-	RootCmd.AddCommand(muxSetCmd)
+	addMuxSub(muxSetCmd, "mux-set")
 }
 
 // readRoutePairs reads an array (or a single object) of {forward,reverse}
@@ -120,7 +120,7 @@ func currentLegTpIDs(infos any, srcPort uint16) (map[uuid.UUID]struct{}, error) 
 }
 
 var muxSetCmd = &cobra.Command{
-	Use:   "mux-set",
+	Use:   "set",
 	Short: "Reconcile an active proxy session's mux legs to a target set",
 	Long: `Reconcile a mux'd proxy session's legs to a caller-supplied target
 set in one shot — the static-mux building block (and the actuation the

--- a/cmd/skywire-cli/commands/proxy/proxy.go
+++ b/cmd/skywire-cli/commands/proxy/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -517,11 +518,12 @@ var statusCmd = &cobra.Command{
 		w := tabwriter.NewWriter(&b, 0, 0, 5, ' ', tabwriter.TabIndent)
 		internal.Catch(cmd.Flags(), err)
 		type appState struct {
-			Name      string       `json:"name"`
-			Status    string       `json:"status"`
-			AutoStart bool         `json:"autostart"`
-			Args      []string     `json:"args"`
-			AppPort   routing.Port `json:"app_port"`
+			Name      string              `json:"name"`
+			Status    string              `json:"status"`
+			AutoStart bool                `json:"autostart"`
+			Args      []string            `json:"args"`
+			AppPort   routing.Port        `json:"app_port"`
+			Route     []muxRouteGroupInfo `json:"route,omitempty"`
 		}
 		var jsonAppStatus []appState
 		_, err = fmt.Fprintf(w, "---- All Proxy List -----------------------------------------------------\n\n")
@@ -538,13 +540,6 @@ var statusCmd = &cobra.Command{
 					if state.Status == appserver.AppStatusErrored {
 						status = "errored"
 					}
-					jsonAppStatus = append(jsonAppStatus, appState{
-						Name:      state.Name,
-						Status:    status,
-						AutoStart: state.AutoStart,
-						Args:      state.Args,
-						AppPort:   state.Port,
-					})
 					var tmpAddr string
 					var tmpSrv string
 					for idx, arg := range state.Args {
@@ -555,7 +550,24 @@ var statusCmd = &cobra.Command{
 							tmpAddr = "127.0.0.1" + state.Args[idx+1]
 						}
 					}
-					_, err = fmt.Fprintf(w, "Name: %s\nStatus: %s\nServer: %s\nAddress: %s\nAppPort: %d\nAutoStart: %t\n\n", state.Name, status, tmpSrv, tmpAddr, state.Port, state.AutoStart)
+					// For a running client, surface the active route group(s) so
+					// the operator can tell which client owns which route (the
+					// server PK + first-hop transport per leg) without a separate
+					// `proxy mux info` call — and can spot a fragile single-leg
+					// route at a glance.
+					var route []muxRouteGroupInfo
+					if status == "running" {
+						route = fetchProxyRoute(rpcClient, state.Name)
+					}
+					jsonAppStatus = append(jsonAppStatus, appState{
+						Name:      state.Name,
+						Status:    status,
+						AutoStart: state.AutoStart,
+						Args:      state.Args,
+						AppPort:   state.Port,
+						Route:     route,
+					})
+					_, err = fmt.Fprintf(w, "Name: %s\nStatus: %s\nServer: %s\nAddress: %s\nAppPort: %d\nAutoStart: %t\n%s\n", state.Name, status, tmpSrv, tmpAddr, state.Port, state.AutoStart, renderProxyRoute(route))
 					internal.Catch(cmd.Flags(), err)
 				}
 			}
@@ -567,6 +579,59 @@ var statusCmd = &cobra.Command{
 		internal.Catch(cmd.Flags(), w.Flush())
 		internal.PrintOutput(cmd.Flags(), jsonAppStatus, b.String())
 	},
+}
+
+// fetchProxyRoute returns this visor's view of the active route group(s) for a
+// proxy app (same data as `proxy mux info`), decoded via the local mirror
+// struct so the JSON contract stays the boundary. Returns nil on any error — a
+// running proxy that hasn't finished dialing simply has no route yet.
+func fetchProxyRoute(rpcClient visor.API, appName string) []muxRouteGroupInfo {
+	infos, err := rpcClient.RouteGroupMuxInfo(appName)
+	if err != nil {
+		return nil
+	}
+	raw, err := json.Marshal(infos)
+	if err != nil {
+		return nil
+	}
+	var rgs []muxRouteGroupInfo
+	if err := json.Unmarshal(raw, &rgs); err != nil {
+		return nil
+	}
+	return rgs
+}
+
+// renderProxyRoute formats the active route group(s) for `proxy status`: the
+// destination + each leg's first-hop transport (type, remote, latency). A
+// single-leg route is flagged since it has no failover — a first-hop flap drops
+// the whole session (the common cause of intermittent proxy drops).
+func renderProxyRoute(rgs []muxRouteGroupInfo) string {
+	if len(rgs) == 0 {
+		return "Route: (no active route group)"
+	}
+	var sb strings.Builder
+	for i, rg := range rgs {
+		plural := "legs"
+		if len(rg.Legs) == 1 {
+			plural = "leg"
+		}
+		fmt.Fprintf(&sb, "Route: %d %s to %s:%d", len(rg.Legs), plural, shortPK(rg.Desc.DstPK), rg.Desc.DstPort)
+		sort.SliceStable(rg.Legs, func(a, b int) bool { return rg.Legs[a].Index < rg.Legs[b].Index })
+		for _, leg := range rg.Legs {
+			lat := ""
+			if leg.LatencyMS > 0 {
+				lat = fmt.Sprintf(" %.0fms", leg.LatencyMS)
+			}
+			fmt.Fprintf(&sb, "  [%d] %s→%s%s", leg.Index, leg.TpType, shortPK(leg.RemotePK), lat)
+		}
+		if len(rg.Legs) == 1 {
+			sb.WriteString("  (single leg — no failover; grow with `proxy mux set`)")
+		}
+		if i < len(rgs)-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
 }
 
 var (


### PR DESCRIPTION
Two operator-usability changes to `skywire cli proxy`, motivated by debugging intermittent skysocks-client route drops.

## 1. `proxy status` shows the active route

Each running client now prints its live route — destination + each mux leg's first-hop transport (type, remote PK, latency), via `RouteGroupMuxInfo`:

```
Name: skysocks-client
Status: running
Server: 02f9aa58…6c36
Address: 127.0.0.1:1080
AppPort: 13
AutoStart: true
Route: 1 leg to 0323272a…9d4c:49183  [0] stcpr→02f9aa58…6c36 153ms  (single leg — no failover; grow with `proxy mux set`)
```

- A **single-leg** route is flagged, because a first-hop flap on a lone leg drops the whole session — the common cause of intermittent proxy drops (a webrtc first hop is especially prone to it).
- This also makes it obvious **which client owns which route** — previously a bare `proxy mux info` gave leg data with no clear association to a client.
- Included in `--json` as a `route` field.

## 2. `proxy mux-*` → `proxy mux <sub>`

The flat pile of `mux-add / mux-auto / mux-info / mux-mode / mux-rm / mux-set` is regrouped under a `proxy mux` parent:

```
proxy mux add | auto | info | mode | rm | set
```

The old `mux-*` forms are kept as **hidden, deprecated aliases** (sharing the same `Run` + flag set), so existing scripts and muscle-memory keep working.

## Testing

Validated live against a running visor: `proxy status` shows the route line + single-leg flag; `proxy mux` lists the six subcommands; `proxy mux-info` still works via the alias. `go build .` clean, gofmt clean.