### PR TITLE
fix(dmsgweb,skynetweb): cache SOCKS upstream dialer + cooldown backoff on unready upstream

### DIFF
--- a/pkg/dmsgweb/runtime.go
+++ b/pkg/dmsgweb/runtime.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/armon/go-socks5"
 	"github.com/chen3feng/safecast"
@@ -275,6 +276,13 @@ func normalize(cfg Config) Config {
 // panics if RemoteAddr() doesn't return *net.TCPAddr, so DMSG
 // streams are wrapped in tcpAddrConn.
 func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Client, cfg Config) error {
+	// Build the upstream SOCKS5 dialer ONCE and reuse it across requests
+	// (proxy.SOCKS5 returns a shareable proxy.Dialer). nil when no upstream
+	// is configured — those requests dial direct.
+	var upstream *upstreamForwarder
+	if cfg.UpstreamSOCKS != "" {
+		upstream = &upstreamForwarder{addr: cfg.UpstreamSOCKS}
+	}
 	conf := &socks5.Config{
 		// Route go-socks5's own [ERR] lines through logrus so they match the
 		// rest of the visor's log format instead of the library's raw stdout
@@ -417,15 +425,11 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 			}
 
 			// Not .dmsg — forward to upstream or direct.
-			if cfg.UpstreamSOCKS != "" {
+			if upstream != nil {
 				if origHost != "" {
 					addr = net.JoinHostPort(origHost, origPort)
 				}
-				upstream, err := proxy.SOCKS5("tcp", cfg.UpstreamSOCKS, nil, proxy.Direct)
-				if err != nil {
-					return nil, err
-				}
-				return upstream.Dial(network, addr)
+				return upstream.dial(network, addr)
 			}
 			return net.Dial(network, addr)
 		},
@@ -451,6 +455,59 @@ func serveSOCKS5Direct(ctx context.Context, log *logging.Logger, dmsgC *dmsg.Cli
 		return fmt.Errorf("SOCKS5 serve: %w", err)
 	}
 	return nil
+}
+
+// upstreamCooldown is how long forwarded dials fast-fail after a recent
+// upstream failure, so a burst of requests during the boot window (when the
+// upstream, e.g. skysocks-client on :1080, is not yet connected and refuses
+// the connection) doesn't each pay a full refused dial. Short by design —
+// the client retries.
+const upstreamCooldown = 500 * time.Millisecond
+
+// upstreamForwarder lazily builds and caches a SOCKS5 dialer to the upstream
+// proxy and reuses it across requests. proxy.SOCKS5 returns a proxy.Dialer
+// that is safe to share, so building it once — instead of per request —
+// avoids a wasteful allocation on every forwarded CONNECT. After a failed
+// dial it fast-fails subsequent requests for upstreamCooldown rather than
+// blocking or queueing them.
+type upstreamForwarder struct {
+	addr string
+
+	mu       sync.Mutex
+	dialer   proxy.Dialer
+	failedAt time.Time
+}
+
+// dial forwards through the cached upstream dialer, building it on first use.
+// It fast-fails during the cooldown window following a recent failure, and
+// records/clears the failure timestamp based on the dial outcome.
+func (f *upstreamForwarder) dial(network, addr string) (net.Conn, error) {
+	f.mu.Lock()
+	if !f.failedAt.IsZero() && time.Since(f.failedAt) < upstreamCooldown {
+		f.mu.Unlock()
+		return nil, fmt.Errorf("upstream SOCKS %s not ready (cooling down)", f.addr)
+	}
+	d := f.dialer
+	if d == nil {
+		nd, err := proxy.SOCKS5("tcp", f.addr, nil, proxy.Direct)
+		if err != nil {
+			f.mu.Unlock()
+			return nil, err
+		}
+		f.dialer = nd
+		d = nd
+	}
+	f.mu.Unlock()
+
+	conn, err := d.Dial(network, addr)
+	f.mu.Lock()
+	if err != nil {
+		f.failedAt = time.Now()
+	} else {
+		f.failedAt = time.Time{}
+	}
+	f.mu.Unlock()
+	return conn, err
 }
 
 // Context keys used by the SOCKS5 resolver ↔ Dial callback handshake.

--- a/pkg/skynetweb/runtime.go
+++ b/pkg/skynetweb/runtime.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sync"
+	"time"
 
 	"github.com/armon/go-socks5"
 	"github.com/sirupsen/logrus"
@@ -195,6 +197,13 @@ func (r *skynetResolver) Resolve(ctx context.Context, name string) (context.Cont
 }
 
 func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, cfg Config) error {
+	// Build the upstream SOCKS5 dialer ONCE and reuse it across requests
+	// (proxy.SOCKS5 returns a shareable proxy.Dialer). nil when no upstream
+	// is configured — those requests dial direct.
+	var upstream *upstreamForwarder
+	if cfg.UpstreamSOCKS != "" {
+		upstream = &upstreamForwarder{addr: cfg.UpstreamSOCKS}
+	}
 	conf := &socks5.Config{
 		// Route go-socks5's own [ERR] lines through logrus so they match the
 		// rest of the visor's log format (colored, module-tagged) instead of
@@ -319,7 +328,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 			}
 
 			// Not .skynet — forward to upstream or direct.
-			if cfg.UpstreamSOCKS != "" {
+			if upstream != nil {
 				// Reconstruct host:port using the original hostname
 				// (the resolved addr has 127.0.0.1 instead of the hostname).
 				if origHost != "" {
@@ -330,11 +339,7 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 					addr = net.JoinHostPort(origHost, port)
 				}
 				log.WithField("addr", addr).Debug("SOCKS5 → upstream")
-				up, err := proxy.SOCKS5("tcp", cfg.UpstreamSOCKS, nil, proxy.Direct)
-				if err != nil {
-					return nil, err
-				}
-				return up.Dial(network, addr)
+				return upstream.dial(network, addr)
 			}
 			return net.Dial(network, addr)
 		},
@@ -365,6 +370,61 @@ func serveSOCKS5(ctx context.Context, log *logging.Logger, dialer SkynetDialer, 
 		return fmt.Errorf("SOCKS5 serve: %w", err)
 	}
 	return nil
+}
+
+// upstreamCooldown is how long forwarded dials fast-fail after a recent
+// upstream failure, so a burst of requests during the boot window (when the
+// upstream, e.g. skysocks-client on :1080, is not yet connected and refuses
+// the connection) doesn't each pay a full refused dial. Short by design —
+// the client retries.
+const upstreamCooldown = 500 * time.Millisecond
+
+// upstreamForwarder lazily builds and caches a SOCKS5 dialer to the upstream
+// proxy and reuses it across requests. proxy.SOCKS5 returns a proxy.Dialer
+// that is safe to share, so building it once — instead of per request —
+// avoids a wasteful allocation on every forwarded CONNECT. After a failed
+// dial it fast-fails subsequent requests for upstreamCooldown rather than
+// blocking or queueing them. This is skynetweb's readiness posture toward the
+// upstream: there is no clean "skysocks-client connected" signal to wait on,
+// so the cached dialer + cooldown stands in for one.
+type upstreamForwarder struct {
+	addr string
+
+	mu       sync.Mutex
+	dialer   proxy.Dialer
+	failedAt time.Time
+}
+
+// dial forwards through the cached upstream dialer, building it on first use.
+// It fast-fails during the cooldown window following a recent failure, and
+// records/clears the failure timestamp based on the dial outcome.
+func (f *upstreamForwarder) dial(network, addr string) (net.Conn, error) {
+	f.mu.Lock()
+	if !f.failedAt.IsZero() && time.Since(f.failedAt) < upstreamCooldown {
+		f.mu.Unlock()
+		return nil, fmt.Errorf("upstream SOCKS %s not ready (cooling down)", f.addr)
+	}
+	d := f.dialer
+	if d == nil {
+		nd, err := proxy.SOCKS5("tcp", f.addr, nil, proxy.Direct)
+		if err != nil {
+			f.mu.Unlock()
+			return nil, err
+		}
+		f.dialer = nd
+		d = nd
+	}
+	f.mu.Unlock()
+
+	conn, err := d.Dial(network, addr)
+	f.mu.Lock()
+	if err != nil {
+		f.failedAt = time.Now()
+	} else {
+		f.failedAt = time.Time{}
+	}
+	f.mu.Unlock()
+	return conn, err
 }
 
 // tcpAddrConn wraps a net.Conn so that LocalAddr/RemoteAddr return


### PR DESCRIPTION
From the pkg/visor init audit. The embedded mesh-browser SOCKS proxies (`.dmsg`/`.skynet` resolvers) built a fresh `proxy.SOCKS5(cfg.UpstreamSOCKS)` dialer **per request** and had no backoff when the upstream (skysocks-client :1080) was refused/not-yet-ready at boot.

- **Cached dialer**: an unexported `upstreamForwarder` (per-package, matching the existing duplicate-helper style like `tcpAddrConn`) builds the `proxy.SOCKS5` dialer once lazily under a mutex and reuses it; nil upstream still dials direct. Happy path unchanged.
- **Cooldown backoff**: after a failed forward dial, subsequent dials within a 500ms window fast-fail ("upstream not ready, cooling down") instead of each doing a full refused dial; a success clears it. No blocking/queueing — the client retries.
- **skynetweb parity**: implemented as the cached-dialer + cooldown. A true "skysocks-client connected" readiness signal isn't cleanly exposed to skynetweb (no dmsg client / router-ready channel), so per the audit's fallback this stands in for it (documented in code).

The ERROR-log noise from this was already fixed in #3883 (level cap); this PR is the efficiency/robustness half. Verified: `go build .`, `go vet ./pkg/dmsgweb/... ./pkg/skynetweb/...` pass.