### PR TITLE
flags: restore the hidden 'tree' command

### DIFF
--- a/pkg/flags/helpall.go
+++ b/pkg/flags/helpall.go
@@ -88,6 +88,27 @@ Modes (mutually exclusive):
 	}
 	root.SetHelpCommand(helpCmd)
 	root.AddCommand(helpCmd)
+
+	// `<root> tree` prints the command hierarchy and nothing else — the same
+	// rendering as `help -t`, reachable as a verb because that is how people
+	// look for it. Hidden, since it duplicates a flag that is already
+	// documented; discoverability is not the point, muscle memory is.
+	//
+	// Installed here rather than on one root so every command group gets it
+	// at its own level: `skywire tree` shows everything, `skywire cli tree`
+	// shows the CLI subtree.
+	if prev := findChild(root, "tree"); prev != nil {
+		root.RemoveCommand(prev)
+	}
+	root.AddCommand(&cobra.Command{
+		Use:    "tree",
+		Short:  "print the subcommand tree",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
+			PrintCommandTree(cmd.Parent())
+		},
+	})
 }
 
 // findChild returns the direct child of c matching name, or nil.


### PR DESCRIPTION
`skywire tree` errored with "unknown command" and `skywire cli tree` silently printed the banner — the root ignores an unknown subcommand rather than rejecting it, so the typo looked like a working command that did nothing.

The rendering already existed as `help -t`; only the verb was missing. Installed alongside the help command so every root gets one at its own level:

- `skywire tree` — 517 lines, the whole binary
- `skywire cli tree` — 362 lines, the CLI subtree
- `skywire dmsg tree` — that group alone

Output is byte-identical to the corresponding `help -t`. Hidden, because it duplicates a documented flag: the point is that it works when reached for, not that it is advertised.