### PR TITLE
docs(cli/proxy): update mux help/examples to `proxy mux <sub>` form

### DIFF
--- a/cmd/skywire-cli/commands/proxy/mux_auto.go
+++ b/cmd/skywire-cli/commands/proxy/mux_auto.go
@@ -1,21 +1,21 @@
 // Package skysocksc cmd/skywire-cli/commands/proxy/mux_auto.go c4-vis-cli
 //
-// mux-auto is the adaptive control loop — the "adaptive" leg of the
-// observable -> manual -> adaptive arc. It reads the live mux-info signals
+// mux auto is the adaptive control loop — the "adaptive" leg of the
+// observable -> manual -> adaptive arc. It reads the live mux info signals
 // (per-leg latency) and steers a running proxy's legs toward a preset's
 // intent, reusing the same RouteGroupMuxInfo read and RemoveMuxRoute /
-// AddMuxRoute actuators that mux-info and mux-set proved.
+// AddMuxRoute actuators that mux info and mux set proved.
 //
 // This first increment is PRUNE-based: it converges the mux to the K
 // lowest-latency legs per the preset (the primary route is always kept).
-// Growing the set back to K — route-calc + mux-add when legs are lost, for
+// Growing the set back to K — route-calc + mux add when legs are lost, for
 // failover / demand-scaling — is the next increment (the latency signal +
 // the AddMuxRoute path are already in place; only the route source needs
 // wiring).
 //
-//	skywire cli proxy mux-auto fastest --watch 5s    # keep the single best path
-//	skywire cli proxy mux-auto balanced --watch 5s   # keep a few low-latency legs
-//	skywire cli proxy mux-auto resilient --dry-run   # show the decision, don't act
+//	skywire cli proxy mux auto fastest --watch 5s    # keep the single best path
+//	skywire cli proxy mux auto balanced --watch 5s   # keep a few low-latency legs
+//	skywire cli proxy mux auto resilient --dry-run   # show the decision, don't act
 package skysocksc
 
 import (
@@ -60,7 +60,7 @@ var autoPresets = map[string]autoPreset{
 
 func init() {
 	muxAutoCmd.Flags().StringVarP(&muxAutoApp, "name", "n", "skysocks-client", "app to adapt")
-	muxAutoCmd.Flags().Uint16Var(&muxAutoSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
+	muxAutoCmd.Flags().Uint16Var(&muxAutoSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux info' (only needed when the app has multiple active rg's)")
 	muxAutoCmd.Flags().DurationVarP(&muxAutoWatch, "watch", "w", 0, "re-evaluate every interval (e.g. 5s); 0 = decide once and exit")
 	muxAutoCmd.Flags().BoolVar(&muxAutoDry, "dry-run", false, "print the prune/grow decision without acting")
 	muxAutoCmd.Flags().IntVar(&muxAutoMinHops, "min-hops", 2, "hop-count floor for legs added when growing toward the preset (>=2 keeps grown legs multihop)")
@@ -70,7 +70,7 @@ func init() {
 var muxAutoCmd = &cobra.Command{
 	Use:   "auto <fastest|balanced|resilient>",
 	Short: "Adapt a proxy session's mux legs to a preset off live latency",
-	Long: `Adaptive control loop: read the live per-leg latency (mux-info) and
+	Long: `Adaptive control loop: read the live per-leg latency (mux info) and
 prune a running proxy's mux toward the preset's intent. The primary route
 is always kept.
 
@@ -80,13 +80,13 @@ Presets converge the mux to the K lowest-latency legs:
   resilient  up to 8 lowest-latency legs (max redundancy)
 
 Each tick PRUNES excess/slowest legs toward the preset, then GROWS the set
-back up with fresh disjoint legs (visor-side route-calc + mux-add, honoring
+back up with fresh disjoint legs (visor-side route-calc + mux add, honoring
 --min-hops) when live legs drop below the target — adaptive failover both
-ways. Pair with 'mux-info --watch' in another terminal to see the effect.
+ways. Pair with 'mux info --watch' in another terminal to see the effect.
 
 Example:
-  skywire cli proxy mux-auto fastest --watch 5s
-  skywire cli proxy mux-auto resilient --dry-run`,
+  skywire cli proxy mux auto fastest --watch 5s
+  skywire cli proxy mux auto resilient --dry-run`,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -145,7 +145,7 @@ Example:
 			}
 			// GROW: after pruning, restore redundancy. When live legs are
 			// below the preset target, add disjoint legs. Planning runs
-			// visor-side (GrowMuxRoute) because mux-info only exposes each
+			// visor-side (GrowMuxRoute) because mux info only exposes each
 			// leg's first-hop PK, not the full chains needed for a correct
 			// disjoint exclude-set.
 			live := len(rg.Legs) - pruned
@@ -241,10 +241,10 @@ func selectAutoRG(rgs []muxRouteGroupInfo, srcPort uint16) (muxRouteGroupInfo, e
 				return rg, nil
 			}
 		}
-		return muxRouteGroupInfo{}, fmt.Errorf("no active route group with src_port=%d (see 'mux-info')", srcPort)
+		return muxRouteGroupInfo{}, fmt.Errorf("no active route group with src_port=%d (see 'mux info')", srcPort)
 	}
 	if len(rgs) > 1 {
-		return muxRouteGroupInfo{}, fmt.Errorf("app=%s has %d active route groups; pass --rg <src_port> (see 'mux-info')", muxAutoApp, len(rgs))
+		return muxRouteGroupInfo{}, fmt.Errorf("app=%s has %d active route groups; pass --rg <src_port> (see 'mux info')", muxAutoApp, len(rgs))
 	}
 	return rgs[0], nil
 }

--- a/cmd/skywire-cli/commands/proxy/mux_info.go
+++ b/cmd/skywire-cli/commands/proxy/mux_info.go
@@ -136,7 +136,7 @@ func humanRate(bytesPerSec float64) string {
 	return humanBytes(uint64(bytesPerSec)) + "/s"
 }
 
-// renderMuxInfo prints the visor's mux-info response. We re-marshal/
+// renderMuxInfo prints the visor's mux info response. We re-marshal/
 // unmarshal through the local muxRouteGroupInfo struct so the CLI's
 // render logic doesn't reach into the visor package's internal type
 // — the JSON contract is the stable boundary.

--- a/cmd/skywire-cli/commands/proxy/mux_ops.go
+++ b/cmd/skywire-cli/commands/proxy/mux_ops.go
@@ -7,26 +7,26 @@
 //
 // Workflow:
 //
-//	skywire cli proxy mux-info                          # see current legs
+//	skywire cli proxy mux info                          # see current legs
 //	skywire cli route calc <peer-pk> --json | \
-//	    skywire cli proxy mux-add                       # add a leg over piped route
-//	skywire cli proxy mux-rm <tp-id>                    # drop a leg by first-hop tp
-//	skywire cli proxy mux-mode auto|equal               # change scheduler
+//	    skywire cli proxy mux add                       # add a leg over piped route
+//	skywire cli proxy mux rm <tp-id>                    # drop a leg by first-hop tp
+//	skywire cli proxy mux mode auto|equal               # change scheduler
 //
-// mux-add reads a {forward, reverse} hop list (JSON) from stdin or
+// mux add reads a {forward, reverse} hop list (JSON) from stdin or
 // from --route <file>. The shape matches what 'cli route calc
-// --json' emits, so the natural pipeline is calc | mux-add. When
+// --json' emits, so the natural pipeline is calc | mux add. When
 // stdin or the file holds an array of routes ('route calc --count N'),
-// mux-add uses the first; pre-filter with jq if you want a specific
+// mux add uses the first; pre-filter with jq if you want a specific
 // one. The visor refuses to attach a leg that starts on a transport
 // already in the rg.
 //
 // When the named app has multiple concurrent rg's (e.g. one per
 // active SOCKS5 client connection on skysocks-client), use --rg
-// <src-port> to pick which one. 'mux-info' prints the src_port
+// <src-port> to pick which one. 'mux info' prints the src_port
 // for every rg so you can copy it across.
 //
-// Combined with 'mux-info --watch' in a second terminal, this gives
+// Combined with 'mux info --watch' in a second terminal, this gives
 // you the basic interactive loop for exploring mux behavior at
 // runtime.
 package skysocksc
@@ -53,10 +53,10 @@ var (
 
 func init() {
 	muxAddCmd.Flags().StringVarP(&muxOpsApp, "name", "n", "skysocks-client", "app whose route group to modify")
-	muxAddCmd.Flags().Uint16Var(&muxOpsSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
+	muxAddCmd.Flags().Uint16Var(&muxOpsSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux info' (only needed when the app has multiple active rg's)")
 	muxAddCmd.Flags().StringVar(&muxAddRouteSrc, "route", "-", "route JSON file ('-' = stdin); shape is 'cli route calc --json' output")
 	muxRmCmd.Flags().StringVarP(&muxOpsApp, "name", "n", "skysocks-client", "app whose route group to modify")
-	muxRmCmd.Flags().Uint16Var(&muxOpsSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
+	muxRmCmd.Flags().Uint16Var(&muxOpsSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux info' (only needed when the app has multiple active rg's)")
 	addMuxSub(muxAddCmd, "mux-add")
 	addMuxSub(muxRmCmd, "mux-rm")
 	addMuxSub(muxModeCmd, "mux-mode")
@@ -124,12 +124,12 @@ target one of them; otherwise the visor errors with the candidate
 list.
 
 Example:
-  skywire cli proxy mux-info                                # see current legs + rg src_port
+  skywire cli proxy mux info                                # see current legs + rg src_port
   skywire cli route calc <peer-pk> --json | \
-      skywire cli proxy mux-add                             # pipe the calculated route
+      skywire cli proxy mux add                             # pipe the calculated route
   skywire cli route calc <peer-pk> --count 5 --json > r.json
-  skywire cli proxy mux-add --route r.json                  # or read from a file (uses [0])
-  skywire cli proxy mux-info                                # confirm it appeared`,
+  skywire cli proxy mux add --route r.json                  # or read from a file (uses [0])
+  skywire cli proxy mux info                                # confirm it appeared`,
 	Args:                  cobra.NoArgs,
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, _ []string) {
@@ -166,8 +166,8 @@ target one of them; otherwise the visor errors with the candidate
 list.
 
 Example:
-  skywire cli proxy mux-info                            # find the leg
-  skywire cli proxy mux-rm 55d43098-bae7-029e-bd8e-b228f7208930`,
+  skywire cli proxy mux info                            # find the leg
+  skywire cli proxy mux rm 55d43098-bae7-029e-bd8e-b228f7208930`,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -204,9 +204,9 @@ Affects every active and future mux'd route group on this visor.
 The setting persists to skywire-config.json so it survives restart.
 
 Example:
-  skywire cli proxy mux-mode equal      # before measuring aggregation
-  skywire cli proxy mux-info --watch 1s
-  skywire cli proxy mux-mode auto       # back to weighted`,
+  skywire cli proxy mux mode equal      # before measuring aggregation
+  skywire cli proxy mux info --watch 1s
+  skywire cli proxy mux mode auto       # back to weighted`,
 	Args:                  cobra.ExactArgs(1),
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/skywire-cli/commands/proxy/mux_set.go
+++ b/cmd/skywire-cli/commands/proxy/mux_set.go
@@ -1,14 +1,14 @@
 // Package skysocksc cmd/skywire-cli/commands/proxy/mux_set.go c4-vis-cli
 //
-// mux-set reconciles an active proxy session's mux legs to a target
-// leg-set in one shot, instead of hand-driving mux-add / mux-rm. It's
+// mux set reconciles an active proxy session's mux legs to a target
+// leg-set in one shot, instead of hand-driving mux add / mux rm. It's
 // the static-mux primitive — "make the legs be exactly these" — and the
 // actuation primitive the adaptive routing presets will drive (compute a
-// target leg-set from the live mux-info signals, then reconcile to it).
+// target leg-set from the live mux info signals, then reconcile to it).
 //
 // A leg's identity is its FIRST-HOP transport id (Forward[0].TpID, which
-// is what mux-info reports as a leg's transport_id and what mux-rm takes).
-// mux-set diffs the target set against the current legs by that id:
+// is what mux info reports as a leg's transport_id and what mux rm takes).
+// mux set diffs the target set against the current legs by that id:
 //   - target legs not currently present -> AddMuxRoute
 //   - with --prune: current legs not in the target -> RemoveMuxRoute
 //
@@ -20,8 +20,8 @@
 // same shape 'cli route calc --json' emits, concatenated:
 //
 //	skywire cli route calc <peer-pk> --count 3 --json > legs.json
-//	skywire cli proxy mux-set --legs legs.json            # ensure those 3 legs
-//	skywire cli proxy mux-set --legs legs.json --prune    # exactly those 3
+//	skywire cli proxy mux set --legs legs.json            # ensure those 3 legs
+//	skywire cli proxy mux set --legs legs.json --prune    # exactly those 3
 package skysocksc
 
 import (
@@ -46,7 +46,7 @@ var (
 
 func init() {
 	muxSetCmd.Flags().StringVarP(&muxSetApp, "name", "n", "skysocks-client", "app whose route group to reconcile")
-	muxSetCmd.Flags().Uint16Var(&muxSetSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux-info' (only needed when the app has multiple active rg's)")
+	muxSetCmd.Flags().Uint16Var(&muxSetSrcPort, "rg", 0, "rg disambiguator: ephemeral src_port from 'mux info' (only needed when the app has multiple active rg's)")
 	muxSetCmd.Flags().StringVar(&muxSetFile, "legs", "-", "leg-set JSON file ('-' = stdin): array of {forward,reverse} pairs ('cli route calc --json' shape)")
 	muxSetCmd.Flags().BoolVar(&muxSetPrune, "prune", false, "also remove current legs not in the target set (exact reconcile). Careful: the primary route is a leg too — include it or it's removed")
 	addMuxSub(muxSetCmd, "mux-set")
@@ -83,7 +83,7 @@ func readRoutePairs(src string) ([]routePair, error) {
 
 // currentLegTpIDs returns the first-hop transport ids of the legs in the
 // target rg. With srcPort 0 it requires exactly one active rg; otherwise
-// it matches the rg by src_port (mux-info prints it).
+// it matches the rg by src_port (mux info prints it).
 func currentLegTpIDs(infos any, srcPort uint16) (map[uuid.UUID]struct{}, error) {
 	raw, _ := json.Marshal(infos) //nolint:errcheck
 	var rgs []muxRouteGroupInfo
@@ -101,11 +101,11 @@ func currentLegTpIDs(infos any, srcPort uint16) (map[uuid.UUID]struct{}, error) 
 			}
 		}
 		if rg == nil {
-			return nil, fmt.Errorf("no active route group with src_port=%d (see 'mux-info')", srcPort)
+			return nil, fmt.Errorf("no active route group with src_port=%d (see 'mux info')", srcPort)
 		}
 	} else {
 		if len(rgs) > 1 {
-			return nil, fmt.Errorf("app=%s has %d active route groups; pass --rg <src_port> (see 'mux-info')", muxSetApp, len(rgs))
+			return nil, fmt.Errorf("app=%s has %d active route groups; pass --rg <src_port> (see 'mux info')", muxSetApp, len(rgs))
 		}
 		rg = &rgs[0]
 	}
@@ -137,9 +137,9 @@ route counts as a leg, so include it in the target or --prune removes it.
 
 Example:
   skywire cli route calc <peer-pk> --count 3 --json > legs.json
-  skywire cli proxy mux-set --legs legs.json            # ensure those legs exist
-  skywire cli proxy mux-set --legs legs.json --prune    # make legs exactly those
-  skywire cli proxy mux-info                            # confirm`,
+  skywire cli proxy mux set --legs legs.json            # ensure those legs exist
+  skywire cli proxy mux set --legs legs.json --prune    # make legs exactly those
+  skywire cli proxy mux info                            # confirm`,
 	Args:                  cobra.NoArgs,
 	DisableFlagsInUseLine: true,
 	Run: func(cmd *cobra.Command, _ []string) {
@@ -201,7 +201,7 @@ Example:
 			}
 		}
 
-		fmt.Printf("mux-set app=%s: target=%d, +%d added, -%d removed, %d already present%s\n",
+		fmt.Printf("mux set app=%s: target=%d, +%d added, -%d removed, %d already present%s\n",
 			muxSetApp, len(want), added, removed, present, pruneNote(muxSetPrune))
 	},
 }


### PR DESCRIPTION
Doc-only follow-up to the `proxy mux` nesting (#3861): sweep the remaining command examples and prose in the mux help / doc-comments from the old flat `proxy mux-info`/`mux-add`/`mux-rm`/`mux-set`/`mux-mode`/`mux-auto` spelling to the nested `proxy mux info`/`add`/`rm`/`set`/`mode`/`auto` form.

The hidden back-compat aliases (registered via `addMuxSub(cmd, "mux-<verb>")`) and the `--mux-mode` flag on `proxy start` are untouched, so old invocations keep working. Comments/strings only — no code change.