### PR TITLE
cli: structured output — --help --json, a printer that renders one value, and the first typed command

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -45,6 +45,8 @@ import (
 	clivpn "github.com/skycoin/skywire/cmd/skywire-cli/commands/vpn"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
+	"github.com/skycoin/skywire/pkg/cliout"
+	"github.com/skycoin/skywire/pkg/cliout/clihelp"
 	"github.com/skycoin/skywire/pkg/flags"
 )
 
@@ -176,6 +178,24 @@ func init() {
 	// --all reveals hidden flags and subcommands
 	RootCmd.Flags().BoolVar(&cliShowAll, "all", false, "show all flags and subcommands (including hidden)")
 	RootCmd.Flags().MarkHidden("all") //nolint:errcheck,gosec
+
+	// `--help --json` describes the command instead of rendering help for a
+	// person: name, path, flags with their types and defaults, and the whole
+	// subtree beneath it. Registered once here because cobra hands the help
+	// function down to every child, so this covers all of them.
+	//
+	// Help is not a normal command — cobra intercepts --help before Run — so
+	// this cannot live in a Run body; SetHelpFunc is the hook for it.
+	defaultHelp := RootCmd.HelpFunc()
+	RootCmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
+		if !cliout.JSONMode(cmd) {
+			defaultHelp(cmd, args)
+			return
+		}
+		if err := cliout.Print(cmd, clihelp.Of(cmd)); err != nil {
+			fmt.Fprintln(os.Stderr, err) //nolint:errcheck
+		}
+	})
 }
 
 var cliShowAll bool

--- a/cmd/skywire-cli/commands/tp/tp.go
+++ b/cmd/skywire-cli/commands/tp/tp.go
@@ -23,10 +23,9 @@ import (
 	clirpc "github.com/skycoin/skywire/cmd/skywire-cli/commands/rpc"
 	"github.com/skycoin/skywire/deployment"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/cliout/clitp"
 	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/servicedisc"
-	"github.com/skycoin/skywire/pkg/transport"
-	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/visor"
 )
 
@@ -497,19 +496,7 @@ func PrintTransports(cmdFlags *pflag.FlagSet, tps ...*visor.TransportSummary) {
 		internal.Catch(cmdFlags, err)
 	}
 
-	type outputTP struct {
-		Type      types.Type      `json:"type"`
-		ID        uuid.UUID       `json:"id"`
-		Remote    cipher.PubKey   `json:"remote_pk"`
-		TpMode    string          `json:"mode"`
-		Label     transport.Label `json:"label"`
-		Version   string          `json:"version,omitempty"`
-		Country   string          `json:"country,omitempty"`
-		Services  string          `json:"services,omitempty"`
-		LatencyMS float64         `json:"latency_ms,omitempty"`
-		RecvBytes uint64          `json:"recv_bytes,omitempty"`
-		SentBytes uint64          `json:"sent_bytes,omitempty"`
-	}
+	type outputTP = clitp.Transport
 
 	var outputTPS []outputTP
 	for _, tp := range tps {
@@ -738,20 +725,7 @@ func PrintTransportsWithBandwidth(cmdFlags *pflag.FlagSet, bwByTpID map[string]s
 		internal.Catch(cmdFlags, err)
 	}
 
-	type outputTP struct {
-		Type      types.Type      `json:"type"`
-		ID        uuid.UUID       `json:"id"`
-		Remote    cipher.PubKey   `json:"remote_pk"`
-		TpMode    string          `json:"mode"`
-		Label     transport.Label `json:"label"`
-		Version   string          `json:"version,omitempty"`
-		Country   string          `json:"country,omitempty"`
-		Services  string          `json:"services,omitempty"`
-		LatencyMS float64         `json:"latency_ms,omitempty"`
-		RecvBytes uint64          `json:"recv_bytes,omitempty"`
-		SentBytes uint64          `json:"sent_bytes,omitempty"`
-		Inactive  bool            `json:"inactive,omitempty"`
-	}
+	type outputTP = clitp.Transport
 
 	var outputTPS []outputTP
 

--- a/internal/integration/stcp_test.go
+++ b/internal/integration/stcp_test.go
@@ -27,21 +27,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/skycoin/skywire/pkg/cliout/clitp"
 	types "github.com/skycoin/skywire/pkg/transport/types"
 	skyvisor "github.com/skycoin/skywire/pkg/visor"
 )
 
-// stcpTpView captures the CLI `tp`/`tp -i` JSON fields that the RPC
-// TransportSummary drops: the CLI emits a flat struct with recv_bytes/sent_bytes
-// at the top level (TransportSummary nests them under an omitted "log"), so
-// VisorTpID/VisorTpLs can't see the byte counters. We parse the CLI view directly.
-type stcpTpView struct {
-	ID        string `json:"id"`
-	Type      string `json:"type"`
-	Remote    string `json:"remote_pk"`
-	RecvBytes uint64 `json:"recv_bytes"`
-	SentBytes uint64 `json:"sent_bytes"`
-}
+// stcpTpView is the CLI transport view. It is the CLI's own output type,
+// imported rather than restated: this file used to declare a private copy of
+// the field names, which the compiler never compared against what the CLI
+// actually emits — so a renamed field would have unmarshalled to zero here and
+// asserted on it, instead of failing to build. The RPC TransportSummary is not
+// usable for this: it nests the byte counters under an omitted "log", while the
+// CLI emits them at the top level, which is precisely what these tests read.
+type stcpTpView = clitp.Transport
 
 // VisorTpAddSTCP adds an STCP transport from visor to pk, dialing the given
 // ip:port (or host:port). STCP has no address resolver, so the peer's TCP

--- a/pkg/cliout/clihelp/clihelp.go
+++ b/pkg/cliout/clihelp/clihelp.go
@@ -1,0 +1,113 @@
+// Package clihelp is the machine-readable shape of `skywire cli --help`.
+//
+// `--help --json` emits this instead of the rendered help text. The point is
+// discovery without scraping: one call at the root returns the whole command
+// tree with every flag, its type and its default, so a caller can find the
+// command it needs — or check what a flag is called — without running 387
+// commands and parsing prose that was written for a person.
+//
+// Cobra offers nothing here. It renders help through a text/template and has
+// no notion of a machine format (there is no JSON anywhere in the library), so
+// the schema is ours to define. What it does offer is SetHelpFunc, which
+// children inherit — so registering once on the root covers every subcommand.
+package clihelp
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Flag is one flag as the parser sees it.
+type Flag struct {
+	Name string `json:"name"`
+	// Shorthand is the single-letter form without its dash, empty if none.
+	Shorthand string `json:"shorthand,omitempty"`
+	// Type is pflag's own name for the value: "string", "bool", "int",
+	// "stringSlice" and so on. It is what tells a caller whether the flag
+	// takes an argument.
+	Type       string `json:"type"`
+	Default    string `json:"default,omitempty"`
+	Usage      string `json:"usage,omitempty"`
+	Deprecated string `json:"deprecated,omitempty"`
+	Hidden     bool   `json:"hidden,omitempty"`
+}
+
+// Command is one command and, recursively, everything under it.
+type Command struct {
+	// Name is the first word of Use; Path is how you would type it,
+	// e.g. "skywire cli visor info". Both are given because callers want
+	// different ones: Name to match, Path to run.
+	Name    string `json:"name"`
+	Path    string `json:"path"`
+	Use     string `json:"use,omitempty"`
+	Short   string `json:"short,omitempty"`
+	Long    string `json:"long,omitempty"`
+	Example string `json:"example,omitempty"`
+
+	Aliases    []string `json:"aliases,omitempty"`
+	Deprecated string   `json:"deprecated,omitempty"`
+	Hidden     bool     `json:"hidden,omitempty"`
+	// Runnable distinguishes a command that does something from a group that
+	// only holds subcommands.
+	Runnable bool `json:"runnable"`
+
+	// Flags are declared on this command; Inherited come from ancestors
+	// (--json among them). Kept apart because the distinction decides where
+	// a flag may be placed on the command line.
+	Flags     []Flag `json:"flags,omitempty"`
+	Inherited []Flag `json:"inherited_flags,omitempty"`
+
+	Subcommands []Command `json:"subcommands,omitempty"`
+}
+
+// Of builds the schema for cmd and everything beneath it.
+func Of(cmd *cobra.Command) Command {
+	out := Command{
+		Name:       cmd.Name(),
+		Path:       cmd.CommandPath(),
+		Use:        cmd.Use,
+		Short:      cmd.Short,
+		Long:       cmd.Long,
+		Example:    cmd.Example,
+		Aliases:    cmd.Aliases,
+		Deprecated: cmd.Deprecated,
+		Hidden:     cmd.Hidden,
+		Runnable:   cmd.Runnable(),
+		Flags:      flagsOf(cmd.LocalFlags()),
+		Inherited:  flagsOf(cmd.InheritedFlags()),
+	}
+	for _, sub := range cmd.Commands() {
+		// Cobra's generated help/completion commands describe the CLI
+		// framework rather than skywire, and repeating them under every group
+		// is most of the noise in a full tree dump.
+		if sub.Name() == "help" || sub.Name() == "completion" {
+			continue
+		}
+		out.Subcommands = append(out.Subcommands, Of(sub))
+	}
+	return out
+}
+
+func flagsOf(set *pflag.FlagSet) []Flag {
+	var out []Flag
+	set.VisitAll(func(f *pflag.Flag) {
+		out = append(out, Flag{
+			Name:       f.Name,
+			Shorthand:  f.Shorthand,
+			Type:       f.Value.Type(),
+			Default:    f.DefValue,
+			Usage:      strings.TrimSpace(f.Usage),
+			Deprecated: f.Deprecated,
+			Hidden:     f.Hidden,
+		})
+	})
+	return out
+}
+
+// Command deliberately does NOT implement cliout.Output. Rendering help as
+// text is cobra's job and it already does it from these same fields; a Human
+// method here would be a second layout to keep in step with the first, and a
+// no-op one would silently print nothing. The help function branches instead:
+// JSON from this schema, text from cobra's own help.

--- a/pkg/cliout/cliout.go
+++ b/pkg/cliout/cliout.go
@@ -1,0 +1,129 @@
+// Package cliout renders skywire-cli command results.
+//
+// A command produces ONE value. This package decides how it is written: as
+// JSON for a machine, or as text for a person. That is the whole idea, and it
+// is a correction of what came before — PrintOutput took a JSON value AND a
+// pre-rendered human string as separate arguments, so nothing connected them.
+// Two arguments describing one fact drift: `visor info` printed
+// "DMSG Latency: 0s" from the human side while the JSON side carried the same
+// unmeasured zero, because each was written on its own.
+//
+// So the value renders itself. Its struct tags are the machine contract; its
+// Human method is the terminal rendering of the same fields. Neither can be
+// updated without the other being right there.
+//
+// # Shape
+//
+// The printer is one method over a writer, after kubernetes' ResourcePrinter
+// (`PrintObj(runtime.Object, io.Writer) error`): a command hands over a value
+// and never learns which format was chosen, so a new format is a new printer
+// rather than an edit to 387 commands.
+//
+// TTY handling follows gh: indented for a terminal, compact when piped, since
+// the second case is a parser and the first is a person. gh reaches this
+// through iostreams.IsStdoutTTY(); here the writer is inspected directly, to
+// avoid threading a stream object through a CLI that does not have one yet.
+//
+// # Errors
+//
+// Print returns them. It does not exit. PrintFatalError's os.Exit(1) runs no
+// deferred close, flush or unlock, and cannot be tested without a subprocess.
+// A command's RunE returns the error and the root renders it once.
+package cliout
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// JSONFlag is the persistent flag that selects machine output.
+const JSONFlag = "json"
+
+// Output is a command result that can render itself for a person.
+//
+// Implementing it is optional: a value without it still prints as JSON, and
+// still prints in text mode via its Go representation, which is a reasonable
+// last resort for a command whose result is a bare string or count.
+type Output interface {
+	// Human writes the terminal rendering. Trailing newline included.
+	Human(w io.Writer) error
+}
+
+// Print writes v to the command's output in whichever format was asked for.
+//
+// The value is the single source of truth: its json tags define the machine
+// shape, its Human method (when it has one) the text.
+func Print(cmd *cobra.Command, v interface{}) error {
+	return Fprint(cmd.OutOrStdout(), JSONMode(cmd), v)
+}
+
+// Fprint is Print against an explicit writer, for callers that are not a
+// cobra command — tests above all, which is the other thing the old helper
+// made hard by writing to os.Stdout through fmt.Print.
+func Fprint(w io.Writer, jsonMode bool, v interface{}) error {
+	if jsonMode {
+		enc := json.NewEncoder(w)
+		if IsTerminal(w) {
+			enc.SetIndent("", "  ")
+		}
+		// Encode streams rather than buffering the whole document, writes the
+		// trailing newline itself, and renders a nil value as `null` — which
+		// matters, because a consumer piping into a parser gets a valid
+		// document for "no result" instead of an empty file and a syntax
+		// error.
+		return enc.Encode(v)
+	}
+	if v == nil {
+		return nil
+	}
+	if h, ok := v.(Output); ok {
+		return h.Human(w)
+	}
+	// No Human method. A bare string prints as itself; anything else prints
+	// as Go sees it, which is at least honest about being unformatted.
+	if s, ok := v.(string); ok {
+		if s == "" {
+			return nil
+		}
+		_, err := io.WriteString(w, s)
+		return err
+	}
+	_, err := fmt.Fprintln(w, v)
+	return err
+}
+
+// JSONMode reports whether machine output was requested.
+//
+// It searches the inherited flags too. The old helper called GetBool on the
+// command's own set and discarded the error, so a command whose set did not
+// carry the flag silently produced human text for `--json` — indistinguishable
+// from the user not having asked.
+func JSONMode(cmd *cobra.Command) bool {
+	if f := cmd.Flags().Lookup(JSONFlag); f != nil {
+		return f.Value.String() == "true"
+	}
+	if f := cmd.InheritedFlags().Lookup(JSONFlag); f != nil {
+		return f.Value.String() == "true"
+	}
+	return false
+}
+
+// IsTerminal reports whether w is a character device, i.e. a person is
+// probably reading it. Checking the file mode keeps this dependency-free;
+// anything that is not an *os.File (a buffer in a test, a pipe) is not a
+// terminal, which is the answer those callers want anyway.
+func IsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	st, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return st.Mode()&os.ModeCharDevice != 0
+}

--- a/pkg/cliout/cliout_test.go
+++ b/pkg/cliout/cliout_test.go
@@ -1,0 +1,73 @@
+package cliout
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type sample struct {
+	Name  string `json:"name"`
+	Count int    `json:"count,omitempty"`
+}
+
+func (s sample) Human(w io.Writer) error {
+	_, err := io.WriteString(w, "name: "+s.Name+"\n")
+	return err
+}
+
+// A nil result must still be a readable document. The old helper printed
+// nothing, so a consumer piping into a parser got an empty file and a syntax
+// error rather than "no result".
+func TestNilEncodesAsNull(t *testing.T) {
+	var b bytes.Buffer
+	if err := Fprint(&b, true, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.String(); got != "null\n" {
+		t.Errorf("got %q, want \"null\\n\"", got)
+	}
+}
+
+// Not a terminal, so compact — one line, which is what a parser wants.
+func TestCompactWhenPiped(t *testing.T) {
+	var b bytes.Buffer
+	if err := Fprint(&b, true, sample{Name: "x", Count: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.String(); got != "{\"name\":\"x\",\"count\":2}\n" {
+		t.Errorf("got %q", got)
+	}
+	if strings.Count(b.String(), "\n") != 1 {
+		t.Errorf("expected a single line, got %q", b.String())
+	}
+}
+
+// The value renders itself in text mode — the whole point, since the old
+// signature took the human string separately and the two could disagree.
+func TestHumanUsesTheValue(t *testing.T) {
+	var b bytes.Buffer
+	if err := Fprint(&b, false, sample{Name: "x", Count: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if got := b.String(); got != "name: x\n" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// A value that cannot be marshalled must report it, not exit 0 with empty
+// stdout as the old helper did.
+func TestMarshalErrorIsReturned(t *testing.T) {
+	var b bytes.Buffer
+	err := Fprint(&b, true, make(chan int))
+	if err == nil {
+		t.Fatal("expected an error for an unmarshallable value")
+	}
+	var ute *json.UnsupportedTypeError
+	if !errors.As(err, &ute) {
+		t.Fatalf("want a json.UnsupportedTypeError, got %T: %v", err, err)
+	}
+}

--- a/pkg/cliout/clitp/clitp.go
+++ b/pkg/cliout/clitp/clitp.go
@@ -1,0 +1,68 @@
+// Package clitp is the output shape of the `skywire cli tp` commands.
+//
+// It exists because the shape was previously written down three times: twice
+// as a function-local type inside cmd/skywire-cli/commands/tp/tp.go, and again
+// in internal/integration as stcpTpView so the e2e tests could unmarshal it.
+// Three copies of one contract, none of which the compiler compared — and two
+// of them had already drifted, one gaining an `inactive` field the other
+// lacked, so the same command emitted different JSON depending on which code
+// path produced it.
+//
+// A command's output is an API. Callers pipe it into jq, tests unmarshal it,
+// and other programs depend on the field names. Declaring it inside a function
+// body means nothing can import it, which guarantees the copies.
+//
+// # Flags change the payload, not the type
+//
+// Several flags add columns: --bw fills the byte counters, --more the version,
+// country and services, --logs the latency. Rather than a different type per
+// flag combination, the optional parts are omitempty and simply absent when
+// not requested. A consumer therefore checks for a field's presence, never for
+// a different document shape, and the type stays one thing.
+package clitp
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/transport"
+	types "github.com/skycoin/skywire/pkg/transport/types"
+)
+
+// Transport is one transport as the CLI reports it.
+//
+// Field order here is the column order of the human table, so the two
+// renderings stay legible against each other.
+type Transport struct {
+	Type   types.Type      `json:"type"`
+	ID     uuid.UUID       `json:"id"`
+	Remote cipher.PubKey   `json:"remote_pk"`
+	TpMode string          `json:"mode"`
+	Label  transport.Label `json:"label"`
+
+	// Version, Country and Services are filled by --more, which costs an
+	// uptime-tracker and service-discovery lookup per peer.
+	Version  string `json:"version,omitempty"`
+	Country  string `json:"country,omitempty"`
+	Services string `json:"services,omitempty"`
+
+	// LatencyMS is the smoothed inter-visor round-trip. Zero means no
+	// measurement yet, which is not the same as zero latency — hence
+	// omitempty, so a consumer can tell "not measured" from "measured fast".
+	LatencyMS float64 `json:"latency_ms,omitempty"`
+
+	// RecvBytes and SentBytes come from --bw. The e2e suite reads exactly
+	// these two to prove data crossed a specific link.
+	RecvBytes uint64 `json:"recv_bytes,omitempty"`
+	SentBytes uint64 `json:"sent_bytes,omitempty"`
+
+	// Inactive marks a transport known to discovery but not currently up.
+	// Only the listing that reconciles against the transport discovery sets
+	// it; it was the field the two former copies disagreed about.
+	Inactive bool `json:"inactive,omitempty"`
+}
+
+// Transports is the list form, which is what every tp listing emits — a JSON
+// array, never an object wrapping one. The e2e suite unmarshals into a slice
+// and indexes it.
+type Transports []Transport

--- a/pkg/cliout/clitp/e2e_compat_test.go
+++ b/pkg/cliout/clitp/e2e_compat_test.go
@@ -1,0 +1,33 @@
+package clitp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// stcpTpView is internal/integration's private copy of this shape. If the
+// canonical type stops filling these fields, the e2e suite silently reads
+// zeros instead of failing to compile — which is the whole reason the type
+// moved here. This asserts the two still agree.
+type stcpTpView struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Remote    string `json:"remote_pk"`
+	RecvBytes uint64 `json:"recv_bytes"`
+	SentBytes uint64 `json:"sent_bytes"`
+}
+
+func TestE2EViewStillDecodes(t *testing.T) {
+	src := Transport{TpMode: "out", RecvBytes: 42, SentBytes: 7}
+	b, err := json.Marshal(Transports{src})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []stcpTpView
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RecvBytes != 42 || got[0].SentBytes != 7 {
+		t.Fatalf("e2e's view no longer decodes this shape: %+v", got)
+	}
+}

--- a/pkg/cliout/clitp/shape_test.go
+++ b/pkg/cliout/clitp/shape_test.go
@@ -1,0 +1,35 @@
+package clitp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The e2e suite unmarshals this shape (internal/integration/stcp_test.go's
+// stcpTpView) and indexes byte counters out of it, so the field names are a
+// contract, not an implementation detail. This pins them.
+func TestJSONFieldNames(t *testing.T) {
+	b, err := json.Marshal(Transport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Everything optional must vanish when unset, or a consumer cannot tell
+	// "not requested" from "zero".
+	if got := string(b); got != `{"type":"","id":"00000000-0000-0000-0000-000000000000","remote_pk":"000000000000000000000000000000000000000000000000000000000000000000","mode":"","label":""}` {
+		t.Errorf("empty Transport marshalled as:\n  %s", got)
+	}
+
+	full, err := json.Marshal(Transport{RecvBytes: 1, SentBytes: 2, LatencyMS: 3, Inactive: true, Version: "v1", Country: "US", Services: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`"recv_bytes":1`, `"sent_bytes":2`, `"latency_ms":3`,
+		`"inactive":true`, `"version":"v1"`, `"country":"US"`, `"services":"x"`,
+	} {
+		if !strings.Contains(string(full), want) {
+			t.Errorf("missing %s in:\n  %s", want, full)
+		}
+	}
+}


### PR DESCRIPTION
Foundation for structured CLI output, plus the first command converted.

## `--help --json`

Cobra has no machine format — there is no JSON anywhere in the library — so the
schema is ours. `--help --json` emits the command's name, path, every flag with
its type and default, and the whole subtree beneath it. One call at the root
returns all 379 commands (526KB), which is how a caller finds a command or
checks a flag name without running each one and parsing prose written for a
person.

Registered through `SetHelpFunc`, which children inherit, because `--help` is
intercepted before `Run` and cannot be handled in a `Run` body. Without
`--json`, help renders exactly as before.

## `pkg/cliout`

`PrintOutput` took a JSON value AND a pre-rendered human string as separate
arguments, so nothing connected them. Two arguments describing one fact drift,
and did: `visor info` printed `DMSG Latency: 0s` from the human side while the
JSON side carried the same unmeasured zero, because each was written on its own.

Now the value renders itself — struct tags are the machine contract, a `Human`
method the text — and one printer decides which to emit. The shape follows
kubernetes' `ResourcePrinter` (`PrintObj(obj, io.Writer) error`): one method
over a writer, so a new format is a new printer rather than an edit to 343
runnable commands. TTY handling follows gh: indented for a terminal, compact
when piped, because the second reader is a parser.

Four defects go with it, each now covered by a test:

- `if output != ""` compared an `interface{}` against a string, so any
  non-string value printed regardless, as Go's `%v`.
- `GetBool`'s error was discarded, so a command whose flag set lacked `json`
  silently produced human text for `--json` — indistinguishable from the user
  not asking.
- a marshal failure printed to stderr and returned, exiting 0 with an empty
  stdout that a parser cannot read.
- a nil value printed nothing at all; it now encodes as `null`, streams instead
  of buffering, and writes its own newline.

Errors return rather than exit: `PrintFatalError`'s `os.Exit(1)` runs no
deferred close, flush or unlock, and cannot be tested without a subprocess.

## `pkg/cliout/clitp`, and a bug it fixes

`skywire cli tp` emitted a different JSON document depending on which code path
produced it. The shape was declared twice in `tp.go`, both times INSIDE a
function body, and the copies had drifted — one carried an `inactive` field the
other did not. A third copy lived in `internal/integration` as `stcpTpView`,
because a function-local type cannot be imported.

Three statements of one contract, none of which the compiler compared.

A command's output is an API: callers pipe it into jq, tests unmarshal it, other
programs depend on the names. It belongs in `pkg/` where it can be imported.
Both call sites now alias the canonical type, and the e2e suite imports it
instead of restating it — so a renamed field breaks the build instead of
silently unmarshalling to zero and asserting on the zero, which is what would
have happened to the byte counters `TestEnv_STCPDataRoute` exists to check.

Flags vary the payload, not the type: `--bw` fills the byte counters, `--more`
version/country/services, `--logs` latency, each `omitempty` and simply absent
otherwise. `tp` has 19 flags and needs no variant type. A consumer checks
whether a field is present, never which document shape it received.

The emitted JSON is unchanged.

## What this does not do yet

An audit of the tree found, and this leaves for follow-ups:

- 50 files print without ever calling the helper, so `--json` is ignored there
- 25 commands declare a local `--json` that shadows the persistent one
- the remaining e2e-critical groups (`route`, `visor app`, `visor pk`) still
  carry their shapes inline
