### PR TITLE
logging(transport): demote first-touch log-entry provisioning WARN→Debug

### DIFF
--- a/pkg/transport/log.go
+++ b/pkg/transport/log.go
@@ -32,8 +32,10 @@ type LogEntry struct {
 func MakeLogEntry(ls LogStore, tpID uuid.UUID, log *logging.Logger) *LogEntry {
 	oldLogEntry, err := ls.Entry(tpID)
 	if err != nil {
-		log.Warn(err)
-		log.Warn(fmt.Errorf("new log entry will create for transport %s", tpID.String()))
+		// A miss is the normal first-touch case (the store is in-memory, so
+		// every transport starts without prior byte counters); it is not a
+		// warning. Fresh counters are created below.
+		log.WithField("transport", tpID.String()).Debug("no prior transport log entry; starting fresh")
 	}
 	newEntry := NewLogEntry()
 	if oldLogEntry != nil {


### PR DESCRIPTION
Second logging-hygiene pass, from watching another fresh visor boot after #3883 landed.

`transport.MakeLogEntry` logged **two WARN lines per transport** on first touch — "transport log entry not found" + "new log entry will create for transport <id>". The bandwidth-counter store is in-memory, so every transport hits this on every boot: ~56 WARN lines at startup on a well-connected visor, none of which are warnings. It's the normal "no prior counters, start fresh" path. Collapsed to a single Debug line.

Verified: `go build`/`go vet ./pkg/transport/` clean. (This was the single largest remaining WARN source; the #3883 SOCKS fix already took boot ERRORs from 240+ to 3.)