### PR TITLE
chore(config): default log_store to memory; gitignore .angular cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ android/app/src/main/jniLibs/
 # was the first version of this rule, and it was wrong.
 /cmd/hvinspect/hvinspect
 /pkg/tpviz/wasm/*.wasm
+
+# Angular build cache (static/skywire-manager-src builds emit .angular/cache).
+# Left untracked it is the sole dirty entry in an otherwise clean tree, so
+# `go build -buildvcs` stamps every local visor build +dirty. Ignore it at any
+# depth so a GUI build can't dirty a release binary's version.
+.angular/

--- a/cmd/skywire-cli/commands/config/gen.go
+++ b/cmd/skywire-cli/commands/config/gen.go
@@ -1198,7 +1198,9 @@ func configureTransports() {
 		PublicAutoconnect: skyenv.PublicAutoconnect,
 		TransportSetupPKs: services.TransportSetupPKs,
 		LogStore: &visorconfig.LogStore{
-			Type:             visorconfig.FileLogStore,
+			// "file" (the retired on-disk CSV store) is now a no-op that only warns
+			// at boot; default fresh configs to "memory" so they don't carry it.
+			Type:             visorconfig.MemoryLogStore,
 			Location:         tpLogPath,
 			RotationInterval: visorconfig.DefaultLogRotationInterval,
 		},

--- a/pkg/visor/visorconfig/config.go
+++ b/pkg/visor/visorconfig/config.go
@@ -45,7 +45,10 @@ func MakeBaseConfig(common *Common, testEnv bool, dmsgHTTP bool, services *Servi
 		AddressResolver:   services.AddressResolver,
 		PublicAutoconnect: skyenv.PublicAutoconnect,
 		LogStore: &LogStore{
-			Type:             FileLogStore,
+			// The on-disk CSV log store was retired; "file" is now a no-op that
+			// only earns a deprecation warning at boot (init_transport.go). Default
+			// fresh configs to "memory" so they don't ship that phantom warning.
+			Type:             MemoryLogStore,
 			Location:         skyenv.LocalPath + "/" + skyenv.TpLogStore,
 			RotationInterval: DefaultLogRotationInterval,
 		},


### PR DESCRIPTION
Two small cleanliness fixes surfaced by watching a native visor boot fresh:

1. **Phantom deprecation warning on every fresh config.** config-gen defaulted `transport.log_store.type` to `"file"` — the retired on-disk CSV store. `init_transport.go` treats `"file"` as a no-op and logs `transport.log_store.type="file" is deprecated ... now treated as "memory"` at **every** boot. So a freshly-generated config ships a warning about its own default. Changed the default to `"memory"` in both the `visorconfig` template (`config.go`) and `cli config gen` (`gen.go`). Existing configs still warn until regenerated — that's the intended nudge; regen is non-destructive.

2. **`.angular/` dirtied every local build.** The Angular build cache (`static/skywire-manager-src` emits `.angular/cache`) was untracked, making it the *sole* dirty entry in an otherwise clean tree — so `go build -buildvcs` stamped every local visor build `+dirty` (observed: `version":"v1.3.92-0.…+dirty"`). Ignored `.angular/` at any depth.

Verified: `go build .` OK, `pkg/visor/visorconfig` tests pass, a freshly-genned config now emits `"type": "memory"`, and the tree is clean with `.angular/` present.