### PR TITLE
tree: structured JSON output, and widen the guard that missed it

### DIFF
--- a/cmd/skywire-cli/jsoncontract_test.go
+++ b/cmd/skywire-cli/jsoncontract_test.go
@@ -26,7 +26,11 @@ import (
 	"testing"
 )
 
-const commandsDir = "commands"
+// scanDirs are the trees searched for commands. pkg/flags is here because
+// commands can be defined outside cmd/skywire-cli/commands and were invisible
+// to these checks when they were: `tree` was added there and shipped ignoring
+// --json, which is exactly what this file exists to prevent.
+var scanDirs = []string{"commands", "../../pkg/flags"}
 
 // streamingCommands print continuously, interactively, or as a byte stream, so
 // there is no single document for --json to shape. Anything added here needs a
@@ -202,7 +206,14 @@ func TestEveryPrintingCommandHonoursJSON(t *testing.T) {
 func forEachFile(t *testing.T, fn func(path string, file *ast.File, fset *token.FileSet)) {
 	t.Helper()
 	fset := token.NewFileSet()
-	err := filepath.Walk(commandsDir, func(path string, info os.FileInfo, err error) error {
+	for _, dir := range scanDirs {
+		walkOne(t, dir, fn, fset)
+	}
+}
+
+func walkOne(t *testing.T, dir string, fn func(path string, file *ast.File, fset *token.FileSet), fset *token.FileSet) {
+	t.Helper()
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -217,7 +228,7 @@ func forEachFile(t *testing.T, fn func(path string, file *ast.File, fset *token.
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("walking %s: %v", commandsDir, err)
+		t.Fatalf("walking %s: %v", dir, err)
 	}
 }
 

--- a/pkg/cliout/clihelp/clihelp.go
+++ b/pkg/cliout/clihelp/clihelp.go
@@ -13,6 +13,8 @@
 package clihelp
 
 import (
+	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -111,3 +113,60 @@ func flagsOf(set *pflag.FlagSet) []Flag {
 // method here would be a second layout to keep in step with the first, and a
 // no-op one would silently print nothing. The help function branches instead:
 // JSON from this schema, text from cobra's own help.
+
+// Node is the command tree with the help text stripped out: what `tree`
+// shows, in the shape a program would want it.
+//
+// Deliberately not Command. `tree` exists to show STRUCTURE — it is
+// `help -t`, help with the text removed — so its JSON carries names and
+// nesting and nothing else. Emitting the full Command schema here would make
+// `tree --json` a duplicate of `--help --json`, and the two commands would
+// stop meaning different things.
+type Node struct {
+	Name string `json:"name"`
+	// Path is how the command is typed, e.g. "skywire cli visor info".
+	Path string `json:"path"`
+	// Runnable separates a command that does something from a group that only
+	// holds others — the distinction the ASCII rendering cannot show.
+	Runnable bool   `json:"runnable"`
+	Children []Node `json:"children,omitempty"`
+}
+
+// TreeOf builds the structural tree rooted at cmd, following the same
+// visibility rule as the ASCII rendering: available commands only, so the two
+// forms describe the same thing.
+func TreeOf(cmd *cobra.Command) Node {
+	n := Node{Name: cmd.Name(), Path: cmd.CommandPath(), Runnable: cmd.Runnable()}
+	for _, child := range cmd.Commands() {
+		if !child.IsAvailableCommand() {
+			continue
+		}
+		n.Children = append(n.Children, TreeOf(child))
+	}
+	return n
+}
+
+// Human writes the ASCII tree, so `tree` and `tree --json` are one value in
+// two renderings rather than two code paths that can disagree.
+func (n Node) Human(w io.Writer) error {
+	if _, err := fmt.Fprintln(w, n.Name); err != nil {
+		return err
+	}
+	return n.writeChildren(w, "")
+}
+
+func (n Node) writeChildren(w io.Writer, prefix string) error {
+	for i, c := range n.Children {
+		branch, next := "├── ", prefix+"│   "
+		if i == len(n.Children)-1 {
+			branch, next = "└── ", prefix+"    "
+		}
+		if _, err := fmt.Fprintf(w, "%s%s%s\n", prefix, branch, c.Name); err != nil {
+			return err
+		}
+		if err := c.writeChildren(w, next); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/flags/helpall.go
+++ b/pkg/flags/helpall.go
@@ -15,7 +15,11 @@ package flags
 
 import (
 	"fmt"
+	"os"
 	"strings"
+
+	"github.com/skycoin/skywire/pkg/cliout"
+	"github.com/skycoin/skywire/pkg/cliout/clihelp"
 
 	"github.com/spf13/cobra"
 )
@@ -106,7 +110,11 @@ Modes (mutually exclusive):
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
-			PrintCommandTree(cmd.Parent())
+			// One value, two renderings: the ASCII tree is Node.Human, so the
+			// text and JSON forms cannot describe different trees.
+			if err := cliout.Print(cmd, clihelp.TreeOf(cmd.Parent())); err != nil {
+				fmt.Fprintln(os.Stderr, err) //nolint:errcheck
+			}
 		},
 	})
 }


### PR DESCRIPTION
`tree` shipped ignoring `--json` — it printed the ASCII tree whatever was asked for.

The guard did not catch it because it only scanned `cmd/skywire-cli/commands`, and this command is defined in `pkg/flags`. A check that cannot see where commands are declared is not a check, so it scans `pkg/flags` too. Verified with a probe file: flagged when present, green when removed.

The JSON is deliberately **not** the `--help --json` schema. `tree` exists to show structure — it is help with the text removed — so `clihelp.Node` carries names, paths and nesting and nothing else. Emitting the full `Command` schema would make `tree --json` a duplicate of `--help --json`, and the two commands would stop meaning different things.

The ASCII rendering is now `Node.Human`, so text and JSON are one value in two renderings rather than two functions that can disagree. Byte-identical to `help -t`, and queryable:

```
skywire cli tree --json | jq '[.. | objects | select(.runnable == true) | .path] | length'   # 327
```