### PR TITLE
dmsg: stop the self-session test racing its own server for sequence 0

### DIFF
--- a/pkg/dmsg/dmsg/self_session_test.go
+++ b/pkg/dmsg/dmsg/self_session_test.go
@@ -32,12 +32,23 @@ func TestSelfSession_SameKeyClientReachesOwnServer(t *testing.T) {
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	addr := lis.Addr().String()
-	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
 
-	// Server entry advertises the loopback listener (as the production fix does).
+	// Post the entry BEFORE serving. Serve publishes the server's own entry
+	// from a background goroutine, so posting afterwards is a race for
+	// sequence 0: whichever lands second is rejected with "sequence field of
+	// new entry is not sequence of old entry + 1", and the one wrapped in
+	// require.NoError here is the test's. It failed that way on CI while
+	// passing 25 consecutive local runs — a window narrow enough to look like
+	// nothing until a loaded runner widens it.
+	//
+	// Ordered this way the test seeds an empty discovery, and the server's
+	// own loop then updates that entry through the normal fetch-and-increment
+	// path instead of colliding with it.
 	srvEntry := disc.NewServerEntry(pk, 0, addr, 10)
 	require.NoError(t, srvEntry.Sign(sk))
 	require.NoError(t, dc.PostEntry(context.Background(), srvEntry))
+
+	go func() { _ = srv.Serve(lis, addr) }() //nolint:errcheck
 
 	// The transit client shares the server's keypair. It must NOT register (in
 	// production it's a direct client) — MinSessions:0 = connect to all known


### PR DESCRIPTION
`TestSelfSession_SameKeyClientReachesOwnServer` posted the server's discovery entry **after** starting `Serve`, which publishes that server's own entry from a background goroutine. Two writers, one sequence 0 — whichever lands second is rejected with `sequence field of new entry is not sequence of old entry + 1`, and the one wrapped in `require.NoError` is the test's.

This is what has been turning the `linux` job red on develop. It failed on CI while passing 25 consecutive runs locally, and 12 more at `-cpu=1`; a window that narrow reads as nothing until a loaded runner widens it.

Posting before `Serve` seeds an empty discovery, so the server's own loop updates that entry through the normal fetch-and-increment path instead of colliding with it. The test's intent is unchanged — the entry still advertises the loopback listener before any client resolves it.

20 consecutive runs green, full package suite passes.