### PR TITLE
logging: fix levels, stdout leaks, format deviations, and a Fatal-on-bad-pidfile availability bug

### DIFF
--- a/pkg/app/appevent/utils.go
+++ b/pkg/app/appevent/utils.go
@@ -17,13 +17,13 @@ func (eb *Broadcaster) SendTPClose(_ context.Context, netType, addr string) {
 	data := TCPCloseData{RemoteNet: netType, RemoteAddr: addr}
 	event := NewEvent(TCPClose, data)
 	if err := eb.Broadcast(context.Background(), event); err != nil {
-		eb.log.WithError(err).Errorln("Failed to broadcast TCPClose event")
+		eb.log.WithError(err).Warnln("failed to broadcast TCPClose event")
 	}
 }
 
 func (eb *Broadcaster) sendEvent(_ context.Context, event *Event) {
 	err := eb.Broadcast(context.Background(), event)
 	if err != nil {
-		eb.log.Warn("Failed to broadcast event: %v", event)
+		eb.log.WithError(err).Warnf("failed to broadcast event: %v", event)
 	}
 }

--- a/pkg/app/conn.go
+++ b/pkg/app/conn.go
@@ -3,8 +3,6 @@ package app
 
 import (
 	"errors"
-	"fmt"
-	"io"
 	"net"
 	"sync"
 	"time"
@@ -35,9 +33,6 @@ func (c *Conn) Read(b []byte) (int, error) {
 func (c *Conn) Write(b []byte) (int, error) {
 	n, err := c.rpc.Write(c.id, b)
 	if err != nil {
-		if err == io.EOF {
-			fmt.Println("EOF WRITING TO APP CONN")
-		}
 		//return n, &net.OpError{Op: "write", Net: c.local.Network(), Source: c.local, Addr: c.remote, Err: err}
 		return n, err
 	}

--- a/pkg/app/launcher/launcher.go
+++ b/pkg/app/launcher/launcher.go
@@ -749,12 +749,14 @@ func (l *AppLauncher) killHangingProcesses() error {
 		appInfo := strings.Split(scan.Text(), " ")
 		if len(appInfo) != 2 {
 			err := errors.New("line should be: [app name] [pid]")
-			log.WithError(err).Fatal("Failed parsing pid file.")
+			log.WithError(err).Warn("skipping malformed pid-file line")
+			continue
 		}
 
 		pid, err := strconv.Atoi(appInfo[1])
 		if err != nil {
-			log.WithError(err).Fatal("Failed parsing pid file.")
+			log.WithError(err).Warnf("skipping malformed pid-file line: %q", scan.Text())
+			continue
 		}
 
 		l.killHangingProc(appInfo[0], pid)
@@ -804,12 +806,14 @@ func (l *AppLauncher) killApp(appName string) error {
 		appInfo := strings.Split(scan.Text(), " ")
 		if len(appInfo) != 2 {
 			err := errors.New("line should be: [app name] [pid]")
-			log.WithError(err).Fatal("Failed parsing pid file.")
+			log.WithError(err).Warn("skipping malformed pid-file line")
+			continue
 		}
 
 		pid, err := strconv.Atoi(appInfo[1])
 		if err != nil {
-			log.WithError(err).Fatal("Failed parsing pid file.")
+			log.WithError(err).Warnf("skipping malformed pid-file line: %q", scan.Text())
+			continue
 		}
 		if appInfo[0] == appName {
 			l.killArbitraryProc(appInfo[0], pid)

--- a/pkg/dmsg/direct/direct.go
+++ b/pkg/dmsg/direct/direct.go
@@ -51,11 +51,11 @@ func StartDmsgWithSetup(ctx context.Context, log *logging.Logger, pk cipher.PubK
 
 	stop = func() {
 		err := dmsgDC.Close()
-		log.WithError(err).Debug("Disconnected from dmsg network.\n")
+		log.WithError(err).Debug("Disconnected from dmsg network.")
 		wg.Wait()
 	}
 
-	log.WithField("public_key", pk.String()).Debug("Connecting to dmsg network...\n")
+	log.WithField("public_key", pk.String()).Debug("Connecting to dmsg network...")
 
 	select {
 	case <-ctx.Done():

--- a/pkg/dmsg/dmsg/entity_common.go
+++ b/pkg/dmsg/dmsg/entity_common.go
@@ -662,7 +662,7 @@ func (c *EntityCommon) updateServerEntryOnEndpoint(ctx context.Context, ep *disc
 	}
 	// Propagate DHT bootstrap status to discovery entry.
 	entry.Server.DHTBootstrap = c.dhtBootstrap
-	log.Debug("Updating entry.\n")
+	log.Debug("Updating entry.")
 
 	return ep.Client.PutEntry(ctx, c.sk, entry)
 }
@@ -993,7 +993,7 @@ func (c *EntityCommon) updateClientEntryOnEndpoint(ctx context.Context, ep *disc
 
 	entry.ClientType = clientType
 	entry.Client.DelegatedServers = srvPKs
-	c.log.WithField("entry", entry).Debug("Updating entry.\n")
+	c.log.WithField("entry", entry).Debug("Updating entry.")
 	if err := ep.Client.PutEntry(ctx, c.sk, entry); err != nil {
 		return nil, err
 	}
@@ -1147,10 +1147,10 @@ func (c *EntityCommon) entryProtocol(ctx context.Context, pk cipher.PubKey) stri
 		if err != nil {
 			continue
 		}
-		c.log.WithField("entry", entry).Debug("Entry's protocol fetch.\n")
+		c.log.WithField("entry", entry).Debug("Entry's protocol fetch.")
 		return entry.Protocol
 	}
-	c.log.WithField("pk", pk).Warn("Entry not found in any discovery; returning empty protocol.\n")
+	c.log.WithField("pk", pk).Warn("Entry not found in any discovery; returning empty protocol.")
 	return ""
 }
 
@@ -1175,7 +1175,7 @@ func (c *EntityCommon) delEntry(ctx context.Context) (err error) {
 			}
 			continue
 		}
-		c.log.WithField("entry", entry).Debug("Deleting entry.\n")
+		c.log.WithField("entry", entry).Debug("Deleting entry.")
 		if delErr := ep.Client.DelEntry(ctx, entry); delErr != nil && firstErr == nil {
 			firstErr = delErr
 		}

--- a/pkg/dmsg/dmsgclient/cli.go
+++ b/pkg/dmsg/dmsgclient/cli.go
@@ -94,11 +94,10 @@ func StartDmsg(ctx context.Context, dlog *logging.Logger, pk cipher.PubKey, sk c
 
 	stop = func() {
 		err := dmsgC.Close()
-		dlog.WithError(err).Debug("Disconnected from dmsg network.\n")
+		dlog.WithError(err).Debug("Disconnected from dmsg network.")
 		log.Println()
 	}
-	dlog.WithField("dmsg_disc", dmsgDisc).Debug("Connecting to dmsg network...\n")
-	dlog.WithField("client public_key", pk.String()).Debug("\n")
+	dlog.WithField("dmsg_disc", dmsgDisc).Debug("Connecting to dmsg network...")
 	select {
 	case <-ctx.Done():
 		stop()

--- a/pkg/dmsg/dmsgclient/cli_fallback.go
+++ b/pkg/dmsg/dmsgclient/cli_fallback.go
@@ -63,11 +63,10 @@ func StartDmsgWithSyntheticDiscovery(ctx context.Context, dlog *logging.Logger, 
 
 	stop = func() {
 		err := dmsgC.Close()
-		dlog.WithError(err).Debug("Disconnected from dmsg network.\n")
+		dlog.WithError(err).Debug("Disconnected from dmsg network.")
 		log.Println()
 	}
-	dlog.WithField("dmsg_disc", dmsgDisc).Debug("Connecting to dmsg network...\n")
-	dlog.WithField("client public_key", pk.String()).Debug("\n")
+	dlog.WithField("dmsg_disc", dmsgDisc).Debug("Connecting to dmsg network...")
 	select {
 	case <-ctx.Done():
 		stop()
@@ -146,11 +145,10 @@ func StartDmsgWithDirectClient(ctx context.Context, dlog *logging.Logger, pk cip
 
 	stop = func() {
 		err := dmsgC.Close()
-		dlog.WithError(err).Debug("Disconnected from dmsg network.\n")
+		dlog.WithError(err).Debug("Disconnected from dmsg network.")
 		log.Println()
 	}
-	dlog.Debug("Connecting to dmsg network...\n")
-	dlog.WithField("client public_key", pk.String()).Debug("\n")
+	dlog.Debug("Connecting to dmsg network...")
 	select {
 	case <-ctx.Done():
 		stop()

--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/armon/go-socks5"
 	"github.com/chen3feng/safecast"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -277,8 +278,9 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 	conf := &socks5.Config{
 		// Route go-socks5's own [ERR] lines through logrus so they match the
 		// rest of the visor's log format instead of the library's raw stdout
-		// default.
-		Logger:   logging.NewStdLogger(log),
+		// default. Cap at Debug: a SOCKS proxy failing a *client-requested*
+		// dial is a routine, client-driven condition, not a visor error.
+		Logger:   logging.NewStdLoggerLevel(log, logrus.DebugLevel),
 		Resolver: &dmsgResolver{cfg: cfg},
 		Dial: func(dialCtx context.Context, network, addr string) (conn net.Conn, dialErr error) {
 			defer func() {

--- a/pkg/logging/stdlog.go
+++ b/pkg/logging/stdlog.go
@@ -18,6 +18,10 @@ import (
 // is stripped and mapped to the corresponding logrus level.
 type logrusWriter struct {
 	log logrus.FieldLogger
+	// maxLevel caps severity: no record is emitted more severe than this
+	// level. Zero means unset (no cap). Because logrus levels are
+	// more-severe = smaller number, the clamp raises the numeric value.
+	maxLevel logrus.Level
 }
 
 func (w logrusWriter) Write(p []byte) (int, error) {
@@ -35,6 +39,11 @@ func (w logrusWriter) Write(p []byte) (int, error) {
 			}
 			msg = strings.TrimSpace(msg[end+1:])
 		}
+	}
+	// Clamp severity to maxLevel. logrus levels are more-severe = smaller
+	// number, so a level below the cap is raised up to it (0 = unset = no cap).
+	if w.maxLevel != 0 && level < w.maxLevel {
+		level = w.maxLevel
 	}
 	switch level {
 	case logrus.ErrorLevel:
@@ -56,4 +65,12 @@ func (w logrusWriter) Write(p []byte) (int, error) {
 // log format instead of writing uncolored lines straight to stdout.
 func NewStdLogger(log logrus.FieldLogger) *stdlog.Logger {
 	return stdlog.New(logrusWriter{log: log}, "", 0)
+}
+
+// NewStdLoggerLevel is like NewStdLogger but caps severity: no line is logged
+// more severe than `maxLevel`. Use it for libraries (e.g. a SOCKS proxy serving
+// external clients) whose "[ERR]" lines are routine, client-driven conditions
+// rather than faults of this process.
+func NewStdLoggerLevel(log logrus.FieldLogger, maxLevel logrus.Level) *stdlog.Logger {
+	return stdlog.New(logrusWriter{log: log, maxLevel: maxLevel}, "", 0)
 }

--- a/pkg/router/route_group.go
+++ b/pkg/router/route_group.go
@@ -617,7 +617,7 @@ func (rg *RouteGroup) writePacket(ctx context.Context, tp *transport.ManagedTran
 
 		if err := rg.rt.UpdateActivity(ruleID); err != nil {
 			if !rg.isClosed() {
-				rg.logger.WithError(err).Errorf("error updating activity of rule %d", ruleID)
+				rg.logger.WithError(err).Debugf("error updating activity of rule %d", ruleID)
 			}
 		}
 	}

--- a/pkg/router/router_packet.go
+++ b/pkg/router/router_packet.go
@@ -344,7 +344,7 @@ func (r *router) forwardPacket(ctx context.Context, packet routing.Packet, rule 
 	}
 
 	if err := r.UpdateRuleActivity(rule.KeyRouteID()); err != nil {
-		r.logger.Errorf("Failed to update activity for rule with route ID %d: %v", rule.KeyRouteID(), err)
+		r.logger.Debugf("Failed to update activity for rule with route ID %d: %v", rule.KeyRouteID(), err)
 	}
 
 	return nil

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 
 	"github.com/armon/go-socks5"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/proxy"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -198,7 +199,9 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 		// Route go-socks5's own [ERR] lines through logrus so they match the
 		// rest of the visor's log format (colored, module-tagged) instead of
 		// the library's raw stdout "2006/01/02 ... [ERR] socks:" default.
-		Logger:   logging.NewStdLogger(log),
+		// Cap at Debug: a SOCKS proxy failing a *client-requested* dial is a
+		// routine, client-driven condition, not a visor error.
+		Logger:   logging.NewStdLoggerLevel(log, logrus.DebugLevel),
 		Resolver: &skynetResolver{cfg: cfg},
 		Dial: func(dialCtx context.Context, network, addr string) (retConn net.Conn, retErr error) {
 			// Fail the single request instead of crashing the whole visor if

--- a/pkg/skysocks/server.go
+++ b/pkg/skysocks/server.go
@@ -11,11 +11,13 @@ import (
 	"github.com/armon/go-socks5"
 	"github.com/hashicorp/yamux"
 	ipc "github.com/james-barrow/golang-ipc"
+	"github.com/sirupsen/logrus"
 
 	"github.com/skycoin/skywire/pkg/app"
 	"github.com/skycoin/skywire/pkg/app/appnet"
 	"github.com/skycoin/skywire/pkg/app/appserver"
 	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
@@ -32,7 +34,13 @@ type Server struct {
 
 // NewServer constructs a new Server.
 func NewServer(whitelist []cipher.PubKey, appCl *app.Client) (*Server, error) {
-	s, err := socks5.New(&socks5.Config{})
+	// Give go-socks5 an explicit logrus-backed logger so it does not fall back
+	// to its default log.New(os.Stdout, …) and leak lines to stdout. Cap at
+	// Debug: a SOCKS proxy failing a *client-requested* dial is a routine,
+	// client-driven condition, not a proxy error.
+	s, err := socks5.New(&socks5.Config{
+		Logger: logging.NewStdLoggerLevel(logging.MustGetLogger("skysocks"), logrus.DebugLevel),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("socks5: %w", err)
 	}

--- a/pkg/transport/network/handshake/handshake.go
+++ b/pkg/transport/network/handshake/handshake.go
@@ -30,7 +30,7 @@ type Error string
 
 // Error implements error.
 func (err Error) Error() string {
-	return fmt.Sprintln("handshake failed:", string(err))
+	return fmt.Sprintf("handshake failed: %s", string(err))
 }
 
 // IsHandshakeError determines whether the error occurred during the handshake.

--- a/pkg/transport/network/stcp/pktable.go
+++ b/pkg/transport/network/stcp/pktable.go
@@ -67,7 +67,9 @@ func NewTableFromFile(path string) (PKTable, error) {
 
 	defer func() {
 		if err := f.Close(); err != nil {
-			fmt.Println("udp_factory: failed to close table file:", err)
+			// No module logger is in scope in this low-level table package;
+			// route to stderr rather than leaking a raw line to stdout.
+			fmt.Fprintln(os.Stderr, "stcp: failed to close pk-table file:", err)
 		}
 	}()
 

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -831,7 +831,6 @@ func (v *Visor) SetAppDNS(appName string, dnsAddr string) error {
 
 // DoCustomSetting implents API.
 func (v *Visor) DoCustomSetting(appName string, customSetting map[string]any) error {
-	fmt.Println(customSetting)
 	v.log.Infof("Changing %s Settings to %v", appName, customSetting)
 	if v.appL == nil {
 		return ErrAppLauncherNotAvailable

--- a/pkg/visor/visorconfig/services_native.go
+++ b/pkg/visor/visorconfig/services_native.go
@@ -36,7 +36,7 @@ func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (service
 	//create the http request
 	req, err := http.NewRequest(http.MethodGet, serviceConf, nil)
 	if err != nil {
-		mLog.WithError(err).Fatal("Failed to create http request\n")
+		mLog.WithError(err).Fatal("Failed to create http request")
 	}
 	req.Header.Add("Cache-Control", "no-cache")
 	//check for errors in the response
@@ -44,7 +44,7 @@ func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (service
 	if err != nil {
 		//silence errors for stdout
 		if !stdout {
-			mLog.WithError(err).Error("Failed to fetch servers\n")
+			mLog.WithError(err).Error("Failed to fetch servers")
 			mLog.Warn("Falling back on hardcoded servers")
 		}
 	} else {
@@ -54,12 +54,12 @@ func Fetch(mLog *logging.MasterLogger, serviceConf string, stdout bool) (service
 		}
 		body, err := io.ReadAll(res.Body)
 		if err != nil {
-			mLog.WithError(err).Fatal("Failed to read response\n")
+			mLog.WithError(err).Fatal("Failed to read response")
 		}
 		//fill in services struct with the response
 		err = json.Unmarshal(body, &services)
 		if err != nil {
-			mLog.WithError(err).Fatal("Failed to unmarshal json response\n")
+			mLog.WithError(err).Fatal("Failed to unmarshal json response")
 		}
 		if !stdout {
 			mLog.Infof("Fetched service endpoints from '%s'", serviceConf)


### PR DESCRIPTION
Surfaced by auditing the visor's logging end-to-end (and watching a fresh boot). All changes are level/format/wording or safe control-flow fixes; no behavior beyond what's logged, except the availability fix. Full public keys are preserved everywhere (no truncation).

## Availability
- **`pkg/app/launcher/launcher.go`** — a malformed line in the pid bookkeeping file `Fatal`'d the whole visor (both `killHangingProcesses` and `killApp`). A blank/partial line could abort startup. Now logs `Warn("skipping malformed pid-file line")` and `continue`s.

## Log levels (stop routine/expected conditions logging at ERROR)
- **`pkg/logging/stdlog.go`** — new `NewStdLoggerLevel(log, maxLevel)` that caps severity when bridging a stdlib `*log.Logger` (e.g. go-socks5) through logrus.
- **`pkg/dmsgweb/runtime.go`, `pkg/skynetweb/runtime.go`** — the embedded mesh-browser SOCKS proxies now cap go-socks5's per-request failures at Debug. A proxy failing a *client-requested* dial (e.g. a browser tab reaching an unreachable host) is routine, not a visor error. Previously one retrying tab could emit hundreds of ERROR lines.
- **`pkg/skysocks/server.go`** — passed the same capped logger; also closes a stdout leak (a nil `socks5.Config.Logger` defaults to `log.New(os.Stdout, …)`).
- **`pkg/router/route_group.go`, `pkg/router/router_packet.go`** — per-packet rule-activity-update failures (an expected mid-flow rule-expiry race) demoted ERROR→Debug. This is the loudest ERROR source on relay nodes.

## stdout leaks (visor path must log to stderr only)
- **`pkg/visor/api_apps.go`** — deleted a stray `fmt.Println(customSetting)` in an RPC handler (already logged on the next line).
- **`pkg/app/conn.go`** — deleted a stray `fmt.Println("EOF WRITING TO APP CONN")` and its dead branch.
- **`pkg/transport/network/stcp/pktable.go`** — table-close error `fmt.Println` → `fmt.Fprintln(os.Stderr, …)`.

## Format / wording
- **`pkg/transport/network/handshake/handshake.go`** — `Error()` returned `fmt.Sprintln(...)` (trailing newline); since it's wrapped and logged, every handshake failure carried an embedded newline that broke one-line parsing. → `Sprintf`.
- **`pkg/app/appevent/utils.go`** — `Warn("… %v", event)` used `Warn` as a formatter (printed a literal `%v`, dropped the error). → `WithError(err).Warnf(...)`.
- Stripped trailing `\n` / removed bare `.Debug("\n")` calls in `pkg/dmsg/direct/direct.go`, `pkg/dmsg/dmsg/entity_common.go`, `pkg/dmsg/dmsgclient/{cli,cli_fallback}.go`, `pkg/visor/visorconfig/services_native.go` (logrus already appends a newline).

Verified: `go build .`, `go vet` (logging/router/skynetweb/dmsgweb/skysocks/app/visor/dmsg/transport), and `go test ./pkg/logging/...` all pass.