### PR TITLE
netutil: make two //nolint directives parse

### DIFF
--- a/pkg/netutil/netutil_more_test.go
+++ b/pkg/netutil/netutil_more_test.go
@@ -118,7 +118,7 @@ func TestPorterReserveEphemeralExhausted(t *testing.T) {
 
 func TestPorterResetEphemeral(t *testing.T) {
 	p := NewPorter(PorterMinEphemeral)
-	p.Reserve(80, "listener") //nolint:errcheck — well-known, must survive
+	p.Reserve(80, "listener") //nolint:errcheck // well-known port, must survive
 	for range 3 {
 		_, _, err := p.ReserveEphemeral(context.Background(), "v")
 		require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestPorterCloseAll(t *testing.T) {
 	p := NewPorter(PorterMinEphemeral)
 	fc := &fakeCloser{}
 	p.Reserve(95, fc)   //nolint:errcheck
-	p.Reserve(96, "no") //nolint:errcheck — not a Closer, skipped
+	p.Reserve(96, "no") //nolint:errcheck // not a Closer, nothing to check
 
 	p.CloseAll(nil) // nil logger → uses a default internally
 	assert.True(t, fc.closed.Load())


### PR DESCRIPTION
`//nolint:errcheck — reason` is not the directive format: golangci-lint reads everything after the colon as a comma-separated linter list, so it took `—`, `well-known,`, `must` and `survive` for linter names and warned on every run:

```
Found unknown linters in //nolint directives: errcheck — not a closer, errcheck — well-known, must survive, skipped
```

The reason must follow a second comment marker — `//nolint:errcheck // why`. Same suppression, minus the warning, and the directive now means what it looks like it means instead of working by accident of where the parser stops.

Found while checking whether CI under-reports lint findings. It does not: the earlier run I compared against simply contained fewer files than my local run. CI reported all ten issues on the #3868 merge.