### PR TITLE
integration: wait for an app to reach running, don't sample once

### DIFF
--- a/internal/integration/env_test.go
+++ b/internal/integration/env_test.go
@@ -116,23 +116,42 @@ func (env *TestEnv) VisorAppLs(visor string) ([]AppState, error) {
 	return apps, nil
 }
 
-// VerifyAppRunning checks if an app is running and fails the test if not.
+// VerifyAppRunning waits for an app to reach "running" and fails the test if it
+// does not get there within waitForVisorApp's bounded budget.
+//
+// Starting an app is asynchronous. `visor app start` and `cli proxy start`
+// return once the launcher has spawned the process, but the launcher only
+// promotes an app out of "starting" once its proc reports a connection summary
+// or a "Running" detailed status — that is, after the app has dialed its server
+// and the route is up (see AppLauncher.AppState in pkg/app/launcher). An app
+// that reconnects (skysocks-client runs with --reconnect) also drops back to
+// "starting" for the duration of each dial-retry loop.
+//
+// Sampling the status once and asserting it equals "running" therefore races the
+// app and loses intermittently — most visibly for skysocks-client over a
+// multi-hop route, where the extra route-finder query and rule install widen the
+// window. Poll instead, reusing the same bounded wait the rest of this package
+// uses, and still fail if the app never gets there.
+//
 // For apps with HTTP endpoints (like skychat), it also verifies the endpoint is ready.
 func (env *TestEnv) VerifyAppRunning(t *testing.T, visor, appName string) {
-	apps, err := env.VisorAppLs(visor)
-	require.NoError(t, err, "Failed to list apps on %s", visor)
+	t.Helper()
 
-	found := false
-	for _, app := range apps {
-		if app.App == appName {
-			require.Equal(t, "running", app.Status, "App %s on %s is not running (status: %s)", appName, visor, app.Status)
-			found = true
-			break
+	if err := env.waitForVisorApp(AppToRun{VisorHostName: visor, AppName: appName}); err != nil {
+		// Re-read the app list so the failure reports the app's actual final
+		// state rather than only that the wait elapsed.
+		apps, lsErr := env.VisorAppLs(visor)
+		if lsErr != nil {
+			t.Fatalf("App %s on %s never reached running: %v (follow-up app ls on %s also failed: %v)",
+				appName, visor, err, visor, lsErr)
 		}
-	}
-
-	if !found {
-		t.Fatalf("App %s not found on %s", appName, visor)
+		for _, app := range apps {
+			if app.App == appName {
+				t.Fatalf("App %s on %s is not running (status: %s, detailed status: %s): %v",
+					appName, visor, app.Status, app.DetailedStatus, err)
+			}
+		}
+		t.Fatalf("App %s not found on %s: %v", appName, visor, err)
 	}
 
 	// For skychat, verify the HTTP endpoint is actually ready to accept connections


### PR DESCRIPTION
`VerifyAppRunning` read the app list **once** and asserted the status equalled `running`.

Starting an app is asynchronous. The launcher promotes it out of `starting` only after the proc reports a connection summary or a Running detailed status — after it has dialled its server and the route is up (`AppLauncher.AppState`) — and an app running with `--reconnect` (which `cli proxy start` passes) drops back to `starting` for each dial-retry. skysocks-client over a 2-hop route widens that window with an extra route-finder query and rule install, which is why `TestMultiHopRoute` flaked *there* and not elsewhere — roughly 2 of 4 recent develop runs.

It polls now, reusing `waitForVisorApp`, the bounded wait the rest of the package already uses, rather than adding a sleep. The assertion is no weaker: `starting` still fails. On timeout it re-reads the list so the message names the app's actual final state and detailed status instead of only reporting that the wait elapsed.

One helper serves all 11 call sites, so this also covers skysocks, mux, skychat-receipt, stcp and ci.

**Flagged, not fixed here:** `ExecInContainerByID` discards `result.ExitCode` and always returns nil, so `require.NoErrorf` on CLI invocations across this package is currently a no-op — a failing `proxy start` cannot fail the test. Fixing it changes the contract for every Exec caller, several of which rely on non-zero exits being ignored (best-effort `VisorTpRm`), so it deserves its own change.

Not run here: these need the Docker stack. Verified with `go vet`, a compile-only test run, and `golangci-lint`.