### PR TITLE
refactor(visor): remove dormant standalone uptime-tracker client (keep TPD heartbeat)

### DIFF
--- a/cmd/skywire-cli/commands/visor/whois.go
+++ b/cmd/skywire-cli/commands/visor/whois.go
@@ -1,12 +1,11 @@
 // Package clivisor cmd/skywire-cli/commands/visor/whois.go c4-vis-cli
-// visor whois <pk>` — single-PK rollup combining transport-discovery,
-// uptime-tracker, and service-discovery state into one report.
+// visor whois <pk>` — single-PK rollup combining transport-discovery
+// and service-discovery state into one report.
 //
 // Today an operator answering "what do we know about this visor PK"
-// has to hit three separate services:
+// has to hit two separate services:
 //
 //	cli tp ls --remote <pk>      — transports the visor is on
-//	cli ut tpd | grep <pk>       — uptime in the tpd-integrated UT
 //	cli sd | grep <pk>           — services the visor advertises
 //
 // whois collapses those into one report. Useful when triaging a peer
@@ -39,7 +38,6 @@ import (
 var (
 	whoisTimeout time.Duration
 	whoisTpdURL  string
-	whoisUtURL   string
 	whoisSdURL   string
 )
 
@@ -49,8 +47,6 @@ func init() {
 		"per-service request timeout")
 	whoisCmd.Flags().StringVar(&whoisTpdURL, "tpd", deployment.Prod.TransportDiscovery,
 		"transport-discovery URL")
-	whoisCmd.Flags().StringVar(&whoisUtURL, "ut", deployment.Prod.TransportDiscovery,
-		"TPD-integrated uptime-tracker URL")
 	whoisCmd.Flags().StringVar(&whoisSdURL, "sd", deployment.Prod.ServiceDiscovery,
 		"service-discovery URL")
 	RootCmd.AddCommand(whoisCmd)
@@ -62,7 +58,6 @@ func init() {
 type whoisReport struct {
 	PK         string     `json:"pk"`
 	Transports whoisBlock `json:"transports"`
-	Uptime     whoisBlock `json:"uptime"`
 	Services   whoisBlock `json:"services"`
 }
 
@@ -79,11 +74,10 @@ type whoisBlock struct {
 
 var whoisCmd = &cobra.Command{
 	Use:   "whois <pk>",
-	Short: "Combined TPD + UT + SD rollup for a single visor PK",
-	Long: `Single-PK rollup over transport-discovery, uptime-tracker, and
-service-discovery. Useful for triaging a peer from a log line, a
-chat message, or a transport-id without manually hitting three
-services.
+	Short: "Combined TPD + SD rollup for a single visor PK",
+	Long: `Single-PK rollup over transport-discovery and service-discovery.
+Useful for triaging a peer from a log line, a chat message, or a
+transport-id without manually hitting two services.
 
 Examples:
   skywire cli visor whois <pk>             # human-readable table
@@ -128,17 +122,6 @@ rather than failing the whole command.`,
 			}
 		}
 
-		// Uptime: prefer the visor RPC (auth + retry handled by the
-		// visor). On any failure, surface the error and move on.
-		if rc != nil {
-			report.Uptime = uptimeFromVisor(rc, pk.String())
-		} else {
-			report.Uptime = whoisBlock{
-				URL:   "(visor RPC unavailable)",
-				Error: "visor RPC client not initialized; uptime lookup needs a local visor",
-			}
-		}
-
 		// Services: SD doesn't have a "give me everything this PK
 		// advertises" endpoint — its public API is keyed by service
 		// type (?type=skysocks, ?type=vpn, etc.) and filters within
@@ -163,7 +146,6 @@ rather than failing the whole command.`,
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "SOURCE\tHTTP\tSUMMARY")                                                         //nolint:errcheck
 		fmt.Fprintf(w, "transports\t%s\t%s\n", httpCell(report.Transports), valOrErr(report.Transports)) //nolint:errcheck
-		fmt.Fprintf(w, "uptime\t%s\t%s\n", httpCell(report.Uptime), valOrErr(report.Uptime))             //nolint:errcheck
 		fmt.Fprintf(w, "services\t%s\t%s\n", httpCell(report.Services), valOrErr(report.Services))       //nolint:errcheck
 		_ = w.Flush()                                                                                    //nolint:errcheck
 	},
@@ -200,78 +182,6 @@ func transportsFromVisor(rc interface {
 	}
 	block.Summary = fmt.Sprintf("%d total (%s)", len(entries), strings.Join(parts, " "))
 	return block
-}
-
-// uptimeFromVisor uses FetchUptimeTrackerData. The RPC returns the
-// raw JSON body the visor's UT client received — we re-parse to
-// pull the percentage out for the one-line summary.
-func uptimeFromVisor(rc interface {
-	FetchUptimeTrackerData(pk string) ([]byte, error)
-}, pk string) whoisBlock {
-	block := whoisBlock{URL: "visor-RPC: FetchUptimeTrackerData"}
-	body, err := rc.FetchUptimeTrackerData(pk)
-	if err != nil {
-		block.Error = err.Error()
-		return block
-	}
-	if len(body) == 0 {
-		block.Summary = "no uptime data"
-		return block
-	}
-	block.Raw = json.RawMessage(body)
-	block.Summary = summarizeUptime(block.Raw)
-	return block
-}
-
-// summarizeUptime extracts a headline from a UT response. The
-// production UT endpoint returns an array of {pk, on, version,
-// daily: {YYYY-MM-DD: "pct"}} records — newest date in `daily` is
-// the most recent day's uptime %, and `on` is the current visor
-// liveness flag from the tracker's POV.
-func summarizeUptime(raw json.RawMessage) string {
-	var record map[string]interface{}
-	if err := json.Unmarshal(raw, &record); err != nil {
-		var arr []map[string]interface{}
-		if err2 := json.Unmarshal(raw, &arr); err2 != nil || len(arr) == 0 {
-			return "no uptime data"
-		}
-		record = arr[0]
-	}
-	on := "?"
-	if v, ok := record["on"].(bool); ok {
-		if v {
-			on = "online"
-		} else {
-			on = "offline"
-		}
-	}
-	version, _ := record["version"].(string)
-	// daily map → find the most recent date + show its percentage.
-	if daily, ok := record["daily"].(map[string]interface{}); ok && len(daily) > 0 {
-		mostRecent := ""
-		var mostRecentPct string
-		for k, v := range daily {
-			if k > mostRecent {
-				mostRecent = k
-				if s, sok := v.(string); sok {
-					mostRecentPct = s
-				}
-			}
-		}
-		out := fmt.Sprintf("%s (today %s%%", on, mostRecentPct)
-		if mostRecent != "" {
-			out += " on " + mostRecent
-		}
-		out += ")"
-		if version != "" {
-			out += " v=" + version
-		}
-		return out
-	}
-	if version != "" {
-		return fmt.Sprintf("%s v=%s (no daily uptime data)", on, version)
-	}
-	return on + " (uptime payload missing daily map)"
 }
 
 // httpCell renders the status as "200", "404", "rpc" (for visor-

--- a/pkg/visor/api.go
+++ b/pkg/visor/api.go
@@ -232,9 +232,6 @@ type API interface {
 
 	ReinitiateModule(module string) error
 
-	//uptime-tracker tools
-	FetchUptimeTrackerData(pk string) ([]byte, error)
-
 	//service discovery management (network monitor functionality)
 	DeregisterService(pks []cipher.PubKey, serviceType string) error
 

--- a/pkg/visor/api_apps.go
+++ b/pkg/visor/api_apps.go
@@ -925,23 +925,6 @@ func (v *Visor) GetAppConnectionsSummary(appName string) ([]appserver.Connection
 	return nil, ErrProcNotAvailable
 }
 
-// FetchUptimeTrackerData implements API
-func (v *Visor) FetchUptimeTrackerData(pk string) ([]byte, error) {
-	var body []byte
-	var pubkey cipher.PubKey
-
-	if pk != "" {
-		err := pubkey.Set(pk)
-		if err != nil {
-			return body, fmt.Errorf("invalid or missing public key")
-		}
-	}
-	if v.uptimeTracker == nil {
-		return body, fmt.Errorf("uptime tracker module not available")
-	}
-	return v.uptimeTracker.FetchUptimes(context.TODO(), pk)
-}
-
 // GetVPNClientAddress get PK address of server set on vpn-client
 func (v *Visor) GetVPNClientAddress() string {
 	for _, v := range v.conf.Launcher.Apps {

--- a/pkg/visor/init_services.go
+++ b/pkg/visor/init_services.go
@@ -73,10 +73,15 @@ func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
 	// uptime_tracker was empty, so decommissioning the standalone tracker
 	// silently disabled the TPD heartbeat too — a fleet-wide reward-uptime
 	// regression. resolveUptimeTargets keeps that invariant unit-testable.
-	utURL, tpdURL := resolveUptimeTargets(v.conf.UptimeTracker, v.conf.Transport.Discovery, v.conf.Transport.DiscoveryDmsg)
+	// The standalone uptime-tracker client has been decommissioned; only the
+	// reward-critical TPD heartbeat target is consumed now. resolveUptimeTargets
+	// is retained (and its regression test with it) because it guarantees the TPD
+	// heartbeat URL is derived INDEPENDENTLY of the (now-absent) uptime_tracker
+	// config — the invariant whose violation once collapsed fleet reward uptime.
+	_, tpdURL := resolveUptimeTargets(v.conf.UptimeTracker, v.conf.Transport.Discovery, v.conf.Transport.DiscoveryDmsg)
 
-	if utURL == "" && tpdURL == "" {
-		v.log.Debug("uptime: no uptime_tracker and no transport-discovery addr; skipping heartbeat.")
+	if tpdURL == "" {
+		v.log.Debug("uptime: no transport-discovery addr; skipping TPD heartbeat.")
 		return nil
 	}
 
@@ -90,21 +95,12 @@ func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
 		bgCtx = context.Background()
 	}
 	go func() { //nolint:gosec,contextcheck
-		var ut utclient.APIClient
-		if utURL != "" {
-			if ut = buildUptimeClient(bgCtx, v, utURL, "uptime tracker"); ut != nil {
-				v.initLock.Lock()
-				v.uptimeTracker = ut
-				v.initLock.Unlock()
-			}
-		}
-
 		var tpdUT utclient.APIClient
 		if tpdURL != "" {
 			tpdUT = buildUptimeClient(bgCtx, v, tpdURL, "TPD heartbeat")
 		}
 
-		if ut == nil && tpdUT == nil {
+		if tpdUT == nil {
 			v.log.Warn("uptime: no heartbeat client could be built; visor presence will not be reported")
 			return
 		}
@@ -114,11 +110,6 @@ func initUptimeTracker(_ context.Context, v *Visor, log *logging.Logger) error {
 		sendHeartbeats := func() {
 			c, cancel := context.WithTimeout(context.Background(), heartbeatSendTimeout)
 			defer cancel()
-			if ut != nil {
-				if err := ut.UpdateVisorUptime(c, v.conf.Version); err != nil {
-					log.WithError(err).Warn("Failed to update visor uptime (standalone tracker).")
-				}
-			}
 			// The TPD heartbeat is the reward-critical presence signal. Surface
 			// failures at Warn and flip the health flags so a persistent 401 /
 			// auth / connectivity failure is visible in the visor's own logs and

--- a/pkg/visor/proxy_default_api.go
+++ b/pkg/visor/proxy_default_api.go
@@ -686,10 +686,6 @@ func (proxyDefaultAPI) ReinitiateModule(_ string) error {
 	return ErrProxyNotSupported
 }
 
-func (proxyDefaultAPI) FetchUptimeTrackerData(_ string) ([]byte, error) {
-	return nil, ErrProxyNotSupported
-}
-
 func (proxyDefaultAPI) DeregisterService(_ []cipher.PubKey, _ string) error {
 	return ErrProxyNotSupported
 }

--- a/pkg/visor/rpc_client.go
+++ b/pkg/visor/rpc_client.go
@@ -431,13 +431,6 @@ func (rc *rpcClient) StopVPNClient(appName string) error {
 	return rc.Call("StopVPNClient", &appName, &struct{}{})
 }
 
-// FetchUptimeTrackerData calls FetchUptimeTrackerData.
-func (rc *rpcClient) FetchUptimeTrackerData(pk string) ([]byte, error) {
-	var data []byte
-	err := rc.Call("FetchUptimeTrackerData", pk, &data)
-	return data, err
-}
-
 // StartSkysocksClient calls StartSkysocksClient.
 func (rc *rpcClient) StartSkysocksClient(pk string) error {
 	return rc.Call("StartSkysocksClient", pk, &struct{}{})

--- a/pkg/visor/rpc_client_mock.go
+++ b/pkg/visor/rpc_client_mock.go
@@ -356,11 +356,6 @@ func (*mockRPCClient) StopVPNClient(string) error {
 	return nil
 }
 
-// FetchUptimeTrackerData implements API.
-func (*mockRPCClient) FetchUptimeTrackerData(string) ([]byte, error) {
-	return []byte{}, nil
-}
-
 // StartSkysocksClient implements API.
 func (*mockRPCClient) StartSkysocksClient(string) error {
 	return nil

--- a/pkg/visor/rpc_test.go
+++ b/pkg/visor/rpc_test.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/skycoin/skywire/pkg/cipher"
 	"github.com/skycoin/skywire/pkg/transport"
-	"github.com/skycoin/skywire/pkg/utclient"
 	"github.com/skycoin/skywire/pkg/visor/visorconfig"
 )
 
@@ -34,10 +32,6 @@ func TestHealth(t *testing.T) {
 			RouteSetupNodes: []cipher.PubKey{c.PK},
 		}
 
-		utClient := &utclient.MockAPIClient{}
-		utClient.On("UpdateVisorUptime", mock.Anything).Return(nil)
-		utClient.On("Health", mock.Anything).Return(nil)
-
 		v := &Visor{
 			conf: c,
 			tpM: &transport.Manager{
@@ -45,7 +39,6 @@ func TestHealth(t *testing.T) {
 					DiscoveryClient: transport.NewDiscoveryMock(),
 				},
 			},
-			uptimeTracker:     utClient,
 			isServicesHealthy: newInternalHealthInfo(),
 		}
 		v.isServicesHealthy.init()

--- a/pkg/visor/rpc_visor.go
+++ b/pkg/visor/rpc_visor.go
@@ -171,14 +171,6 @@ func (r *RPC) Overview(_ *struct{}, out *Overview) (err error) {
 	return err
 }
 
-// FetchUptimeTrackerData trying to fetch ut data
-func (r *RPC) FetchUptimeTrackerData(pk string, data *[]byte) (err error) {
-	defer rpcutil.LogCall(r.log, "FetchUptimeTrackerData", pk)(data, &err)
-	rep, err := r.visor.FetchUptimeTrackerData(pk)
-	*data = rep
-	return err
-}
-
 // Reload reloads the config - without restarting the visor
 func (r *RPC) Reload(_ *struct{}, _ *struct{}) (err error) {
 	// @evanlinjin: do not defer this log statement, as the underlying visor.Logger will get closed.

--- a/pkg/visor/visor.go
+++ b/pkg/visor/visor.go
@@ -42,7 +42,6 @@ import (
 	"github.com/skycoin/skywire/pkg/transport/network/addrresolver"
 	"github.com/skycoin/skywire/pkg/transport/network/stcp"
 	tptypes "github.com/skycoin/skywire/pkg/transport/types"
-	"github.com/skycoin/skywire/pkg/utclient"
 	"github.com/skycoin/skywire/pkg/visor/dmsgtracker"
 	"github.com/skycoin/skywire/pkg/visor/logserver"
 	"github.com/skycoin/skywire/pkg/visor/logstore"
@@ -105,7 +104,6 @@ type Visor struct {
 
 	startedAt       time.Time
 	startupComplete chan struct{}
-	uptimeTracker   utclient.APIClient
 
 	ebc                *appevent.Broadcaster // event broadcaster
 	dmsgC              *dmsg.Client


### PR DESCRIPTION
Removes the deprecated standalone uptime-tracker **client** (dormant fleet-wide — its URL is empty), which the audit flagged as dead code. **The reward-critical TPD heartbeat is untouched.**

Removed: `Visor.uptimeTracker` field + its construction, the standalone `ut.UpdateVisorUptime` send branch in `initUptimeTracker`, the `FetchUptimeTrackerData` RPC (interface/impl/server/client/mock/proxy), and the `whois` CLI's uptime section.

Kept intact (verified): `initUptimeTracker` runs; `resolveUptimeTargets → tpdURL`; `tpdUT = buildUptimeClient(..., "TPD heartbeat")` and its 5-min send; `RecordHeartbeat`; config schema. 10 files, −168/+16. `go build`, `go vet`, `go test ./pkg/visor/...` all pass.