### PR TITLE
feat(wasm-visor): dmsg self-recovery via ForceReconnect (signal-driven, no self-dial)

### DIFF
--- a/cmd/wasm-visor/main.go
+++ b/cmd/wasm-visor/main.go
@@ -597,6 +597,11 @@ func bootEdge(skHex, seedPKHex, seedWSURL, discDmsgAddr, cfgOverrideJSON string)
 		}
 	}()
 
+	// dmsg self-recovery: watch session health and force a reconnect if the tab
+	// wedges with no connected servers (see recovery_js.go). Signal-driven only —
+	// no periodic self-dial (that would scale fleet traffic with tab count).
+	go startRecoverySupervisor(ctx)
+
 	// 4. in-process app server (RunModeInternal). The browser-adapted
 	// appserver.NewProcManager no longer net.Listen("tcp")s under TinyGo (a
 	// browser can't); in-process apps connect over net.Pipe. addr "" → no TCP

--- a/cmd/wasm-visor/recovery_js.go
+++ b/cmd/wasm-visor/recovery_js.go
@@ -1,0 +1,133 @@
+//go:build js && wasm
+
+// Package main cmd/wasm-visor/recovery_js.go c3-vis-wasm
+// dmsg self-recovery for the browser wasm-visor, mirroring the native visor's
+// pkg/visor/init_selfprobe.go recovery action (dmsgC.ForceReconnect on
+// persistent failure) without its self-DIAL probe. A browser tab whose dmsg
+// sessions die or wedge otherwise has no recovery short of a manual reload.
+//
+// DESIGN — signal-driven, NOT periodic self-dial. The native visor dials its
+// OWN dmsg listeners each interval to detect an inbound wedge; doing that from
+// every browser tab would add fleet traffic that scales with tab count, so
+// inbound-wedge detection via self-dial is intentionally out of scope here for
+// bandwidth reasons. Instead we (a) watch for the local session count dropping
+// to zero (a cheap ConnectedServers() read, no network) and (b) let the loops
+// that already send over dmsg (uptime heartbeat, telemetry announce) feed their
+// pass/fail into reportDmsgSuccess/reportDmsgFailure. Either path, once it
+// persists past its threshold and the cooldown has elapsed, triggers a single
+// dmsgC.ForceReconnect() — closing all sessions and nudging a discovery-entry
+// refresh so the reconnect loop re-dials.
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	// recoveryCheckInterval is how often the supervisor samples session health.
+	recoveryCheckInterval = 60 * time.Second
+	// recoveryNoSessionGrace is how long the tab may sit with zero connected
+	// dmsg servers before a force-reconnect is warranted. Kept generous so a
+	// normal reconnect (which the dmsg client already retries on its own) has
+	// time to complete before we intervene.
+	recoveryNoSessionGrace = 2 * time.Minute
+	// recoveryFailThreshold is the number of consecutive failure reports from a
+	// dmsg-using loop that will trigger a force-reconnect. Kept >1 so a single
+	// transient send failure doesn't churn sessions.
+	recoveryFailThreshold = 2
+	// recoveryCooldown is the minimum wait between two recovery reconnects.
+	// Prevents thrashing when the root cause is server-side and reconnecting
+	// won't help — we only try once per cooldown.
+	recoveryCooldown = 5 * time.Minute
+)
+
+var (
+	recoveryMu             sync.Mutex
+	lastForceReconnect     time.Time
+	firstUnhealthyAt       time.Time
+	consecutiveFailReports int
+)
+
+// startRecoverySupervisor runs a background loop that samples dmsg session
+// health every recoveryCheckInterval and forces a reconnect if the tab has had
+// zero connected dmsg servers for longer than recoveryNoSessionGrace (subject
+// to cooldown). Runs until ctx is done.
+func startRecoverySupervisor(ctx context.Context) {
+	t := time.NewTicker(recoveryCheckInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			recoveryCheckTick()
+		}
+	}
+}
+
+// recoveryCheckTick performs one health sample. Zero connected servers for
+// longer than the grace window (and past cooldown) triggers a reconnect; any
+// connected server resets the unhealthy timer.
+func recoveryCheckTick() {
+	recoveryMu.Lock()
+	defer recoveryMu.Unlock()
+
+	if dmsgC == nil {
+		return
+	}
+	now := time.Now()
+	healthy := len(dmsgC.ConnectedServers()) > 0
+	if healthy {
+		firstUnhealthyAt = time.Time{}
+		return
+	}
+	if firstUnhealthyAt.IsZero() {
+		firstUnhealthyAt = now
+		return
+	}
+	if now.Sub(firstUnhealthyAt) >= recoveryNoSessionGrace &&
+		now.Sub(lastForceReconnect) >= recoveryCooldown {
+		forceDmsgReconnect("no connected dmsg servers")
+	}
+}
+
+// reportDmsgFailure is called by dmsg-using loops (uptime heartbeat, telemetry
+// announce) when a send fails. After recoveryFailThreshold consecutive
+// failures — and past cooldown — it forces a reconnect.
+func reportDmsgFailure(reason string) {
+	recoveryMu.Lock()
+	defer recoveryMu.Unlock()
+	consecutiveFailReports++
+	if consecutiveFailReports >= recoveryFailThreshold &&
+		time.Since(lastForceReconnect) >= recoveryCooldown {
+		forceDmsgReconnect(reason)
+	}
+}
+
+// reportDmsgSuccess is called by dmsg-using loops on a successful send; it
+// clears the consecutive-failure counter.
+func reportDmsgSuccess() {
+	recoveryMu.Lock()
+	defer recoveryMu.Unlock()
+	consecutiveFailReports = 0
+}
+
+// forceDmsgReconnect tears down and re-dials all dmsg sessions if the cooldown
+// has elapsed. The caller MUST hold recoveryMu. No-op inside cooldown; on
+// action it stamps lastForceReconnect and resets the failure counters.
+func forceDmsgReconnect(reason string) {
+	now := time.Now()
+	if now.Sub(lastForceReconnect) < recoveryCooldown {
+		return
+	}
+	lastForceReconnect = now
+	firstUnhealthyAt = time.Time{}
+	consecutiveFailReports = 0
+	if dmsgC != nil {
+		n := dmsgC.ForceReconnect()
+		vlog(fmt.Sprintf("wasm self-recovery: forced dmsg reconnect (reason=%s, closed %d sessions)", reason, n))
+	}
+}

--- a/cmd/wasm-visor/telemetry_js.go
+++ b/cmd/wasm-visor/telemetry_js.go
@@ -131,7 +131,13 @@ func telemetryAnnounceLoop(tpdPK cipher.PubKey) {
 		// half-dead transport); cap it so a stuck dial can't starve the next tick.
 		dctx, cancel := context.WithTimeout(ctx, telemetryAnnounceInterval/2)
 		defer cancel()
-		_ = telemetryPub.AnnounceTo(dctx, tpdPK) //nolint:errcheck // transient during boot/dmsg churn; retried next tick
+		// Feed failures into self-recovery (weaker signal than the uptime
+		// heartbeat, so we only report failures here, not successes). A single
+		// announce miss is transient and retried next tick; recovery only acts
+		// after recoveryFailThreshold consecutive reports.
+		if err := telemetryPub.AnnounceTo(dctx, tpdPK); err != nil {
+			reportDmsgFailure("telemetry announce failed")
+		}
 	}
 	announce()
 	for {

--- a/cmd/wasm-visor/uptime_js.go
+++ b/cmd/wasm-visor/uptime_js.go
@@ -39,8 +39,10 @@ func startUptimeHeartbeat(ctx context.Context, u tpdclient.UptimeUpdater, log *l
 		defer cancel()
 		if err := u.UpdateUptime(c, buildinfo.Version()); err != nil {
 			log.WithError(err).Warn("uptime heartbeat failed")
+			reportDmsgFailure("uptime heartbeat failed")
 		} else {
 			log.Debug("uptime heartbeat sent")
+			reportDmsgSuccess()
 		}
 	}
 


### PR DESCRIPTION
The native visor has `init_selfprobe.go`: it dials its own dmsg listeners and calls `dmsgC.ForceReconnect()` on persistent failure. The browser wasm-visor had **no equivalent**, so a tab whose dmsg sessions die or silently wedge stays "registered but unreachable" until manually reloaded — wasting any route setups aimed at it.

This adds signal-driven recovery, reusing the same `*dmsg.Client.ForceReconnect()` the native visor uses.

## Design: signal-driven, NOT a periodic self-dial
A periodic self-dial from every browser tab would add fleet traffic that scales with tab count, so inbound-wedge detection via self-dial is intentionally out of scope. Instead:
- **`recovery_js.go`** (new): a supervisor that (a) every 60s reads the *local* `dmsgC.ConnectedServers()` (no network) and force-reconnects if it's been zero past a 2-min grace, and (b) accepts pass/fail reports from the loops that already send over dmsg. Either path force-reconnects once past its threshold and a 5-min cooldown — closing all sessions + nudging a discovery-entry refresh so the client re-dials. Constants mirror native (`selfProbeRecoveryThreshold=2`, `selfProbeRecoveryCooldown=5m`).
- **`uptime_js.go`** — heartbeat reports `reportDmsgFailure`/`reportDmsgSuccess`.
- **`telemetry_js.go`** — the previously-ignored `AnnounceTo` error now feeds `reportDmsgFailure`.
- **`main.go`** — starts the supervisor alongside the existing dmsg convergence goroutine.

## Note on the embedded blob
Source-only PR. The committed wasm blobs (`pkg/wasmhv/wasmbin/`) are regenerated separately (as intentional artifact updates) — this PR does not touch them, so the provenance test still passes; the regenerated blobs carrying this change follow.

Verified: `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor` and `go build .` pass.