### PR TITLE
cli: fix lint failures from the cliout merge

### DIFF
--- a/cmd/skywire-cli/commands/serve/serve.go
+++ b/cmd/skywire-cli/commands/serve/serve.go
@@ -64,7 +64,6 @@ func init() {
 			"(any client-supplied copy is stripped) so the backend can do per-PK auth. "+
 			"Bind the backend to loopback only — see docs/guides/skynet-website-auth.md")
 
-
 	RootCmd.AddCommand(servePortCmd, servePortRmCmd, servePortLsCmd, serveWhitelistCmd)
 }
 

--- a/cmd/skywire-cli/jsoncontract_test.go
+++ b/cmd/skywire-cli/jsoncontract_test.go
@@ -64,7 +64,7 @@ var streamingCommands = map[string]string{
 
 // localJSONFlags are commands that declare their own --json instead of using
 // the persistent one from the root. Two variables for one concept: a command
-// reading its own package-level bool cannot see the root's flag, so behaviour
+// reading its own package-level bool cannot see the root's flag, so behavior
 // depends on where the user put the word.
 // pendingJSON is debt, not exemption: each of these prints without
 // consulting --json and should be converted to a typed output in
@@ -100,7 +100,8 @@ func TestNoLocalJSONFlag(t *testing.T) {
 			if !ok || lit.Kind != token.STRING {
 				return true
 			}
-			if name, _ := strconv.Unquote(lit.Value); name == "json" {
+			name, uerr := strconv.Unquote(lit.Value)
+			if uerr == nil && name == "json" {
 				found = append(found, path+":"+posLine(fset, call.Pos()))
 			}
 			return true
@@ -158,7 +159,7 @@ func TestNoFunctionLocalOutputShape(t *testing.T) {
 func TestEveryPrintingCommandHonoursJSON(t *testing.T) {
 	var found []string
 	forEachFile(t, func(path string, file *ast.File, fset *token.FileSet) {
-		var prints, honours bool
+		var prints, honors bool
 		ast.Inspect(file, func(n ast.Node) bool {
 			sel, ok := n.(*ast.SelectorExpr)
 			if !ok {
@@ -177,11 +178,11 @@ func TestEveryPrintingCommandHonoursJSON(t *testing.T) {
 			case sel.Sel.Name == "PrintOutput",
 				pkg.Name == "cliout" && (sel.Sel.Name == "Print" || sel.Sel.Name == "Fprint"),
 				sel.Sel.Name == "JSONMode":
-				honours = true
+				honors = true
 			}
 			return true
 		})
-		if prints && !honours {
+		if prints && !honors {
 			found = append(found, path)
 		}
 	})

--- a/internal/integration/stcp_test.go
+++ b/internal/integration/stcp_test.go
@@ -35,7 +35,7 @@ import (
 // stcpTpView is the CLI transport view. It is the CLI's own output type,
 // imported rather than restated: this file used to declare a private copy of
 // the field names, which the compiler never compared against what the CLI
-// actually emits — so a renamed field would have unmarshalled to zero here and
+// actually emits — so a renamed field would have unmarshaled to zero here and
 // asserted on it, instead of failing to build. The RPC TransportSummary is not
 // usable for this: it nests the byte counters under an omitted "log", while the
 // CLI emits them at the top level, which is precisely what these tests read.

--- a/pkg/cliout/cliout_test.go
+++ b/pkg/cliout/cliout_test.go
@@ -58,7 +58,7 @@ func TestHumanUsesTheValue(t *testing.T) {
 	}
 }
 
-// A value that cannot be marshalled must report it, not exit 0 with empty
+// A value that cannot be marshaled must report it, not exit 0 with empty
 // stdout as the old helper did.
 func TestMarshalErrorIsReturned(t *testing.T) {
 	var b bytes.Buffer

--- a/pkg/cliout/cliroute/cliroute.go
+++ b/pkg/cliout/cliroute/cliroute.go
@@ -19,7 +19,7 @@ import (
 // The optional fields are per rule TYPE, not per flag: an app rule has ports
 // and a remote key, a forward rule has a next hop, and neither carries the
 // other's fields. omitempty is what keeps one type serving all three without a
-// consumer having to recognise three documents.
+// consumer having to recognize three documents.
 type Rule struct {
 	ID   routing.RouteID `json:"id"`
 	Type string          `json:"type"`
@@ -79,7 +79,7 @@ type TraceHop struct {
 }
 
 // Trace is the whole path `route trace` measured. It was an anonymous struct
-// marshalled inline, which is a shape no caller could name.
+// marshaled inline, which is a shape no caller could name.
 type Trace struct {
 	Src  string     `json:"src"`
 	Dst  string     `json:"dst"`

--- a/pkg/cliout/clitp/shape_test.go
+++ b/pkg/cliout/clitp/shape_test.go
@@ -17,7 +17,7 @@ func TestJSONFieldNames(t *testing.T) {
 	// Everything optional must vanish when unset, or a consumer cannot tell
 	// "not requested" from "zero".
 	if got := string(b); got != `{"type":"","id":"00000000-0000-0000-0000-000000000000","remote_pk":"000000000000000000000000000000000000000000000000000000000000000000","mode":"","label":""}` {
-		t.Errorf("empty Transport marshalled as:\n  %s", got)
+		t.Errorf("empty Transport marshaled as:\n  %s", got)
 	}
 
 	full, err := json.Marshal(Transport{RecvBytes: 1, SentBytes: 2, LatencyMS: 3, Inactive: true, Version: "v1", Country: "US", Services: "x"})


### PR DESCRIPTION
misspell rejects the British spellings (marshalled, behaviour, honours, recognise) — one reached identifiers, not just comments — plus an unchecked `strconv.Unquote` and a gofmt slip in `serve.go` from removing its dead `--json` flag.

CI reported only the two `marshalled` hits; running golangci-lint locally found seven. Clean now across `pkg/cliout`, `cmd/skywire-cli`, `pkg/wasmhv`, `cmd/wasm-visor` and `internal/integration`.

This is what turned `windows`, `darwin` and `linux` red on develop after #3866.