### PR TITLE
refactor(visor): lazy on-demand node_health, remove dead LogRotationInterval RPC/HTTP, init cruft

### DIFF
--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -26,7 +26,6 @@ import (
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 // API represents visor API.
@@ -63,8 +62,6 @@ type API interface {
 	SkychatLocalAddr() (string, error)
 	RemoteVisors() ([]string, error)
 	DmsgPtyExec(args DmsgPtyExecArgs) (*pty.CommandExecResult, error)
-	GetLogRotationInterval() (visorconfig.Duration, error)
-	SetLogRotationInterval(visorconfig.Duration) error
 	IsDMSGClientReady() (bool, error)
 	DMSGServers() ([]DMSGServerInfo, error)
 	Ports() (map[string]PortDetail, error)

--- a/pkg/visor/api_services.go
+++ b/pkg/visor/api_services.go
@@ -659,16 +659,6 @@ func addrPort(addr string) string {
 	return ""
 }
 
-// SetLogRotationInterval sets log_rotation_interval config of visor
-func (v *Visor) SetLogRotationInterval(d visorconfig.Duration) error {
-	return v.conf.UpdateLogRotationInterval(d)
-}
-
-// GetLogRotationInterval gets log_rotation_interval config of visor
-func (v *Visor) GetLogRotationInterval() (visorconfig.Duration, error) {
-	return v.conf.GetLogRotationInterval()
-}
-
 // SetPublicAutoconnect sets public_autoconnect config of visor
 func (v *Visor) SetPublicAutoconnect(pAc bool) error {
 	return v.conf.UpdatePublicAutoconnect(pAc)

--- a/pkg/visor/hypervisor.go
+++ b/pkg/visor/hypervisor.go
@@ -863,8 +863,6 @@ func (hv *Hypervisor) makeMux() chi.Router {
 				r.Post("/visors/{pk}/min-hops", hv.postMinHops())
 				r.Get("/visors/{pk}/persistent-transports", hv.getPersistentTransports())
 				r.Put("/visors/{pk}/persistent-transports", hv.putPersistentTransports())
-				r.Get("/visors/{pk}/log/rotation", hv.getLogRotationInterval())
-				r.Put("/visors/{pk}/log/rotation", hv.putLogRotationInterval())
 				r.Get("/visors/{pk}/reward", hv.getRewardAddress())
 				r.Put("/visors/{pk}/reward", hv.putRewardAddress())
 				r.Delete("/visors/{pk}/reward", hv.deleteRewardAddress())

--- a/pkg/visor/hypervisor_handlers_admin.go
+++ b/pkg/visor/hypervisor_handlers_admin.go
@@ -16,7 +16,6 @@ import (
 	"github.com/skycoin/skywire/pkg/httputil"
 	"github.com/skycoin/skywire/pkg/visor/rewardconfig"
 	"github.com/skycoin/skywire/pkg/visor/usermanager"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 func (hv *Hypervisor) shutdown() http.HandlerFunc {
@@ -99,39 +98,6 @@ func (hv *Hypervisor) getRuntimeLogs() http.HandlerFunc {
 		if err != nil {
 			hv.visor.log.Errorf("Cannot write response: %s", err)
 		}
-	})
-}
-
-func (hv *Hypervisor) putLogRotationInterval() http.HandlerFunc {
-	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
-		var reqBody struct {
-			LogRotationInterval visorconfig.Duration `json:"log_rotation_interval"`
-		}
-
-		if err := httputil.ReadJSON(r, &reqBody); err != nil {
-			if err != io.EOF {
-				hv.log(r).Warnf("putLogRotationInterval request: %v", err)
-			}
-			httputil.WriteJSON(w, r, http.StatusBadRequest, usermanager.ErrMalformedRequest)
-			return
-		}
-
-		if err := ctx.API.SetLogRotationInterval(reqBody.LogRotationInterval); err != nil {
-			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
-			return
-		}
-		httputil.WriteJSON(w, r, http.StatusOK, struct{}{})
-	})
-}
-
-func (hv *Hypervisor) getLogRotationInterval() http.HandlerFunc {
-	return hv.withCtx(hv.visorCtx, func(w http.ResponseWriter, r *http.Request, ctx *httpCtx) {
-		pts, err := ctx.API.GetLogRotationInterval()
-		if err != nil {
-			httputil.WriteJSON(w, r, http.StatusInternalServerError, err)
-			return
-		}
-		httputil.WriteJSON(w, r, http.StatusOK, pts)
 	})
 }
 

--- a/pkg/visor/init.go
+++ b/pkg/visor/init.go
@@ -154,8 +154,6 @@ var (
 	regCXOMod vinit.Module
 	// visor that groups all modules together
 	vis vinit.Module
-	// config initialization
-//	visorConfig vinit.Module
 )
 
 // register all modules: instantiate modules with correct names and dependencies, wrap init
@@ -166,7 +164,6 @@ func registerModules(logger *logging.MasterLogger) {
 	maker := func(name string, f initFn, deps ...*vinit.Module) vinit.Module {
 		return vinit.MakeModule(name, withInitCtx(f), logger, deps...)
 	}
-	//	visorConfig = maker("visor_config", initVisorConfig)
 	dmsgHTTP = maker("dmsg_http", initDmsgHTTP)
 	ebc = maker("event_broadcaster", initEventBroadcaster)
 	ar = maker("address_resolver", initAddressResolver, &dmsgC, &sc, &dmsgHTTP)

--- a/pkg/visor/init_dmsg.go
+++ b/pkg/visor/init_dmsg.go
@@ -574,7 +574,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 		}
 	}
 
-	lsAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, "", whitelistedPKs, &v.survey.data, printLog)
+	lsAPI := logserver.New(logger, v.conf.LocalPath, "", whitelistedPKs, &v.survey.data, printLog)
 
 	// Set visor as health stats provider for /health endpoint
 	lsAPI.SetHealthStatsProvider(v)
@@ -716,7 +716,7 @@ func initDmsgHTTPLogServer(ctx context.Context, v *Visor, _ *logging.Logger) err
 		logger.WithField("local_addr", localAddr).Info("Starting localhost log server")
 
 		// Create a separate API without whitelist authentication for localhost
-		localAPI := logserver.New(logger, v.conf.Transport.LogStore.Location, v.conf.LocalPath, "", nil, &v.survey.data, printLog)
+		localAPI := logserver.New(logger, v.conf.LocalPath, "", nil, &v.survey.data, printLog)
 
 		// Set visor as health stats provider for /health endpoint
 		localAPI.SetHealthStatsProvider(v)
@@ -1294,9 +1294,3 @@ func buildPtyAppFunc(v *Visor, host *pty.Host, dmsgPort uint16, sshAddr string) 
 		return nil
 	}
 }
-
-// Ensure the launcher package is referenced. The RegisterApp call
-// in initDmsgpty's body uses launcher.RegisterApp; this nolint hint
-// keeps tooling that scans for unused imports happy in case the
-// init path is conditionally compiled out somewhere.
-var _ = launcher.RegisterApp

--- a/pkg/visor/init_router.go
+++ b/pkg/visor/init_router.go
@@ -439,8 +439,10 @@ func initNodeHealth(ctx context.Context, v *Visor, log *logging.Logger) error {
 		WithField("rsn_count", len(rsnNodes)).
 		Info("Initializing node health tracker")
 
-	v.nodeHealthTracker = NewNodeHealthTracker(v.dmsgC, log)
-	v.nodeHealthTracker.Start(ctx, tpsNodes, rsnNodes)
+	v.nodeHealthTracker = NewNodeHealthTracker(v.dmsgC, log,
+		func() []cipher.PubKey { return v.conf.EffectiveTransportSetupPKs() },
+		func() []cipher.PubKey { return v.conf.EffectiveRouteSetupNodes() })
+	v.nodeHealthTracker.Start(ctx)
 
 	return nil
 }

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -451,7 +451,6 @@ func initSkywireForwardConn(ctx context.Context, v *Visor, log *logging.Logger) 
 	if v.tpM != nil {
 		appDirectMux := transport.NewVStreamMux(v.tpM, routing.AppDirectPacket, log)
 		v.tpM.SetAppDirectHandler(appDirectMux.HandlePacket)
-		v.appDirectMux = appDirectMux
 		wireDirectDialPolicyHook(v, appDirectMux)
 		if n, err := appnet.ResolveNetworker(appnet.TypeSkynet); err == nil {
 			if sn, ok := n.(*appnet.SkywireNetworker); ok {

--- a/pkg/visor/init_transport.go
+++ b/pkg/visor/init_transport.go
@@ -957,7 +957,6 @@ func initPublicVisor(_ context.Context, v *Visor, log *logging.Logger) error { /
 func initEnsureVisorIsTransportable(ctx context.Context, v *Visor, log *logging.Logger) error {
 	const tickDuration = 5 * time.Minute
 	ticker := time.NewTicker(tickDuration)
-	_ = ctx // unused after removing AR check
 
 	// Perform transportability check logic - only DMSG is required
 	performCheck := func(tries int) int {

--- a/pkg/visor/logserver/api.go
+++ b/pkg/visor/logserver/api.go
@@ -144,12 +144,11 @@ func ptyPKAllowed(wl pty.Whitelist, remoteHost string) bool {
 
 // New creates a new API.
 //
-// The unused string parameter (formerly the per-day transport-log CSV
-// directory) is preserved for call-site compatibility — historical
-// bandwidth is now served from the bbolt stats store via
-// /stats/transports/history, and the /transport_logs/:file route has
-// been removed along with the on-disk CSV log store.
-func New(log *logging.Logger, _, localPath, _ string, whitelistedPKs []cipher.PubKey, survey *visorconfig.Survey, printLog bool) *API {
+// The trailing unused string parameter is legacy: historical bandwidth is
+// now served from the bbolt stats store via /stats/transports/history, and
+// the on-disk CSV transport-log store (with its /transport_logs/:file route)
+// has been removed.
+func New(log *logging.Logger, localPath, _ string, whitelistedPKs []cipher.PubKey, survey *visorconfig.Survey, printLog bool) *API {
 	api := &API{
 		logger:    log,
 		startedAt: time.Now(),

--- a/pkg/visor/node_health.go
+++ b/pkg/visor/node_health.go
@@ -15,6 +15,13 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 )
 
+// cacheTTL bounds how long a computed health snapshot is served before the
+// next on-demand request triggers a recompute.
+const cacheTTL = 60 * time.Second
+
+// nodeCheckTimeout bounds a single per-node discovery + dial + health-check.
+const nodeCheckTimeout = 10 * time.Second
+
 // NodeHealth represents the health status of a setup node.
 type NodeHealth struct {
 	PK          cipher.PubKey `json:"pk"`
@@ -24,174 +31,186 @@ type NodeHealth struct {
 	Latency     time.Duration `json:"latency_ms"`
 }
 
-// NodeHealthTracker tracks health status of TPS and RSN nodes.
+// NodeHealthTracker computes health status of TPS and RSN nodes on demand,
+// behind a short TTL cache. It re-seeds its node set from the supplied
+// providers on every recompute so runtime config_refresh changes are picked
+// up. Results feed the api_tps UI panel RPCs only; the real transport/route
+// dial path does not depend on this.
 type NodeHealthTracker struct {
 	dmsgC *dmsg.Client
 	log   *logging.Logger
 
+	// tpsProvider / rsnProvider return the current effective node sets. They
+	// are read fresh on every recompute so config changes take effect without
+	// a restart.
+	tpsProvider func() []cipher.PubKey
+	rsnProvider func() []cipher.PubKey
+
+	baseCtx context.Context
+
+	mu        sync.RWMutex
 	tpsHealth map[cipher.PubKey]*NodeHealth
 	rsnHealth map[cipher.PubKey]*NodeHealth
-	mu        sync.RWMutex
+	lastCheck time.Time
 
-	checkInterval time.Duration
+	// refreshMu serializes recompute so concurrent RPCs don't stampede the
+	// per-node dials (singleflight-style: one recompute at a time).
+	refreshMu sync.Mutex
+
+	// checkFn performs a single per-node check. It defaults to checkNode and
+	// is overridable in tests to avoid real dmsg dials.
+	checkFn func(ctx context.Context, pk cipher.PubKey, port uint16, kind string) *NodeHealth
 }
 
-// NewNodeHealthTracker creates a new health tracker.
-func NewNodeHealthTracker(dmsgC *dmsg.Client, log *logging.Logger) *NodeHealthTracker {
-	return &NodeHealthTracker{
-		dmsgC:         dmsgC,
-		log:           log,
-		tpsHealth:     make(map[cipher.PubKey]*NodeHealth),
-		rsnHealth:     make(map[cipher.PubKey]*NodeHealth),
-		checkInterval: 1 * time.Hour,
+// NewNodeHealthTracker creates a new on-demand health tracker. The providers
+// are invoked on every recompute to (re)seed the node set.
+func NewNodeHealthTracker(dmsgC *dmsg.Client, log *logging.Logger, tpsProvider, rsnProvider func() []cipher.PubKey) *NodeHealthTracker {
+	nht := &NodeHealthTracker{
+		dmsgC:       dmsgC,
+		log:         log,
+		tpsProvider: tpsProvider,
+		rsnProvider: rsnProvider,
+		baseCtx:     context.Background(),
+		tpsHealth:   make(map[cipher.PubKey]*NodeHealth),
+		rsnHealth:   make(map[cipher.PubKey]*NodeHealth),
 	}
+	nht.checkFn = nht.checkNode
+	return nht
 }
 
-// Start begins periodic health checking of configured nodes.
-func (nht *NodeHealthTracker) Start(ctx context.Context, tpsNodes, rsnNodes []cipher.PubKey) {
-	// Initialize health entries
+// Start records the base context used for on-demand checks. It no longer runs
+// a background ticker — health is computed lazily when an api_tps RPC asks for
+// it (see ensureFresh). Kept for lifecycle symmetry.
+func (nht *NodeHealthTracker) Start(ctx context.Context) {
+	if ctx != nil {
+		nht.baseCtx = ctx
+	}
+	nht.log.Debug("Node health tracker ready (on-demand)")
+}
+
+// ensureFresh recomputes health if the cached snapshot is older than cacheTTL.
+// A single recompute runs at a time; concurrent callers block on refreshMu and
+// re-check freshness after acquiring it, so they return the just-computed data
+// without launching a second storm of dials.
+func (nht *NodeHealthTracker) ensureFresh() {
+	nht.mu.RLock()
+	fresh := !nht.lastCheck.IsZero() && time.Since(nht.lastCheck) < cacheTTL
+	nht.mu.RUnlock()
+	if fresh {
+		return
+	}
+
+	nht.refreshMu.Lock()
+	defer nht.refreshMu.Unlock()
+
+	// Re-check: another goroutine may have recomputed while we waited.
+	nht.mu.RLock()
+	fresh = !nht.lastCheck.IsZero() && time.Since(nht.lastCheck) < cacheTTL
+	nht.mu.RUnlock()
+	if fresh {
+		return
+	}
+
+	nht.recompute()
+}
+
+// recompute re-seeds the node set from the providers and checks every node
+// concurrently, then swaps in the fresh snapshot.
+func (nht *NodeHealthTracker) recompute() {
+	ctx := nht.baseCtx
+
+	var tpsPKs, rsnPKs []cipher.PubKey
+	if nht.tpsProvider != nil {
+		tpsPKs = nht.tpsProvider()
+	}
+	if nht.rsnProvider != nil {
+		rsnPKs = nht.rsnProvider()
+	}
+
+	tpsResults := make([]*NodeHealth, len(tpsPKs))
+	rsnResults := make([]*NodeHealth, len(rsnPKs))
+
+	var wg sync.WaitGroup
+	for i, pk := range tpsPKs {
+		wg.Add(1)
+		go func(i int, pk cipher.PubKey) {
+			defer wg.Done()
+			tpsResults[i] = nht.checkFn(ctx, pk, skyenv.DmsgTransportSetupServicePort, "TPS")
+		}(i, pk)
+	}
+	for i, pk := range rsnPKs {
+		wg.Add(1)
+		go func(i int, pk cipher.PubKey) {
+			defer wg.Done()
+			rsnResults[i] = nht.checkFn(ctx, pk, skyenv.DmsgSetupPort, "RSN")
+		}(i, pk)
+	}
+	wg.Wait()
+
+	tpsMap := make(map[cipher.PubKey]*NodeHealth, len(tpsResults))
+	tpsHealthy := 0
+	for _, h := range tpsResults {
+		tpsMap[h.PK] = h
+		if h.Healthy {
+			tpsHealthy++
+		}
+	}
+	rsnMap := make(map[cipher.PubKey]*NodeHealth, len(rsnResults))
+	rsnHealthy := 0
+	for _, h := range rsnResults {
+		rsnMap[h.PK] = h
+		if h.Healthy {
+			rsnHealthy++
+		}
+	}
+
 	nht.mu.Lock()
-	for _, pk := range tpsNodes {
-		nht.tpsHealth[pk] = &NodeHealth{PK: pk}
-	}
-	for _, pk := range rsnNodes {
-		nht.rsnHealth[pk] = &NodeHealth{PK: pk}
-	}
+	nht.tpsHealth = tpsMap
+	nht.rsnHealth = rsnMap
+	nht.lastCheck = time.Now()
 	nht.mu.Unlock()
 
-	// Initial check after short delay
-	go func() {
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(10 * time.Second):
-		}
-		nht.checkAllNodes(ctx)
-	}()
-
-	// Periodic checks
-	go func() {
-		ticker := time.NewTicker(nht.checkInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				nht.checkAllNodes(ctx)
-			}
-		}
-	}()
-
-	nht.log.Info("Node health tracking started")
-}
-
-// checkAllNodes performs health checks on all configured nodes.
-func (nht *NodeHealthTracker) checkAllNodes(ctx context.Context) {
-	nht.log.Debug("Starting periodic health check of setup nodes")
-
-	nht.mu.RLock()
-	tpsPKs := make([]cipher.PubKey, 0, len(nht.tpsHealth))
-	for pk := range nht.tpsHealth {
-		tpsPKs = append(tpsPKs, pk)
-	}
-	rsnPKs := make([]cipher.PubKey, 0, len(nht.rsnHealth))
-	for pk := range nht.rsnHealth {
-		rsnPKs = append(rsnPKs, pk)
-	}
-	nht.mu.RUnlock()
-
-	// Check TPS nodes
-	tpsHealthyCount := 0
-	for _, pk := range tpsPKs {
-		if ctx.Err() != nil {
-			return
-		}
-		nht.checkTPSHealth(ctx, pk)
-	}
-
-	// Count healthy TPS nodes
-	nht.mu.RLock()
-	for _, h := range nht.tpsHealth {
-		if h.Healthy {
-			tpsHealthyCount++
-		}
-	}
-	nht.mu.RUnlock()
-
-	if len(tpsPKs) > 0 && tpsHealthyCount == 0 {
+	if len(tpsPKs) > 0 && tpsHealthy == 0 {
 		nht.log.Error("No transport setup nodes are responding")
 	}
-
-	// Check RSN nodes
-	rsnHealthyCount := 0
-	for _, pk := range rsnPKs {
-		if ctx.Err() != nil {
-			return
-		}
-		nht.checkRSNHealth(ctx, pk)
-	}
-
-	// Count healthy RSN nodes
-	nht.mu.RLock()
-	for _, h := range nht.rsnHealth {
-		if h.Healthy {
-			rsnHealthyCount++
-		}
-	}
-	nht.mu.RUnlock()
-
-	if len(rsnPKs) > 0 && rsnHealthyCount == 0 {
+	if len(rsnPKs) > 0 && rsnHealthy == 0 {
 		nht.log.Error("No route setup nodes are responding")
 	}
-
-	nht.log.Debug("Completed periodic health check of setup nodes")
 }
 
-// checkTPSHealth checks the health of a single TPS node.
-func (nht *NodeHealthTracker) checkTPSHealth(ctx context.Context, pk cipher.PubKey) {
+// checkNode performs a discovery lookup + dmsg dial + HealthCheck RPC against a
+// single setup node and returns its health. kind is "TPS" or "RSN" (for logs).
+func (nht *NodeHealthTracker) checkNode(ctx context.Context, pk cipher.PubKey, port uint16, kind string) *NodeHealth {
 	start := time.Now()
-	err := nht.doTPSHealthCheck(ctx, pk)
+	err := nht.doHealthCheck(ctx, pk, port)
 	latency := time.Since(start)
 
-	nht.mu.Lock()
-	defer nht.mu.Unlock()
-
-	health, ok := nht.tpsHealth[pk]
-	if !ok {
-		health = &NodeHealth{PK: pk}
-		nht.tpsHealth[pk] = health
-	}
-
-	health.LastChecked = time.Now()
-	health.Latency = latency
-
+	h := &NodeHealth{PK: pk, LastChecked: time.Now(), Latency: latency}
 	if err != nil {
-		health.Healthy = false
-		health.LastError = err.Error()
-		nht.log.WithField("pk", pk.String()).WithError(err).Warn("TPS health check failed")
+		h.Healthy = false
+		h.LastError = err.Error()
+		nht.log.WithField("pk", pk.String()).WithError(err).Warnf("%s health check failed", kind)
 	} else {
-		health.Healthy = true
-		health.LastError = ""
-		nht.log.WithField("pk", pk.String()).WithField("latency", latency).Debug("TPS health check passed")
+		h.Healthy = true
+		nht.log.WithField("pk", pk.String()).WithField("latency", latency).Debugf("%s health check passed", kind)
 	}
+	return h
 }
 
-// doTPSHealthCheck performs the actual TPS health check via dmsg.
-func (nht *NodeHealthTracker) doTPSHealthCheck(ctx context.Context, pk cipher.PubKey) error {
+// doHealthCheck performs the actual health check via dmsg against the given port.
+func (nht *NodeHealthTracker) doHealthCheck(ctx context.Context, pk cipher.PubKey, port uint16) error {
 	// Quick discovery lookup before dialing — if the PK isn't registered
 	// as a client in dmsg-discovery, there's no point dialing (it would
 	// fall back to dialViaConnectedServers and burn port reservations
-	// for 15s across all 6 servers for nothing).
+	// across all servers for the full timeout for nothing).
 	if _, err := nht.dmsgC.DiscEntry(ctx, pk); err != nil {
 		return fmt.Errorf("not in dmsg discovery: %w", err)
 	}
 
-	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	checkCtx, cancel := context.WithTimeout(ctx, nodeCheckTimeout)
 	defer cancel()
 
-	conn, err := nht.dmsgC.Dial(checkCtx, dmsg.Addr{PK: pk, Port: skyenv.DmsgTransportSetupServicePort})
+	conn, err := nht.dmsgC.Dial(checkCtx, dmsg.Addr{PK: pk, Port: port})
 	if err != nil {
 		return fmt.Errorf("dmsg dial failed: %w", err)
 	}
@@ -212,68 +231,10 @@ func (nht *NodeHealthTracker) doTPSHealthCheck(ctx context.Context, pk cipher.Pu
 	return nil
 }
 
-// checkRSNHealth checks the health of a single RSN node.
-func (nht *NodeHealthTracker) checkRSNHealth(ctx context.Context, pk cipher.PubKey) {
-	start := time.Now()
-	err := nht.doRSNHealthCheck(ctx, pk)
-	latency := time.Since(start)
-
-	nht.mu.Lock()
-	defer nht.mu.Unlock()
-
-	health, ok := nht.rsnHealth[pk]
-	if !ok {
-		health = &NodeHealth{PK: pk}
-		nht.rsnHealth[pk] = health
-	}
-
-	health.LastChecked = time.Now()
-	health.Latency = latency
-
-	if err != nil {
-		health.Healthy = false
-		health.LastError = err.Error()
-		nht.log.WithField("pk", pk.String()).WithError(err).Warn("RSN health check failed")
-	} else {
-		health.Healthy = true
-		health.LastError = ""
-		nht.log.WithField("pk", pk.String()).WithField("latency", latency).Debug("RSN health check passed")
-	}
-}
-
-// doRSNHealthCheck performs the actual RSN health check via dmsg.
-func (nht *NodeHealthTracker) doRSNHealthCheck(ctx context.Context, pk cipher.PubKey) error {
-	if _, err := nht.dmsgC.DiscEntry(ctx, pk); err != nil {
-		return fmt.Errorf("not in dmsg discovery: %w", err)
-	}
-
-	checkCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-
-	conn, err := nht.dmsgC.Dial(checkCtx, dmsg.Addr{PK: pk, Port: skyenv.DmsgSetupPort})
-	if err != nil {
-		return fmt.Errorf("dmsg dial failed: %w", err)
-	}
-	defer conn.Close() //nolint:errcheck,gosec
-
-	client := rpc.NewClient(conn)
-	defer client.Close() //nolint:errcheck,gosec
-
-	// RSN uses the same health check pattern
-	var reply RSNHealthCheckReply
-	if err := client.Call("SetupRPCGateway.HealthCheck", &RSNHealthCheckArgs{}, &reply); err != nil {
-		return fmt.Errorf("health check RPC failed: %w", err)
-	}
-
-	if reply.Status != "OK" {
-		return fmt.Errorf("unhealthy status: %s", reply.Status)
-	}
-
-	return nil
-}
-
 // GetTPSNodesSorted returns TPS nodes sorted by health (healthy first, then by latency).
 func (nht *NodeHealthTracker) GetTPSNodesSorted() []cipher.PubKey {
+	nht.ensureFresh()
+
 	nht.mu.RLock()
 	defer nht.mu.RUnlock()
 
@@ -300,6 +261,8 @@ func (nht *NodeHealthTracker) GetTPSNodesSorted() []cipher.PubKey {
 
 // GetRSNNodesSorted returns RSN nodes sorted by health (healthy first, then by latency).
 func (nht *NodeHealthTracker) GetRSNNodesSorted() []cipher.PubKey {
+	nht.ensureFresh()
+
 	nht.mu.RLock()
 	defer nht.mu.RUnlock()
 
@@ -326,6 +289,8 @@ func (nht *NodeHealthTracker) GetRSNNodesSorted() []cipher.PubKey {
 
 // GetTPSHealth returns health status for all TPS nodes.
 func (nht *NodeHealthTracker) GetTPSHealth() []NodeHealth {
+	nht.ensureFresh()
+
 	nht.mu.RLock()
 	defer nht.mu.RUnlock()
 
@@ -338,6 +303,8 @@ func (nht *NodeHealthTracker) GetTPSHealth() []NodeHealth {
 
 // GetRSNHealth returns health status for all RSN nodes.
 func (nht *NodeHealthTracker) GetRSNHealth() []NodeHealth {
+	nht.ensureFresh()
+
 	nht.mu.RLock()
 	defer nht.mu.RUnlock()
 
@@ -346,34 +313,4 @@ func (nht *NodeHealthTracker) GetRSNHealth() []NodeHealth {
 		result = append(result, *h)
 	}
 	return result
-}
-
-// IsTPSHealthy returns whether a specific TPS node is healthy.
-func (nht *NodeHealthTracker) IsTPSHealthy(pk cipher.PubKey) bool {
-	nht.mu.RLock()
-	defer nht.mu.RUnlock()
-
-	if h, ok := nht.tpsHealth[pk]; ok {
-		return h.Healthy
-	}
-	return false
-}
-
-// IsRSNHealthy returns whether a specific RSN node is healthy.
-func (nht *NodeHealthTracker) IsRSNHealthy(pk cipher.PubKey) bool {
-	nht.mu.RLock()
-	defer nht.mu.RUnlock()
-
-	if h, ok := nht.rsnHealth[pk]; ok {
-		return h.Healthy
-	}
-	return false
-}
-
-// RSNHealthCheckArgs is input for RSN health check.
-type RSNHealthCheckArgs struct{}
-
-// RSNHealthCheckReply is output from RSN health check.
-type RSNHealthCheckReply struct {
-	Status string
 }

--- a/pkg/visor/node_health_test.go
+++ b/pkg/visor/node_health_test.go
@@ -1,0 +1,100 @@
+// Package visor pkg/visor/node_health_test.go c3-vis-core
+package visor
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/skycoin/skywire/pkg/cipher"
+	"github.com/skycoin/skywire/pkg/logging"
+)
+
+// newTestTracker builds a tracker with a stubbed per-node check so no real
+// dmsg dials occur. checks counts how many times the stub ran.
+func newTestTracker(tps, rsn func() []cipher.PubKey, checks *int32) *NodeHealthTracker {
+	nht := NewNodeHealthTracker(nil, logging.MustGetLogger("node_health_test"), tps, rsn)
+	nht.checkFn = func(_ context.Context, pk cipher.PubKey, _ uint16, _ string) *NodeHealth {
+		atomic.AddInt32(checks, 1)
+		return &NodeHealth{PK: pk, Healthy: true, LastChecked: time.Now()}
+	}
+	return nht
+}
+
+// TestNodeHealthTracker_CacheHit verifies a second call within the TTL is
+// served from cache without recomputing (the stub check is not re-invoked).
+func TestNodeHealthTracker_CacheHit(t *testing.T) {
+	pk, _ := cipher.GenerateKeyPair()
+	var checks int32
+	nht := newTestTracker(
+		func() []cipher.PubKey { return []cipher.PubKey{pk} },
+		func() []cipher.PubKey { return nil },
+		&checks,
+	)
+
+	// First call computes.
+	if got := nht.GetTPSHealth(); len(got) != 1 {
+		t.Fatalf("first GetTPSHealth: got %d entries, want 1", len(got))
+	}
+	if c := atomic.LoadInt32(&checks); c != 1 {
+		t.Fatalf("after first call: checks=%d, want 1", c)
+	}
+
+	// Second call within TTL must hit cache — no additional check.
+	if got := nht.GetTPSHealth(); len(got) != 1 {
+		t.Fatalf("second GetTPSHealth: got %d entries, want 1", len(got))
+	}
+	if c := atomic.LoadInt32(&checks); c != 1 {
+		t.Fatalf("after cache-hit call: checks=%d, want 1 (recompute stampede)", c)
+	}
+}
+
+// TestNodeHealthTracker_ReseedOnStale verifies that once the cache is stale the
+// node set is re-seeded from the providers, so runtime config changes are
+// picked up without a restart.
+func TestNodeHealthTracker_ReseedOnStale(t *testing.T) {
+	pk1, _ := cipher.GenerateKeyPair()
+	pk2, _ := cipher.GenerateKeyPair()
+
+	current := []cipher.PubKey{pk1}
+	var checks int32
+	nht := newTestTracker(
+		func() []cipher.PubKey { return current },
+		func() []cipher.PubKey { return nil },
+		&checks,
+	)
+
+	got := nht.GetTPSNodesSorted()
+	if len(got) != 1 || got[0] != pk1 {
+		t.Fatalf("initial sorted set = %v, want [%s]", got, pk1)
+	}
+
+	// Change the effective node set and force the cache stale.
+	current = []cipher.PubKey{pk2}
+	nht.mu.Lock()
+	nht.lastCheck = time.Now().Add(-2 * cacheTTL)
+	nht.mu.Unlock()
+
+	got = nht.GetTPSNodesSorted()
+	if len(got) != 1 || got[0] != pk2 {
+		t.Fatalf("re-seeded sorted set = %v, want [%s]", got, pk2)
+	}
+}
+
+// TestNodeHealthTracker_EmptyNoPanic verifies recompute with empty providers
+// produces empty results without touching the (nil) dmsg client.
+func TestNodeHealthTracker_EmptyNoPanic(t *testing.T) {
+	var checks int32
+	nht := newTestTracker(
+		func() []cipher.PubKey { return nil },
+		func() []cipher.PubKey { return nil },
+		&checks,
+	)
+	if got := nht.GetRSNHealth(); len(got) != 0 {
+		t.Fatalf("GetRSNHealth with no nodes: got %d, want 0", len(got))
+	}
+	if c := atomic.LoadInt32(&checks); c != 0 {
+		t.Fatalf("checks=%d, want 0 (no nodes to check)", c)
+	}
+}

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -170,14 +170,6 @@ func (proxyDefaultAPI) DmsgPtyExec(_ DmsgPtyExecArgs) (*pty.CommandExecResult, e
 	return nil, ErrProxyNotSupported
 }
 
-func (proxyDefaultAPI) GetLogRotationInterval() (visorconfig.Duration, error) {
-	return 0, ErrProxyNotSupported
-}
-
-func (proxyDefaultAPI) SetLogRotationInterval(_ visorconfig.Duration) error {
-	return ErrProxyNotSupported
-}
-
 func (proxyDefaultAPI) IsDMSGClientReady() (bool, error) {
 	return false, ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/skycoin/skywire/pkg/skyenv"
 	"github.com/skycoin/skywire/pkg/transport"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 var (
@@ -1089,19 +1088,6 @@ func (rc *rpcClient) GetTransportLogs(days int) ([]TransportLogEntry, error) {
 	var entries []TransportLogEntry
 	err := rc.Call("GetTransportLogs", &days, &entries)
 	return entries, err
-}
-
-// SetLogRotationInterval sets the log_rotation_interval from visor config
-func (rc *rpcClient) SetLogRotationInterval(d visorconfig.Duration) error {
-	err := rc.Call("SetLogRotationInterval", &d, &struct{}{})
-	return err
-}
-
-// GetLogRotationInterval gets the log_rotation_interval from visor config
-func (rc *rpcClient) GetLogRotationInterval() (visorconfig.Duration, error) {
-	var d visorconfig.Duration
-	err := rc.Call("GetLogRotationInterval", &struct{}{}, &d)
-	return d, err
 }
 
 // StatusMessage defines a status of visor update.

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -31,7 +31,6 @@ import (
 	types "github.com/skycoin/skywire/pkg/transport/types"
 	"github.com/skycoin/skywire/pkg/util/cipherutil"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
-	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
 // MockRPCClient mocks API.
@@ -973,17 +972,6 @@ func (mc *mockRPCClient) GetPersistentTransports() ([]transport.PersistentTransp
 // GetTransportLogs implements API
 func (mc *mockRPCClient) GetTransportLogs(_ int) ([]TransportLogEntry, error) {
 	return []TransportLogEntry{}, nil
-}
-
-// SetLogRotationInterval implements API
-func (mc *mockRPCClient) SetLogRotationInterval(_ visorconfig.Duration) error {
-	return nil
-}
-
-// GetLogRotationInterval implements API
-func (mc *mockRPCClient) GetLogRotationInterval() (visorconfig.Duration, error) {
-	var d visorconfig.Duration
-	return d, nil
 }
 
 // VPNServers implements API

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -304,13 +304,6 @@ type Visor struct {
 	// Shared VStreamMux for skynet forwarding (route ID 0).
 	// Used by both the forwarding server (Accept) and the skynetweb dialer (Dial).
 	skynetFwdMux *transport.VStreamMux
-	// VStreamMux for direct skywire-network app dials (route ID 0,
-	// AppDirectPacket type). Lets skysocks-client / vpn-client and
-	// any other skywire-network apps reach their server-side
-	// counterparts over an existing direct transport without going
-	// through the setup-node-mediated route group machinery. Falls
-	// back to router.DialRoutes when no direct transport exists.
-	appDirectMux *transport.VStreamMux
 	// Shared VStreamMux for visor RPC over transport (VisorRPCPacket,
 	// route ID 0). Used by BOTH the TransportRPCServer's Accept loop
 	// AND by TransportRPCCall's outbound dial. Sharing one mux per


### PR DESCRIPTION
Follow-up to the visor init/behavior audit.

## node_health → lazy on-demand (was an hourly dead-dial storm)
The setup-node health tracker ran a background loop — boot+10s then a fixed 1-hour ticker — that dialed **every** configured transport/route setup node sequentially with a 15s timeout. Because these are on-demand services, offline nodes hold stale discovery entries, so "1 online / 10 configured" meant ~135s of dead-dialing every hour. Two defects: its output feeds **only** a UI panel (not the real transport/route dial path), and it seeded the node set **once** so `config_refresh`'s runtime changes were ignored (removed nodes dialed forever, added ones never checked).

Now: no background loop. Health is computed **on demand** when an `api_tps` RPC asks, behind a 60s TTL cache with a singleflight `refreshMu` so concurrent RPCs don't stampede. Each recompute **re-seeds** from `EffectiveTransportSetupPKs()`/`EffectiveRouteSetupNodes()` (fixes the stale-set bug) and checks nodes **concurrently** (10s each). Return shape unchanged, so RPC/CLI/UI consumers are unaffected. Added network-free unit tests (cache-hit, re-seed-on-stale, empty-set).

## Remove the dead LogStore.RotationInterval RPC/HTTP surface
The CSV log store was retired, so `LogStore.RotationInterval` is a no-op — but its `Get/SetLogRotationInterval` RPC + `/log/rotation` HTTP endpoints were still fully plumbed and consumed by nothing. Removed the RPC interface methods, Visor methods, client + mock + proxy, and both HTTP routes/handlers. Kept the config field + `DefaultLogRotationInterval` (config schema unchanged). (The orphaned `V1.Get/UpdateLogRotationInterval` config helpers are left as an optional later cleanup.)

## Init cruft (each grep-verified unused)
- `Visor.appDirectMux` write-only field + its sole assignment (distinct from the live `appnet` field of the same name).
- The discarded `LogStore.Location` argument threaded into `logserver.New` (now `_`).
- Dead commented-out `visorConfig`/`initVisorConfig` lines.
- The `var _ = launcher.RegisterApp` keep-import hack (the import is genuinely used).
- A `_ = ctx` silencer on a function parameter.
- Unused `IsTPSHealthy`/`IsRSNHealthy` + the now-dead `RSNHealthCheckArgs/Reply` types.

Did NOT touch the uptime-tracker or the reward/TPD-heartbeat path (handled separately). Verified: `go build .`, `go vet ./pkg/visor/...`, `go test ./pkg/visor/...` all pass.