### PR TITLE
skycoin: serve the TinyGo visor as the wallet's cipher, not the std-Go one

### DIFF
--- a/cmd/skycoin/commands/cipherwasm.go
+++ b/cmd/skycoin/commands/cipherwasm.go
@@ -21,9 +21,24 @@ import (
 // binary entirely (see the package comment on root.go).
 //
 // Both halves come from the SAME variant. A TinyGo wasm needs TinyGo's loader
-// and a Go wasm needs Go's, and which variant is the default depends on how
-// skywire itself was compiled — a TinyGo build embeds only the TinyGo pair. So
-// this asks wasmbin for its default rather than naming one.
+// and a Go wasm needs Go's — so both are taken from one variant, never mixed.
+//
+// The TinyGo variant is preferred here, which is the opposite of what the visor
+// itself defaults to, because this route pays for the whole blob on page load
+// and uses only the cipher out of it:
+//
+//	wasm-visor, std Go     10.0 MB gzip
+//	wasm-visor, TinyGo      3.9 MB gzip
+//	skycoin-lite (was)      1.7 MB gzip
+//
+// `skywire skycoin web` runs the wallet against clearnet nodes with the visor
+// dormant, so serving the std-Go visor would make that page ~6x heavier than the
+// skycoin-lite it replaced for a cipher it does not otherwise use. TinyGo brings
+// that back to ~2x. It is still not free — see the note in the PR — but a
+// standard-Go skywire embeds BOTH pairs, so this costs nothing to prefer.
+//
+// Where the visor is actually running, the page loads the blob regardless and
+// the cipher genuinely is free; that path takes whatever variant it is serving.
 func registerCipherWasm() {
 	if !wasmbin.Embedded() {
 		// No wasm visor is embedded — a build made without the committed blobs.
@@ -32,7 +47,12 @@ func registerCipherWasm() {
 		return
 	}
 
+	// A TinyGo build of skywire embeds only the TinyGo pair; a standard-Go build
+	// embeds both. Falling back to the default covers the former.
 	v := wasmbin.Default()
+	if wasmbin.Has(wasmbin.TinyGo) {
+		v = wasmbin.TinyGo
+	}
 
 	gz, execJS := wasmbin.GetVariantGz(v), wasmbin.WasmExecJSVariant(v)
 	if len(gz) == 0 || len(execJS) == 0 {


### PR DESCRIPTION
Follow-up to #3876, fixing a page-weight regression it introduced.

## The problem

`registerCipherWasm` took `wasmbin.Default()` — the std-Go wasm-visor. That route pays for the whole blob on page load and uses only the cipher out of it:

| blob | gzip |
|---|---|
| wasm-visor, std Go | 10.0 MB |
| wasm-visor, TinyGo | 3.9 MB |
| skycoin-lite (what it replaced) | 1.7 MB |

`skywire skycoin web` runs the wallet against clearnet nodes with the visor dormant — the context specified to behave exactly as `skycoin web` does today. Serving the std-Go visor made that page **~6x heavier** than the skycoin-lite it replaced.

## The fix

Prefer the TinyGo variant, bringing it to ~2x. This costs nothing: a standard-Go skywire embeds **both** pairs, and a TinyGo build embeds only TinyGo, which the fallback to `Default()` covers. Both halves still come from one variant, since a TinyGo wasm needs TinyGo's loader.

## Why TinyGo is safe here

`wasmcipher`'s own comment:

> It cannot be relied on. Under TinyGo the recover does not fire at all and a panic traps the whole module, leaving the cipher dead for the rest of the page — which is why the errors are returned rather than recovered.

The cipher does not depend on the recover backstop; `liteclient` returns errors at source. That is what makes the TinyGo build usable in this role.

## Honest residual

~2x is better than ~6x but still not parity with skycoin-lite's 1.7 MB. Getting to parity would mean keeping a skycoin-lite copy in skywire, which is the duplication #3876 removed — so this is the trade, not a full fix.

Where the visor actually runs, the page loads the blob regardless and the cipher genuinely is free — that path is unaffected.