### PR TITLE
fix(transport): dial-only networks log serve-unsupported at Debug, not ERROR (+guard Fatal)

### DIFF
--- a/pkg/transport/manager.go
+++ b/pkg/transport/manager.go
@@ -769,10 +769,21 @@ func (tm *Manager) runClient(ctx context.Context, netType types.Type) {
 	tm.Logger.Debugf("Serving %s network", client.Type())
 	err := client.Start()
 	if err != nil {
-		tm.Logger.WithError(err).Errorf("Failed to listen on %s network", client.Type())
+		if errors.Is(err, network.ErrServeDialOnly) {
+			// A dial-only build (browser/embedded WT) cannot serve by design —
+			// this is expected, not a failure. Log at Debug, not ERROR.
+			tm.Logger.WithError(err).Debugf("network %s is dial-only on this build (serving unsupported)", client.Type())
+		} else {
+			tm.Logger.WithError(err).Errorf("Failed to listen on %s network", client.Type())
+		}
 	}
 	lis, err := client.Listen(skyenv.TransportPort)
 	if err != nil {
+		if errors.Is(err, network.ErrServeDialOnly) {
+			// A dial-only client that also cannot Listen is expected, not fatal.
+			tm.Logger.WithError(err).Debugf("network %s is dial-only on this build (cannot listen)", client.Type())
+			return
+		}
 		tm.Logger.WithError(err).Fatalf("failed to listen on network '%s' of port '%d'",
 			client.Type(), skyenv.TransportPort)
 		return

--- a/pkg/transport/network/wt.go
+++ b/pkg/transport/network/wt.go
@@ -113,6 +113,13 @@ func newWT(generic *genericClient, table WTTable) Client {
 // ErrWTEntryNotFound is returned when the requested PK has no WT entry in the table.
 var ErrWTEntryNotFound = errors.New("wt: entry not found in table")
 
+// ErrServeDialOnly is the sentinel a network client's Start returns (wrapped)
+// when the build is dial-only and cannot serve (no listening socket). The
+// transport manager checks errors.Is(err, ErrServeDialOnly) to log this expected
+// condition at Debug rather than ERROR/Fatal — a browser/embedded WT client
+// dials peers but never accepts, which is by design, not a failure.
+var ErrServeDialOnly = errors.New("transport network is dial-only on this build (serving unsupported)")
+
 // Dial implements Client: resolve the peer's WT endpoint + cert hash, dial it
 // (build-tagged carrier: webtransport-go on native, the browser WebTransport API
 // on TinyGo/js), and wrap the resulting net.Conn in a skywire transport.

--- a/pkg/transport/network/wt_browser.go
+++ b/pkg/transport/network/wt_browser.go
@@ -17,7 +17,7 @@ package network
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -31,7 +31,7 @@ func wtDial(ctx context.Context, url, certHashHex string) (net.Conn, error) {
 // Start implements Client: a browser tab cannot run the HTTP/3 WebTransport
 // server a WT listener needs, so it fails closed (dial-only, like ws_browser).
 func (c *wtClient) Start() error {
-	return errors.New("wt: serving not supported in a browser (no HTTP/3 listener) — dial only")
+	return fmt.Errorf("wt: serving not supported in a browser (no HTTP/3 listener) — dial only: %w", ErrServeDialOnly)
 }
 
 // dialResolvedWT is a no-op in the browser: there is no address-resolver client

--- a/pkg/transport/network/wt_tinygo.go
+++ b/pkg/transport/network/wt_tinygo.go
@@ -12,6 +12,7 @@ package network
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 
 	"github.com/skycoin/skywire/pkg/cipher"
@@ -24,7 +25,9 @@ func (c *wtClient) dialResolvedWT(_ context.Context, _ cipher.PubKey) (net.Conn,
 }
 
 // errWTServe is returned by Start on TinyGo (no listening socket / no HTTP/3).
-var errWTServe = errors.New("wt: serving not supported on this build (TinyGo) — a browser/embedded target has no HTTP/3 listener")
+// It wraps ErrServeDialOnly so the transport manager logs the expected
+// dial-only condition at Debug rather than ERROR/Fatal.
+var errWTServe = fmt.Errorf("wt: serving not supported on this build (TinyGo) — a browser/embedded target has no HTTP/3 listener: %w", ErrServeDialOnly)
 
 // errWTDial is returned by the WT dial stub on non-browser TinyGo targets.
 var errWTDial = errors.New("wt: WebTransport dial not supported on this TinyGo target")


### PR DESCRIPTION
Surfaced by the wasm-vs-native log comparison: the wasm/TinyGo visor logs `ERROR [tp_manager]: Failed to listen on swtr network` on every boot, because WebTransport inbound serving is impossible in a browser (no HTTP/3 listener) — it's dial-only by design. The shared `manager.go` logged any `client.Start()` failure at ERROR.

- New exported sentinel `network.ErrServeDialOnly` (in the build-tag-free `wt.go`).
- `wt_browser.go` / `wt_tinygo.go` wrap it (keeping their readable text).
- `manager.go runClient`: `Start()` failures matching the sentinel log at **Debug** ("network swtr is dial-only on this build"); all others stay ERROR. The `Listen()` `Fatalf` right below is now guarded — a dial-only sentinel returns cleanly instead of crashing; genuine listen failures on real networks stay fatal.

Verified: `go build .`, `GOOS=js GOARCH=wasm go build ./cmd/wasm-visor`, `go vet ./pkg/transport/...` all pass. `types.WT == "swtr"` confirmed.

Follow-up (out of scope here): the WS transport has the identical dial-only pattern (`errWSServe` in `ws_tinygo.go`, unwrapped) and would emit the same spurious ERROR on a *TinyGo* browser boot — wrapping it with the same sentinel is a one-line follow-up.