### PR TITLE
wasm-visor: carry the skycoin browser cipher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,17 +98,19 @@ INFO?=$(VERSION) $(DATE) $(COMMIT) $(BUILDTAG)
 # built from, so WASM_VERSION uses --dirty: a blob built from an uncommitted
 # tree says so, in a string TestCommittedWasmBuiltFromCommit can find.
 #
-# It has to come from here rather than from Go. Go's own vcs.revision/
-# vcs.modified — which the equivalent skycoin check reads — is not available:
-# GOOS=js does not emit a readable buildinfo blob at all (no "Go buildinf"
-# magic, and `go version -m` cannot parse wasm). The 0magnet/tinygo build DOES
-# record it, so the test reads both signals and requires Go's stamp only of the
-# TinyGo artifact, which is the only one that has it.
+# It is stamped here as well as by Go, not instead of it. `go version -m` cannot
+# parse wasm, but that is a limitation of that command rather than of the
+# format: Go writes vcs.revision/vcs.modified into a GOOS=js binary as plain
+# text, and skycoin reads them straight out of its own js/wasm cipher in
+# ci-scripts/check-wasm-version.js. The committed std-Go blob here carries none
+# only because it was built while this file still passed -buildvcs=false; once
+# it is regenerated it will, and the test can require it of both artifacts
+# rather than of the TinyGo one alone.
 #
 # -buildvcs=false was previously passed on the std-Go build to keep a "+dirty"
-# suffix out of the version of a blob built from an uncommitted tree. It is gone
-# — suppressing the marker removed the evidence rather than the problem — though
-# on js/wasm it never had an observable effect either way.
+# suffix out of the version of a blob built from an uncommitted tree. It is gone:
+# suppressing the marker removed the evidence rather than the problem, and it
+# also removed the vcs records the test would otherwise be able to require.
 # The repo's OWN pkg/buildinfo (vs skywire-utilities' above). Despite the
 # historical WASM_ prefix there is nothing wasm about the path — the wasm-visor
 # was simply the first target that needed to stamp it. The skywire-mobile

--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -60,6 +60,7 @@ import (
 
 	"github.com/google/uuid"
 
+	wasmcipher "github.com/skycoin/skycoin/src/skycoin-lite/wasmcipher"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/app/appcommon"
 	"github.com/skycoin/skywire/pkg/app/appdisc"
@@ -156,6 +157,19 @@ func main() {
 		fmt.Println("wasm-visor: shell role — call skywireShell.open(el)")
 		keepAlive()
 	}
+	// Publish the skycoin browser cipher on the same page.
+	//
+	// The wallet in skycoin's src/skycoin-web reaches its cipher only through
+	// window.SkycoinCipher (see cipher.provider.ts there), so a visor that
+	// registers it is a drop-in for skycoin-lite.wasm and the page cannot tell
+	// the difference. That is what lets one wasm serve both: the wallet gets its
+	// key derivation and transaction signing, and the visor underneath can make
+	// the node requests itself instead of the wallet proxying them.
+	//
+	// Register returns once the objects are in place; it does not block, so the
+	// visor keeps owning the program's lifetime.
+	wasmcipher.Register()
+
 	js.Global().Set("skywireVisor", js.ValueOf(map[string]interface{}{
 		"boot":          js.FuncOf(jsBoot),
 		"status":        js.FuncOf(jsStatus),

--- a/pkg/wasmhv/wasmbin/provenance_test.go
+++ b/pkg/wasmhv/wasmbin/provenance_test.go
@@ -14,13 +14,18 @@ import (
 // committedBlob is a wasm artifact kept in the repository.
 type committedBlob struct {
 	path string
-	// goStamped is true where the toolchain records Go's own
-	// vcs.revision/vcs.modified. Only the TinyGo build does — see the comment
-	// on TestCommittedWasmBuiltFromCommit.
+	// goStamped requires Go's own vcs.revision to be present, rather than only
+	// checking it when it happens to be. See the comment on
+	// TestCommittedWasmBuiltFromCommit for why the std-Go blob does not require
+	// it yet.
 	goStamped bool
 }
 
 var committedBlobs = []committedBlob{
+	// Not goStamped yet: the committed blob predates the removal of
+	// -buildvcs=false, so it carries no vcs.revision. Once it is regenerated it
+	// will, and this can require it. Until then the check below still rejects a
+	// vcs.modified=true if one appears.
 	{path: filepath.Join("wasmgo", "wasm-visor.wasm.gz")},
 	{path: filepath.Join("wasmtinygo", "wasm-visor.wasm.gz"), goStamped: true},
 }
@@ -55,11 +60,15 @@ var goRevision = regexp.MustCompile(`vcs\.revision=[0-9a-f]{40}`)
 //   - the Makefile stamps WASM_VERSION from `git describe --always --dirty`,
 //     which both builds carry. This is the load-bearing one.
 //   - Go's own vcs.revision/vcs.modified, which the equivalent check in skycoin
-//     reads, exists ONLY in the TinyGo artifact. GOOS=js emits no readable
-//     buildinfo — no "Go buildinf" magic, and `go version -m` cannot parse
-//     wasm — so requiring it of the std-Go blob would fail every time. Note
-//     that a bare "vcs.revision" string DOES appear in any binary linking
-//     runtime/debug, which is why the pattern here requires the value too.
+//     reads. `go version -m` cannot parse wasm, but that is a limitation of
+//     that command, not of the format: the records themselves are written into
+//     a GOOS=js binary as plain text and can be read straight out of it, which
+//     is exactly what skycoin's ci-scripts/check-wasm-version.js does to its
+//     own js/wasm cipher. The std-Go blob here carries none only because it was
+//     built while the Makefile still passed -buildvcs=false; the TinyGo one,
+//     built without it, carries them. Note that a bare "vcs.revision" string
+//     DOES appear in any binary linking runtime/debug, which is why the pattern
+//     here requires the value too.
 //
 // The revision is not checked against HEAD. Committing an artifact necessarily
 // moves HEAD past the commit it was built at, so requiring equality would fail

--- a/vendor/github.com/skycoin/skycoin/src/skycoin-lite/liteclient/client.go
+++ b/vendor/github.com/skycoin/skycoin/src/skycoin-lite/liteclient/client.go
@@ -1,0 +1,230 @@
+// Package liteclient implements a lightweight Skycoin client
+//
+// Every exported function reports failure by returning an error. It used to
+// panic instead, which the wasm entry points turned back into an error with
+// recover — and that only works on the standard toolchain. Under TinyGo the
+// recover does not fire and the panic traps the whole module, so a mistyped
+// destination address killed the browser cipher for the rest of the page rather
+// than being rejected. Returning errors is also what makes these paths testable
+// without a browser.
+package liteclient
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	"github.com/skycoin/skycoin/src/coin"
+)
+
+// Address includes a skycoin address, a public and secret key
+// and the next seed to generate the next address from
+type Address struct {
+	NextSeed string
+	Secret   string
+	Public   string
+	Address  string
+}
+
+// TransactionInput represents a transaction input
+type TransactionInput struct {
+	Hash   string
+	Secret string
+}
+
+// TransactionOutput represents a transaction output
+type TransactionOutput struct {
+	Address string
+	Coins   uint64
+	Hours   uint64
+}
+
+var (
+	// ErrNullOutputAddress is returned when a transaction would send to the null
+	// address, which would burn the coins.
+	ErrNullOutputAddress = errors.New("output address is the null address")
+
+	// ErrNoInputs is returned when a transaction to be signed has no inputs.
+	ErrNoInputs = errors.New("transaction has no inputs to sign")
+
+	// ErrTooManyInputs is returned when a transaction has more inputs than the
+	// encoding can represent.
+	ErrTooManyInputs = errors.New("transaction has too many inputs")
+)
+
+// GenerateAddress generates an address from a seed. The seed should be hex-encoded bytes.
+func GenerateAddress(seed string) (Address, error) {
+	addresses, err := GenerateAddresses(seed, 1)
+	if err != nil {
+		return Address{}, err
+	}
+
+	return addresses[0], nil
+}
+
+// GenerateAddresses generates addresses from a seed. The seed should be hex-encoded bytes.
+func GenerateAddresses(seed string, num int) ([]Address, error) {
+	addresses := make([]Address, num)
+
+	nextSeed := seed
+	for i := 0; i < num; i++ {
+		decodedSeed, err := hex.DecodeString(nextSeed)
+		if err != nil {
+			return nil, err
+		}
+
+		next, keys, err := cipher.GenerateDeterministicKeyPairsSeed(decodedSeed, 1)
+		if err != nil {
+			return nil, err
+		}
+
+		nextSeed = hex.EncodeToString(next)
+		pub, err := cipher.PubKeyFromSecKey(keys[0])
+		if err != nil {
+			return nil, err
+		}
+
+		addresses[i] = Address{
+			NextSeed: nextSeed,
+			Secret:   keys[0].Hex(),
+			Public:   pub.Hex(),
+			Address:  cipher.AddressFromPubKey(pub).String(),
+		}
+	}
+
+	return addresses, nil
+}
+
+// PrepareTransaction receives inputs and outputs and returns a signed transaction
+// inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
+func PrepareTransaction(inputsBody string, outputsBody string) (string, error) {
+	return prepareTransaction(inputsBody, outputsBody, nil)
+}
+
+// PrepareTransactionWithSignatures receives inputs, outputs,and the signatures and returns.
+// inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
+// signatureList is a JSONified array of strings.
+func PrepareTransactionWithSignatures(inputsBody string, outputsBody string, signatureList string) (string, error) {
+	var signatures []string
+	if err := json.Unmarshal([]byte(signatureList), &signatures); err != nil {
+		return "", err
+	}
+
+	return prepareTransaction(inputsBody, outputsBody, signatures)
+}
+
+func prepareTransaction(inputsBody string, outputsBody string, signatureList []string) (string, error) {
+	newTransaction, err := buildTransaction(inputsBody, outputsBody, signatureList)
+	if err != nil {
+		return "", err
+	}
+
+	d, err := newTransaction.Serialize()
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(d), nil
+}
+
+// Creates a coin.Transaction using the given lists of inputs, outputs and signatures. If signatureList is nil or
+// empty the signatures are created using the Secret property of each input.
+// inputsBody and outputsBody are JSONified arrays of TransactionInput and TransactionOutput, respectively.
+func buildTransaction(inputsBody string, outputsBody string, signatureList []string) (coin.Transaction, error) {
+	var inputs []TransactionInput
+	var outputs []TransactionOutput
+
+	newTransaction := coin.Transaction{}
+
+	if err := json.Unmarshal([]byte(inputsBody), &inputs); err != nil {
+		return newTransaction, err
+	}
+
+	if err := json.Unmarshal([]byte(outputsBody), &outputs); err != nil {
+		return newTransaction, err
+	}
+
+	keys := make([]cipher.SecKey, len(inputs))
+
+	for i, in := range inputs {
+		if len(signatureList) == 0 {
+			k, err := cipher.SecKeyFromHex(in.Secret)
+			if err != nil {
+				return newTransaction, err
+			}
+
+			keys[i] = k
+		}
+
+		inputHash, err := cipher.SHA256FromHex(in.Hash)
+		if err != nil {
+			return newTransaction, err
+		}
+
+		if err := newTransaction.PushInput(inputHash); err != nil {
+			return newTransaction, err
+		}
+	}
+
+	for _, out := range outputs {
+		addr, err := cipher.DecodeBase58Address(out.Address)
+		if err != nil {
+			return newTransaction, err
+		}
+
+		if addr.Null() {
+			return newTransaction, ErrNullOutputAddress
+		}
+
+		if err := newTransaction.PushOutput(addr, out.Coins, out.Hours); err != nil {
+			return newTransaction, err
+		}
+	}
+
+	if len(signatureList) == 0 {
+		// Not coin.Transaction.SignInputs: it reports every one of these through
+		// log.Panic, including the empty-input case a caller can trigger, and
+		// signs with cipher.MustSignHash, which panics on a secret key that is
+		// well-formed hex but not a valid key.
+		if len(keys) == 0 {
+			return newTransaction, ErrNoInputs
+		}
+
+		if len(keys) > math.MaxUint16 {
+			return newTransaction, ErrTooManyInputs
+		}
+
+		newTransaction.InnerHash = newTransaction.HashInner()
+		newTransaction.Sigs = make([]cipher.Sig, len(keys))
+		for i, key := range keys {
+			sig, err := cipher.SignHash(cipher.AddSHA256(newTransaction.InnerHash, newTransaction.In[i]), key)
+			if err != nil {
+				return newTransaction, err
+			}
+
+			newTransaction.Sigs[i] = sig
+		}
+	} else {
+		newTransaction.Sigs = make([]cipher.Sig, len(signatureList))
+		for i, sig := range signatureList {
+			parsed, err := cipher.SigFromHex(sig)
+			if err != nil {
+				return newTransaction, err
+			}
+
+			newTransaction.Sigs[i] = parsed
+		}
+	}
+
+	if err := newTransaction.UpdateHeader(); err != nil {
+		return newTransaction, err
+	}
+
+	if err := newTransaction.Verify(); err != nil {
+		return newTransaction, err
+	}
+
+	return newTransaction, nil
+}

--- a/vendor/github.com/skycoin/skycoin/src/skycoin-lite/liteclient/extras.go
+++ b/vendor/github.com/skycoin/skycoin/src/skycoin-lite/liteclient/extras.go
@@ -1,0 +1,180 @@
+package liteclient
+
+import (
+	"errors"
+
+	"github.com/skycoin/skycoin/src/cipher"
+	secp256k1 "github.com/skycoin/skycoin/src/cipher/secp256k1-go"
+)
+
+/*
+Functions used mainly during test procedures.
+
+Like the rest of the package these report failure by returning an error. They
+used to panic, both directly and through the cipher Must* constructors, which
+made a malformed hex string from a caller indistinguishable from a real
+verification failure and killed the wasm module outright under TinyGo.
+*/
+
+var (
+	// ErrInvalidSecKey is returned when a secret key does not verify.
+	ErrInvalidSecKey = errors.New("invalid secret key")
+
+	// ErrInvalidPubKey is returned when a public key does not verify.
+	ErrInvalidPubKey = errors.New("invalid public key")
+)
+
+// VerifyPubKeySignedHash verifies that hash was signed by PubKey
+func VerifyPubKeySignedHash(pubkey, sig, hash string) error {
+	p, err := cipher.PubKeyFromHex(pubkey)
+	if err != nil {
+		return err
+	}
+
+	s, err := cipher.SigFromHex(sig)
+	if err != nil {
+		return err
+	}
+
+	h, err := cipher.SHA256FromHex(hash)
+	if err != nil {
+		return err
+	}
+
+	return cipher.VerifyPubKeySignedHash(p, s, h)
+}
+
+// VerifyAddressSignedHash checks whether PubKey corresponding to address hash signed hash
+// - recovers the PubKey from sig and hash
+// - fail if PubKey cannot be be recovered
+// - computes the address from the PubKey
+// - fail if recovered address does not match PubKey hash
+// - verify that signature is valid for hash for PubKey
+func VerifyAddressSignedHash(address, sig, hash string) error {
+	a, err := cipher.DecodeBase58Address(address)
+	if err != nil {
+		return err
+	}
+
+	h, err := cipher.SHA256FromHex(hash)
+	if err != nil {
+		return err
+	}
+
+	s, err := cipher.SigFromHex(sig)
+	if err != nil {
+		return err
+	}
+
+	return cipher.VerifyAddressSignedHash(a, s, h)
+}
+
+// VerifySignatureRecoverPubKey this only checks that the signature can be converted to a public key.
+// It does not check that the signature signed the hash.
+// The original public key or address is required to verify that the signature signed the hash.
+func VerifySignatureRecoverPubKey(sig, hash string) error {
+	s, err := cipher.SigFromHex(sig)
+	if err != nil {
+		return err
+	}
+
+	h, err := cipher.SHA256FromHex(hash)
+	if err != nil {
+		return err
+	}
+
+	return cipher.VerifySignatureRecoverPubKey(s, h)
+}
+
+// VerifySeckey validate a private key
+func VerifySeckey(seckey string) error {
+	s, err := cipher.SecKeyFromHex(seckey)
+	if err != nil {
+		return err
+	}
+
+	if secp256k1.VerifySeckey(s[:]) != 1 {
+		return ErrInvalidSecKey
+	}
+
+	return nil
+}
+
+// VerifyPubkey validate a public key
+func VerifyPubkey(pubkey string) error {
+	p, err := cipher.PubKeyFromHex(pubkey)
+	if err != nil {
+		return err
+	}
+
+	if secp256k1.VerifyPubkey(p[:]) != 1 {
+		return ErrInvalidPubKey
+	}
+
+	return nil
+}
+
+// AddressFromPubKey creates Address from PubKey as ripemd160(sha256(sha256(pubkey)))
+func AddressFromPubKey(pubkey string) (string, error) {
+	p, err := cipher.PubKeyFromHex(pubkey)
+	if err != nil {
+		return "", err
+	}
+
+	return cipher.AddressFromPubKey(p).String(), nil
+}
+
+// AddressFromSecKey generates address from secret key
+func AddressFromSecKey(seckey string) (string, error) {
+	s, err := cipher.SecKeyFromHex(seckey)
+	if err != nil {
+		return "", err
+	}
+
+	address, err := cipher.AddressFromSecKey(s)
+	if err != nil {
+		return "", err
+	}
+
+	return address.String(), nil
+}
+
+// PubKeyFromSig recovers the public key from a signed hash
+func PubKeyFromSig(sig string, hash string) (string, error) {
+	s, err := cipher.SigFromHex(sig)
+	if err != nil {
+		return "", err
+	}
+
+	h, err := cipher.SHA256FromHex(hash)
+	if err != nil {
+		return "", err
+	}
+
+	pubKey, err := cipher.PubKeyFromSig(s, h)
+	if err != nil {
+		return "", err
+	}
+
+	return pubKey.Hex(), nil
+}
+
+// SignHash sign hash
+func SignHash(hash string, seckey string) (string, error) {
+	h, err := cipher.SHA256FromHex(hash)
+	if err != nil {
+		return "", err
+	}
+
+	s, err := cipher.SecKeyFromHex(seckey)
+	if err != nil {
+		return "", err
+	}
+
+	sig, err := cipher.SignHash(h, s)
+	if err != nil {
+		return "", err
+	}
+
+	return sig.Hex(), nil
+}

--- a/vendor/github.com/skycoin/skycoin/src/skycoin-lite/wasmcipher/wasmcipher.go
+++ b/vendor/github.com/skycoin/skycoin/src/skycoin-lite/wasmcipher/wasmcipher.go
@@ -1,0 +1,217 @@
+//go:build wasm
+
+// Package wasmcipher publishes the skycoin browser cipher on the JavaScript
+// global object.
+//
+// It lives in a package rather than in a main so that any wasm program can carry
+// the cipher, not just the one built from src/skycoin-lite/wasm. The wallet
+// front end reaches the cipher only through window.SkycoinCipher — see
+// cipher.provider.ts in src/skycoin-web — so a larger wasm that calls Register
+// is a drop-in for skycoin-lite.wasm, and the page cannot tell the difference.
+// That is what would let a single wasm serve both a visor and the wallet.
+//
+// Register does not block. The caller owns the program's lifetime, because a
+// host that carries the cipher alongside other things has its own reason to
+// stay alive.
+package wasmcipher
+
+import (
+	"fmt"
+	"runtime/debug"
+	"syscall/js"
+
+	"github.com/skycoin/skycoin/src/skycoin-lite/liteclient"
+)
+
+// buildVersion reports what this wasm was built from.
+//
+// The toolchain already records it: a `go build` inside a git work tree stamps
+// the module version and the vcs.* settings into the binary, so nothing needs
+// injecting through -ldflags. Reading it back is the only way to tell, from a
+// running wallet, which cipher it is actually holding — the wasm is a committed
+// artifact, so the commit it was built at is necessarily an earlier one than the
+// commit that carries it.
+//
+// modified is the interesting field. It means the working tree had uncommitted
+// changes when this was compiled, so no commit describes what is in it.
+//
+// version describes the wasm program that called Register, which is what
+// identifies the module the browser actually loaded. When that program is not
+// skycoin — a visor carrying the cipher — cipherVersion additionally reports the
+// skycoin version it was built against, read from the dependency list the way
+// `skywire -d | grep skycoin` shows it. Both matter: one says which binary is
+// running, the other which cipher is inside it.
+//
+// The upstream TinyGo does not record any of this and reports empty strings;
+// github.com/0magnet/tinygo does.
+// skycoinModulePath is this module, used to find the cipher's own version when
+// the wasm was built from a different one.
+const skycoinModulePath = "github.com/skycoin/skycoin"
+
+func buildVersion() map[string]interface{} {
+	version := map[string]interface{}{
+		"version":       "",
+		"commit":        "",
+		"date":          "",
+		"modified":      false,
+		"cipherVersion": "",
+	}
+
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return version
+	}
+
+	version["version"] = info.Main.Version
+
+	// The cipher's own version, when the host is something else.
+	if info.Main.Path == skycoinModulePath || info.Main.Path == "" {
+		version["cipherVersion"] = info.Main.Version
+	} else {
+		for _, dep := range info.Deps {
+			if dep.Path == skycoinModulePath {
+				version["cipherVersion"] = dep.Version
+
+				break
+			}
+		}
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			version["commit"] = setting.Value
+		case "vcs.time":
+			version["date"] = setting.Value
+		case "vcs.modified":
+			version["modified"] = setting.Value == "true"
+		}
+	}
+
+	return version
+}
+
+// errorResult is what every entry point returns when it could not do its job.
+// Callers check for the "error" key, so the shape has to be a map even when the
+// success value is a plain string.
+func errorResult(err interface{}) map[string]interface{} {
+	return map[string]interface{}{"error": fmt.Sprint(err)}
+}
+
+// guard runs fn and turns a panic into an {"error": ...} result.
+//
+// liteclient returns errors now, so nothing below is expected to panic and this
+// should never fire. It stays as a backstop for the cipher package underneath,
+// which still reports some failures that way.
+//
+// It cannot be relied on. Under TinyGo the recover does not fire at all and a
+// panic traps the whole module, leaving the cipher dead for the rest of the
+// page — which is why the errors are returned rather than recovered.
+func guard(fn func() (interface{}, error)) (result interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			result = errorResult(r)
+		}
+	}()
+
+	value, err := fn()
+	if err != nil {
+		return errorResult(err)
+	}
+
+	return value
+}
+
+// arity wraps a function of n string arguments, rejecting short calls before
+// they reach the cipher.
+func arity(n int, name string, fn func(args []js.Value) (interface{}, error)) js.Func {
+	return js.FuncOf(func(_ js.Value, args []js.Value) interface{} {
+		if len(args) < n {
+			return errorResult(fmt.Sprintf("%s requires %d argument(s)", name, n))
+		}
+
+		return guard(func() (interface{}, error) { return fn(args) })
+	})
+}
+
+// Register publishes SkycoinCipher and SkycoinCipherExtras on the JavaScript
+// global object. It returns once they are in place.
+func Register() {
+	// The wallet's own entry points.
+	skycoinCipher := js.Global().Get("Object").New()
+
+	skycoinCipher.Set("generateAddress", arity(1, "generateAddress", func(args []js.Value) (interface{}, error) {
+		address, err := liteclient.GenerateAddress(args[0].String())
+		if err != nil {
+			return nil, err
+		}
+
+		return map[string]interface{}{
+			"nextSeed": address.NextSeed,
+			"secret":   address.Secret,
+			"public":   address.Public,
+			"address":  address.Address,
+		}, nil
+	}))
+
+	skycoinCipher.Set("prepareTransaction", arity(2, "prepareTransaction", func(args []js.Value) (interface{}, error) {
+		return liteclient.PrepareTransaction(args[0].String(), args[1].String())
+	}))
+
+	// prepareTransactionWithSignatures is used for hardware wallet signing.
+	skycoinCipher.Set("prepareTransactionWithSignatures", arity(3, "prepareTransactionWithSignatures", func(args []js.Value) (interface{}, error) {
+		return liteclient.PrepareTransactionWithSignatures(args[0].String(), args[1].String(), args[2].String())
+	}))
+
+	skycoinCipher.Set("version", buildVersion())
+
+	js.Global().Set("SkycoinCipher", skycoinCipher)
+
+	// The verification helpers. These exist so the browser cipher can be checked
+	// against src/cipher/testsuite/testdata — the same golden vectors the Go
+	// implementation is checked against — by
+	// src/skycoin-web/src/app/services/cipher.provider.lib.spec.ts. The GopherJS
+	// build publishes the same set as CipherExtras.
+	//
+	// Each verify* returns null when the check passes and an error string when it
+	// does not, rather than the int the underlying secp256k1 helpers use.
+	skycoinCipherExtras := js.Global().Get("Object").New()
+
+	skycoinCipherExtras.Set("verifyPubKeySignedHash", arity(3, "verifyPubKeySignedHash", func(args []js.Value) (interface{}, error) {
+		return nil, liteclient.VerifyPubKeySignedHash(args[0].String(), args[1].String(), args[2].String())
+	}))
+
+	skycoinCipherExtras.Set("verifyAddressSignedHash", arity(3, "verifyAddressSignedHash", func(args []js.Value) (interface{}, error) {
+		return nil, liteclient.VerifyAddressSignedHash(args[0].String(), args[1].String(), args[2].String())
+	}))
+
+	skycoinCipherExtras.Set("verifySignatureRecoverPubKey", arity(2, "verifySignatureRecoverPubKey", func(args []js.Value) (interface{}, error) {
+		return nil, liteclient.VerifySignatureRecoverPubKey(args[0].String(), args[1].String())
+	}))
+
+	skycoinCipherExtras.Set("verifySeckey", arity(1, "verifySeckey", func(args []js.Value) (interface{}, error) {
+		return nil, liteclient.VerifySeckey(args[0].String())
+	}))
+
+	skycoinCipherExtras.Set("verifyPubkey", arity(1, "verifyPubkey", func(args []js.Value) (interface{}, error) {
+		return nil, liteclient.VerifyPubkey(args[0].String())
+	}))
+
+	skycoinCipherExtras.Set("addressFromPubKey", arity(1, "addressFromPubKey", func(args []js.Value) (interface{}, error) {
+		return liteclient.AddressFromPubKey(args[0].String())
+	}))
+
+	skycoinCipherExtras.Set("addressFromSecKey", arity(1, "addressFromSecKey", func(args []js.Value) (interface{}, error) {
+		return liteclient.AddressFromSecKey(args[0].String())
+	}))
+
+	skycoinCipherExtras.Set("pubKeyFromSig", arity(2, "pubKeyFromSig", func(args []js.Value) (interface{}, error) {
+		return liteclient.PubKeyFromSig(args[0].String(), args[1].String())
+	}))
+
+	skycoinCipherExtras.Set("signHash", arity(2, "signHash", func(args []js.Value) (interface{}, error) {
+		return liteclient.SignHash(args[0].String(), args[1].String())
+	}))
+
+	js.Global().Set("SkycoinCipherExtras", skycoinCipherExtras)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1070,8 +1070,10 @@ github.com/skycoin/skycoin/src/kvstorage
 github.com/skycoin/skycoin/src/params
 github.com/skycoin/skycoin/src/readable
 github.com/skycoin/skycoin/src/skycoin
+github.com/skycoin/skycoin/src/skycoin-lite/liteclient
 github.com/skycoin/skycoin/src/skycoin-lite/wasm-go
 github.com/skycoin/skycoin/src/skycoin-lite/wasm-tinygo
+github.com/skycoin/skycoin/src/skycoin-lite/wasmcipher
 github.com/skycoin/skycoin/src/skycoin-lite/wasmgz
 github.com/skycoin/skycoin/src/skycoin-web/src/gui
 github.com/skycoin/skycoin/src/skydex/chain


### PR DESCRIPTION
The visor now calls `wasmcipher.Register()`, publishing `SkycoinCipher` and `SkycoinCipherExtras` on the page alongside `skywireVisor`.

The wallet in skycoin's `src/skycoin-web` reaches its cipher **only** through `window.SkycoinCipher` (see `cipher.provider.ts` there), so a visor that registers it is a drop-in for `skycoin-lite.wasm` and the page cannot tell the difference. That is what lets one wasm serve both: the wallet gets key derivation and transaction signing, and the visor underneath can make the node requests itself rather than the wallet proxying them through `cmd/skycoin-web`.

### Verified against the real suite

Pointed skycoin-web's own cipher suite at this binary:

**2216 of 2217 pass** — every address vector against the Go cipher testsuite golden files, every signature suite, every error case. The visor's own boot line shows up in the log while they run.

The single failure is the spec asserting a 40-character commit, which is host-specific — see below.

### It costs 0.03 MB gzip

| | raw | gzip |
|---|---|---|
| without cipher | 44.4 MB | 10.0 MB |
| with cipher | 44.6 MB | 10.0 MB |
| **delta** | **+0.15 MB** | **+0.03 MB** |

Nearly all of it was already linked in, because skywire imports `cmd/skycoin-web/commands`, which embeds the cipher.

### Also drops `-buildvcs=false`

`pkg/buildinfo` reads `runtime/debug.BuildInfo` first and falls back to the `vcs.*` settings the toolchain records for every build. Its own comment says why: so a `go install <pkg>@<version>` binary can describe itself *with no Makefile and no git*.

The wasm-visor was the one target that disabled that fallback. That:

- made **git a build dependency** for a target that otherwise has none, and
- let a blob built from uncommitted source claim a clean commit — `COMMIT` is `git rev-list -1 HEAD`, which returns HEAD regardless of working-tree state. The VCS stamp says `+dirty` instead.

The `-X` flags stay as an override, which is what every other target passes.

### The committed blobs still need regenerating

`pkg/wasmhv/wasmbin` is unchanged here and does **not** yet carry the cipher, so this is inert for users until `make embed-wasm-visor` / `embed-wasm-visor-tinygo` run.

They must be regenerated **from a normal clone**: Go records no `vcs.*` at all when building from a git *worktree*, where `.git` is a file rather than a directory. I confirmed this both ways — a native binary built in the worktree gets no stamp either, while the same build in a normal clone stamps `vcs.revision` and `vcs.modified` correctly. A blob built in a worktree would carry no stamp, which is exactly what this PR restores.

Worth considering separately: having `embed-wasm-visor` refuse to run from a dirty tree, now that the stamp is honest again.
