### PR TITLE
cli: move 'web' under 'skywire cli'

### DIFF
--- a/cmd/skywire-cli/commands/root.go
+++ b/cmd/skywire-cli/commands/root.go
@@ -43,6 +43,7 @@ import (
 	cliversion "github.com/skycoin/skywire/cmd/skywire-cli/commands/version"
 	clivisor "github.com/skycoin/skywire/cmd/skywire-cli/commands/visor"
 	clivpn "github.com/skycoin/skywire/cmd/skywire-cli/commands/vpn"
+	"github.com/skycoin/skywire/cmd/skywire/commands/web"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
 	"github.com/skycoin/skywire/pkg/cliout"
@@ -111,6 +112,7 @@ func init() {
 	cliutil.RootCmd.GroupID = groupUtil
 	cligot.RootCmd.GroupID = groupUtil
 	cliversion.RootCmd.GroupID = groupUtil
+	web.RootCmd.GroupID = groupUtil
 
 	// Install flag-aware `help` command (supports -r/-t/-d). Covers
 	// the case where `skywire cli` is invoked as a subcommand of the
@@ -150,6 +152,7 @@ func init() {
 		cliutil.RootCmd,
 		cligot.RootCmd,
 		cliversion.RootCmd,
+		web.RootCmd,
 
 		// Top-level shortcuts: high-traffic verbs reachable without
 		// the `visor` middle word. Long forms keep working at

--- a/cmd/skywire/commands/root.go
+++ b/cmd/skywire/commands/root.go
@@ -24,7 +24,6 @@ import (
 	dmsgprobe "github.com/skycoin/skywire/cmd/dmsg/dmsgprobe/commands"
 	scli "github.com/skycoin/skywire/cmd/skywire-cli/commands"
 	"github.com/skycoin/skywire/cmd/skywire/commands/doc"
-	"github.com/skycoin/skywire/cmd/skywire/commands/web"
 	services "github.com/skycoin/skywire/cmd/svc/skywire-services/commands"
 	"github.com/skycoin/skywire/pkg/buildinfo"
 	"github.com/skycoin/skywire/pkg/calvin"
@@ -79,7 +78,6 @@ func init() {
 		cxo.RootCmd,
 		appsCmd,
 		doc.RootCmd,
-		web.RootCmd,
 	)
 
 	visor.RootCmd.Long = calvin.AsciiFont("skywire-visor")


### PR DESCRIPTION
It serves the CLI as a browser page — `skywire cli web` says that, while `skywire web` put a CLI feature beside visor, dmsg and the services. It lands in the Utilities group alongside `got`, `util` and `version`.

Only the registration moves. The package keeps its directory, its `//go:embed` of `static/` and its own Makefile, so the wasm build is untouched; and it imports nothing from skywire-cli, so hanging it there introduces no cycle.